### PR TITLE
PG-156: Fix the placeholder replacement function for prepared statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PGFILEDESC = "pg_stat_monitor - execution statistics of SQL statements"
 LDFLAGS_SL += $(filter -lm, $(LIBS)) 
 
 REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/pg_stat_monitor/pg_stat_monitor.conf --inputdir=regression
-REGRESS = basic version guc counters relations database top_query application_name cmd_type error state rows 
+REGRESS = basic version guc counters relations database top_query application_name cmd_type error state rows normalize
 
 # Disabled because these tests require "shared_preload_libraries=pg_stat_statements",
 # which typical installcheck users do not have (e.g. buildfarm clients).

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -183,6 +183,7 @@ typedef struct pgssQueryEntry
 {
 	pgssQueryHashKey    key;		/* hash key of entry - MUST BE FIRST */
 	uint64              pos;		/* bucket number */
+	bool				query_setted;	/* whewher query text was setted*/
 } pgssQueryEntry;
 
 typedef struct PlanInfo
@@ -353,6 +354,30 @@ typedef struct pgssJumbleState
 	/* highest Param id we've seen, in order to start normalization correctly */
 	int			highest_extern_param_id;
 } pgssJumbleState;
+
+/*
+ * the placeholder location and its corresponding parameter id;
+ */
+typedef struct pgssPlaceholderLocation
+{
+	pgssLocationLen plocation;	/*placeholder location and its length */
+	int paramid;				/*the parameter id bound with this placeholder*/
+}pgssPlaceholderLocation;
+
+/*
+ * the state we used for denormalizing a query with pararmeters
+ */
+typedef struct pgssPlaceholderState
+{
+	/* a array of placeholder's locaiton and its value*/
+	pgssPlaceholderLocation *plocations;
+
+	/* the allocated size of plocations*/
+	int			plocations_buf_size;
+
+	/* the number of elements in plocations*/
+	int			plocations_count;
+}pgssPlaceholderState;
 
 /* Links to shared memory state */
 

--- a/regression/expected/normalize.out
+++ b/regression/expected/normalize.out
@@ -1,0 +1,46 @@
+CREATE EXTENSION pg_stat_monitor;
+SET pg_stat_monitor.pgsm_normalized_query TO off;
+CREATE TABLE tb1(id int, name text);
+INSERT INTO tb1 VALUES (1,'foo'),(2,'bar'),(3,'baz');
+CREATE OR REPLACE FUNCTION dup(int) RETURNS TABLE(f1 int, f2 text)
+AS $$ SELECT $1, CAST($1 AS text) || ' is text' $$
+LANGUAGE SQL;
+PREPARE gettb1 AS SELECT name,'test placeholder in string: $1' AS test_string FROM tb1 WHERE id = $1;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SELECT dup(22);
+        dup        
+-------------------
+ (22,"22 is text")
+(1 row)
+
+EXECUTE gettb1(2);
+ name |          test_string           
+------+--------------------------------
+ bar  | test placeholder in string: $1
+(1 row)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                                                query                                                 | calls 
+------------------------------------------------------------------------------------------------------+-------
+  SELECT 22, CAST(22 AS text) || ' is text'                                                           |     1
+ <insufficient shared space or query text not set>                                                    |     1
+ PREPARE gettb1 AS SELECT name,'test placeholder in string: $1' AS test_string FROM tb1 WHERE id = 2; |     1
+ SELECT dup(22);                                                                                      |     1
+ SELECT pg_stat_monitor_reset();                                                                      |     1
+(5 rows)
+
+DROP TABLE tb1;
+DROP FUNCTION dup;
+DEALLOCATE gettb1;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/normalize.sql
+++ b/regression/sql/normalize.sql
@@ -1,0 +1,22 @@
+CREATE EXTENSION pg_stat_monitor;
+SET pg_stat_monitor.pgsm_normalized_query TO off;
+
+CREATE TABLE tb1(id int, name text);
+INSERT INTO tb1 VALUES (1,'foo'),(2,'bar'),(3,'baz');
+
+CREATE OR REPLACE FUNCTION dup(int) RETURNS TABLE(f1 int, f2 text)
+AS $$ SELECT $1, CAST($1 AS text) || ' is text' $$
+LANGUAGE SQL;
+
+PREPARE gettb1 AS SELECT name,'test placeholder in string: $1' AS test_string FROM tb1 WHERE id = $1;
+SELECT pg_stat_monitor_reset();
+
+SELECT dup(22);
+EXECUTE gettb1(2);
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+DROP TABLE tb1;
+DROP FUNCTION dup;
+DEALLOCATE gettb1;
+SELECT pg_stat_monitor_reset();
+DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
This commit is for placeholder replacement when set PGSM_NORMALIZED_QUERY to off. It works for both prepared statement and function.

The easist way to get external parameter is from ParamList and we can get ParamList at planner hook or Executor's QueryDesc. For a parepared statement, it won't get planned for every execution, so Executor is the only place we can get external parameters. 

So my solution is to delay the query text storage until the end of execution when we set normalized_query to off. When the query is analyzed and trying to store its query text. It will only create an entry in the query_text_hash table. The entry will be marked as 'not set'. The query text will not be stored until the query reaches the end of execution or emit an error.
This has a side effect, the 'ACTIVE' query may show '<query not set yet>'.

The reason I did't delay all queries until the end of execution is that if we set normalized to on, we still need to get normalized queries on analyzer.

Hamid and I discussed how to use get_normalized_query to get all the placeholder locations. But the problem is that it needs a query tree as input. For prepared statements, it will only be parsed and analyzed during the creation, and will not be analyzed each time it is executed. So we have to use some storage space keep the querytree information and ensure that it exists during the lifetime of pg_stat_monitor. And there seems to be no way to decrease these information. Because we don't know when prepared statements will get deallocated. Therefore, my approach is to parse the query string again and use the walker function to get all the 'ParamRef' nodes in the parsetree and get their locations. This will increase the overhead, but I think this is the only way works for prepared statement.

reviewd by @EngineeredVirus 