### PR TITLE
DISTPG-271: Fix the failing 'relations' test case.

### DIFF
--- a/regression/expected/relations.out
+++ b/regression/expected/relations.out
@@ -36,15 +36,15 @@ SELECT * FROM foo1, foo2, foo3, foo4;
 ---+---+---+---
 (0 rows)
 
-SELECT query, relations from pg_stat_monitor ORDER BY query;
-                            query                             |                     relations                     
---------------------------------------------------------------+---------------------------------------------------
- SELECT * FROM foo1, foo2, foo3, foo4;                        | {public.foo1,public.foo2,public.foo3,public.foo4}
- SELECT * FROM foo1, foo2, foo3;                              | {public.foo1,public.foo2,public.foo3}
- SELECT * FROM foo1, foo2;                                    | {public.foo1,public.foo2}
- SELECT * FROM foo1;                                          | {public.foo1}
- SELECT pg_stat_monitor_reset();                              | 
- SELECT query, relations from pg_stat_monitor ORDER BY query; | {public.pg_stat_monitor*,pg_catalog.pg_database}
+SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+                                  query                                   |                     relations                     
+--------------------------------------------------------------------------+---------------------------------------------------
+ SELECT * FROM foo1, foo2, foo3, foo4;                                    | {public.foo1,public.foo2,public.foo3,public.foo4}
+ SELECT * FROM foo1, foo2, foo3;                                          | {public.foo1,public.foo2,public.foo3}
+ SELECT * FROM foo1, foo2;                                                | {public.foo1,public.foo2}
+ SELECT * FROM foo1;                                                      | {public.foo1}
+ SELECT pg_stat_monitor_reset();                                          | 
+ SELECT query, relations from pg_stat_monitor ORDER BY query collate "C"; | {public.pg_stat_monitor*,pg_catalog.pg_database}
 (6 rows)
 
 SELECT pg_stat_monitor_reset();
@@ -88,15 +88,15 @@ SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3, sch4.foo4;
 ---+---+---+---
 (0 rows)
 
-SELECT query, relations from pg_stat_monitor ORDER BY query;
-                            query                             |                    relations                     
---------------------------------------------------------------+--------------------------------------------------
- SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3, sch4.foo4;    | {sch1.foo1,sch2.foo2,sch3.foo3,sch4.foo4}
- SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3;               | {sch1.foo1,sch2.foo2,sch3.foo3}
- SELECT * FROM sch1.foo1, sch2.foo2;                          | {sch1.foo1,sch2.foo2}
- SELECT * FROM sch1.foo1;                                     | {sch1.foo1}
- SELECT pg_stat_monitor_reset();                              | 
- SELECT query, relations from pg_stat_monitor ORDER BY query; | {public.pg_stat_monitor*,pg_catalog.pg_database}
+SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+                                  query                                   |                    relations                     
+--------------------------------------------------------------------------+--------------------------------------------------
+ SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3, sch4.foo4;                | {sch1.foo1,sch2.foo2,sch3.foo3,sch4.foo4}
+ SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3;                           | {sch1.foo1,sch2.foo2,sch3.foo3}
+ SELECT * FROM sch1.foo1, sch2.foo2;                                      | {sch1.foo1,sch2.foo2}
+ SELECT * FROM sch1.foo1;                                                 | {sch1.foo1}
+ SELECT pg_stat_monitor_reset();                                          | 
+ SELECT query, relations from pg_stat_monitor ORDER BY query collate "C"; | {public.pg_stat_monitor*,pg_catalog.pg_database}
 (6 rows)
 
 SELECT pg_stat_monitor_reset();
@@ -167,15 +167,15 @@ SELECT * FROM v1,v2,v3,v4;
 ---+---+---+---+---+---+---+---+---+---
 (0 rows)
 
-SELECT query, relations from pg_stat_monitor ORDER BY query;
-                            query                             |                                           relations                                           
---------------------------------------------------------------+-----------------------------------------------------------------------------------------------
- SELECT * FROM v1,v2,v3,v4;                                   | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3,public.v4*,public.foo4}
- SELECT * FROM v1,v2,v3;                                      | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3}
- SELECT * FROM v1,v2;                                         | {public.v1*,public.foo1,public.v2*,public.foo2}
- SELECT * FROM v1;                                            | {public.v1*,public.foo1}
- SELECT pg_stat_monitor_reset();                              | 
- SELECT query, relations from pg_stat_monitor ORDER BY query; | {public.pg_stat_monitor*,pg_catalog.pg_database}
+SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+                                  query                                   |                                           relations                                           
+--------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------
+ SELECT * FROM v1,v2,v3,v4;                                               | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3,public.v4*,public.foo4}
+ SELECT * FROM v1,v2,v3;                                                  | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3}
+ SELECT * FROM v1,v2;                                                     | {public.v1*,public.foo1,public.v2*,public.foo2}
+ SELECT * FROM v1;                                                        | {public.v1*,public.foo1}
+ SELECT pg_stat_monitor_reset();                                          | 
+ SELECT query, relations from pg_stat_monitor ORDER BY query collate "C"; | {public.pg_stat_monitor*,pg_catalog.pg_database}
 (6 rows)
 
 SELECT pg_stat_monitor_reset();

--- a/regression/sql/relations.sql
+++ b/regression/sql/relations.sql
@@ -11,7 +11,7 @@ SELECT * FROM foo1;
 SELECT * FROM foo1, foo2;
 SELECT * FROM foo1, foo2, foo3;
 SELECT * FROM foo1, foo2, foo3, foo4;
-SELECT query, relations from pg_stat_monitor ORDER BY query;
+SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
 SELECT pg_stat_monitor_reset();
 
 
@@ -31,7 +31,7 @@ SELECT * FROM sch1.foo1;
 SELECT * FROM sch1.foo1, sch2.foo2;
 SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3;
 SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3, sch4.foo4;
-SELECT query, relations from pg_stat_monitor ORDER BY query;
+SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
 SELECT pg_stat_monitor_reset();
 
 SELECT pg_stat_monitor_reset();
@@ -51,7 +51,7 @@ SELECT * FROM v1;
 SELECT * FROM v1,v2;
 SELECT * FROM v1,v2,v3;
 SELECT * FROM v1,v2,v3,v4;
-SELECT query, relations from pg_stat_monitor ORDER BY query;
+SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
 SELECT pg_stat_monitor_reset();
 
 


### PR DESCRIPTION
Testcase 'relations' was failing due to absence of default locale setting 'c' in sql. Similarly due to changes in sql, expected output has to be changed.  