### PR TITLE
PG-204: fix save previous emit_log_hook.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -279,9 +279,10 @@ _PG_init(void)
 	planner_hook_next       		= planner_hook;
 	planner_hook                    = pgss_planner_hook;
 #endif
-	emit_log_hook                 = pgsm_emit_log_hook;
+	prev_emit_log_hook				= emit_log_hook;
+	emit_log_hook					= pgsm_emit_log_hook;
 	prev_ExecutorCheckPerms_hook 	= ExecutorCheckPerms_hook;
-	ExecutorCheckPerms_hook		= pgss_ExecutorCheckPerms;
+	ExecutorCheckPerms_hook			= pgss_ExecutorCheckPerms;
 
 	nested_queryids = (uint64*) malloc(sizeof(uint64) * max_stack_depth);
 
@@ -303,6 +304,7 @@ _PG_fini(void)
 	ExecutorFinish_hook 	= prev_ExecutorFinish;
 	ExecutorEnd_hook 		= prev_ExecutorEnd;
 	ProcessUtility_hook 	= prev_ProcessUtility;
+	emit_log_hook			= prev_emit_log_hook;
 
 	free(nested_queryids);
 


### PR DESCRIPTION
pg_stat_monitor was not saving the pointer to the previous hook for
emit_log_hook, this commit fix the issue.