### PR TITLE
PG-218: Added Coverall code coverage to pg_stat_monitor.

### DIFF
--- a/.github/workflows/coverage_test.yml
+++ b/.github/workflows/coverage_test.yml
@@ -1,0 +1,68 @@
+name: coverage-test
+on: ["push", "pull_request"]
+
+jobs:
+  build:
+    name: coverage-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone postgres repository
+        uses: actions/checkout@v2
+        with:
+          repository: 'postgres/postgres'
+          ref: 'REL_13_STABLE'
+
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
+          ref: 'master'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
+          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl git lcov -y
+          sudo rm -rf /var/lib/postgresql/
+          sudo rm -rf /var/log/postgresql/
+          sudo rm -rf /etc/postgresql/
+          sudo rm -rf /usr/lib/postgresql
+          sudo rm -rf /usr/include/postgresql
+          sudo rm -rf /usr/share/postgresql
+          sudo rm -rf /etc/postgresql
+          sudo rm -f /usr/bin/pg_config
+      - name: Create pgsql dir
+        run: mkdir -p /opt/pgsql
+
+      - name: Build postgres
+        run: |
+          export PATH="/opt/pgsql/bin:$PATH"
+          ./configure --enable-coverage --enable-tap-tests --prefix=/opt/pgsql
+           make
+           make install
+      - name: Start postgresql cluster
+        run: |
+          export PATH="/opt/pgsql/bin:$PATH"
+          /opt/pgsql/bin/initdb -D /opt/pgsql/data
+          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+      - name: Build pg_stat_monitor
+        run: |
+          export PATH="/opt/pgsql/bin:$PATH"
+          sudo cp /opt/pgsql/bin/pg_config /usr/bin
+          make USE_PGXS=1
+          make USE_PGXS=1 install 
+        working-directory: src/pg_stat_monitor/
+
+      - name: Start pg_stat_monitor_tests & Run code coverage 
+        run: |
+          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
+          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+          make installcheck
+          make coverage-html
+          lcov --capture --directory . --output-file coverage/lcov.info
+          pip install cpp-coveralls
+          export COVERALLS_REPO_TOKEN="${{ secrets.COVERALL_PG_STAT_MONITOR_TOKEN }}"
+          coveralls --verbose
+        working-directory: src/pg_stat_monitor/
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ![pg13-test](https://github.com/percona/pg_stat_monitor/workflows/pg13-test/badge.svg)
 ![pg14-test](https://github.com/percona/pg_stat_monitor/workflows/pg14-test/badge.svg)
 
+[![Coverage Status](https://coveralls.io/repos/github/percona/pg_stat_monitor/badge.svg)](https://coveralls.io/github/percona/pg_stat_monitor)
+
 ## What is pg_stat_monitor?
 
 The **pg_stat_monitor** is a **Query Performance Monitoring** tool for [Percona Distribution for PostgreSQL](https://www.percona.com/software/postgresql-distribution) and PostgreSQL. **pg_stat_monitor** is based on PostgreSQL's contrib module ``pg_stat_statements``. pg_stat_statements provides the basic statistics, which is sometimes not enough. The major shortcoming in pg_stat_statements is that it accumulates all the queries and their statistics and does not provide aggregated statistics nor histogram information. In this case, a user needs to calculate the aggregate which is quite expensive. 


### PR DESCRIPTION
Added 'Coverall' (https://coveralls.io) code coverage to pg_stat_monitor repo so that in future we don't have to perform this activity manually. Secondly, it will also make sure that code coverage detailed report link and status is readily available on repos Github main page for each checkin (PR & Push), eventually helping in development velocity.