### PR TITLE
PG-200: Add application name to the bucket ID.

### DIFF
--- a/hash_query.c
+++ b/hash_query.c
@@ -268,7 +268,7 @@ hash_entry_reset()
 
 /* Caller must accuire lock */
 pgssQueryEntry*
-hash_create_query_entry(uint64 bucket_id, uint64 queryid, uint64 dbid, uint64 userid, uint64 ip)
+hash_create_query_entry(uint64 bucket_id, uint64 queryid, uint64 dbid, uint64 userid, uint64 ip, uint64 appid)
 {
     pgssQueryHashKey    key;
 	pgssQueryEntry      *entry;
@@ -279,6 +279,7 @@ hash_create_query_entry(uint64 bucket_id, uint64 queryid, uint64 dbid, uint64 us
 	key.dbid = dbid;
 	key.userid = userid;
 	key.ip = ip;
+	key.appid = appid;
 
 	entry = (pgssQueryEntry *) hash_search(pgss_query_hash, &key, HASH_ENTER, &found);
 	return entry;
@@ -286,7 +287,7 @@ hash_create_query_entry(uint64 bucket_id, uint64 queryid, uint64 dbid, uint64 us
 
 /* Caller must accuire lock */
 pgssQueryEntry*
-hash_find_query_entry(uint64 bucket_id, uint64 queryid, uint64 dbid, uint64 userid, uint64 ip)
+hash_find_query_entry(uint64 bucket_id, uint64 queryid, uint64 dbid, uint64 userid, uint64 ip, uint64 appid)
 {
     pgssQueryHashKey    key;
 	pgssQueryEntry      *entry;
@@ -297,6 +298,7 @@ hash_find_query_entry(uint64 bucket_id, uint64 queryid, uint64 dbid, uint64 user
 	key.dbid = dbid;
 	key.userid = userid;
 	key.ip = ip;
+	key.appid = appid;
 
     /* Lookup the hash table entry with shared lock. */
 	entry = (pgssQueryEntry *) hash_search(pgss_query_hash, &key, HASH_FIND, &found);

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -178,6 +178,7 @@ typedef struct pgssQueryHashKey
 	uint64		userid;			/* user OID */
 	uint64		dbid;			/* database OID */
 	uint64		ip;				/* client ip address */
+	uint64		appid;			/* hash of application name */
 } pgssQueryHashKey;
 
 typedef struct pgssQueryEntry
@@ -201,6 +202,7 @@ typedef struct pgssHashKey
 	uint64		dbid;			/* database OID */
 	uint64		ip;				/* client ip address */
 	uint64		planid;			/* plan identifier */
+	uint64		appid;			/* hash of application name */
 } pgssHashKey;
 
 typedef struct QueryInfo
@@ -388,8 +390,8 @@ Size hash_memsize(void);
 
 int read_query_buffer(int bucket_id, uint64 queryid, char *query_txt);
 uint64 read_query(unsigned char *buf, uint64 bucketid, uint64 queryid, char * query);
-pgssQueryEntry* hash_find_query_entry(uint64 bucket_id, uint64 queryid, uint64 dbid, uint64 userid, uint64 ip);
-pgssQueryEntry* hash_create_query_entry(uint64 bucket_id, uint64 queryid, uint64 dbid, uint64 userid, uint64 ip);
+pgssQueryEntry* hash_find_query_entry(uint64 bucket_id, uint64 queryid, uint64 dbid, uint64 userid, uint64 ip, uint64 appid);
+pgssQueryEntry* hash_create_query_entry(uint64 bucket_id, uint64 queryid, uint64 dbid, uint64 userid, uint64 ip, uint64 appid);
 void pgss_startup(void);
 void set_qbuf(int i, unsigned char *);
 


### PR DESCRIPTION
Add application name to the key used to identify queries in the hash
table, this allows different applications to have separate entries in
pg_stat_monitor view if they issued the same query.