### PR TITLE
PG-195: Change pgsm_bucket_time value from 300 to 60.

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -23,7 +23,7 @@ SELECT * FROM pg_stat_monitor_settings;
  pg_stat_monitor.pgsm_track_utility       |      1 |             1 | Selects whether utility commands are tracked.                                                            |       0 |      0     |       0
  pg_stat_monitor.pgsm_normalized_query    |      1 |             1 | Selects whether save query in normalized format.                                                         |       0 |      0     |       0
  pg_stat_monitor.pgsm_max_buckets         |     10 |            10 | Sets the maximum number of buckets.                                                                      |       1 |      10    |       1
- pg_stat_monitor.pgsm_bucket_time         |    300 |           300 | Sets the time in seconds per bucket.                                                                     |       1 | 2147483647 |       1
+ pg_stat_monitor.pgsm_bucket_time         |     60 |            60 | Sets the time in seconds per bucket.                                                                     |       1 | 2147483647 |       1
  pg_stat_monitor.pgsm_histogram_min       |      0 |             0 | Sets the time in millisecond.                                                                            |       0 | 2147483647 |       1
  pg_stat_monitor.pgsm_histogram_max       | 100000 |        100000 | Sets the time in millisecond.                                                                            |      10 | 2147483647 |       1
  pg_stat_monitor.pgsm_histogram_buckets   |     10 |            10 | Sets the maximum number of histogram buckets                                                             |       2 | 2147483647 |       1

--- a/guc.c
+++ b/guc.c
@@ -104,7 +104,7 @@ init_guc(void)
 	conf[i] = (GucVariable) {
 		.guc_name = "pg_stat_monitor.pgsm_bucket_time",
 		.guc_desc = "Sets the time in seconds per bucket.",
-		.guc_default = 300,
+		.guc_default = 60,
 		.guc_min = 1,
 		.guc_max = INT_MAX,
 		.guc_restart = true,

--- a/regression/expected/guc.out
+++ b/regression/expected/guc.out
@@ -14,7 +14,7 @@ select pg_sleep(.5);
 SELECT * FROM pg_stat_monitor_settings ORDER BY name COLLATE "C";
                    name                   | value  | default_value |                                               description                                                | minimum |  maximum   | restart 
 ------------------------------------------+--------+---------------+----------------------------------------------------------------------------------------------------------+---------+------------+---------
- pg_stat_monitor.pgsm_bucket_time         |    300 |           300 | Sets the time in seconds per bucket.                                                                     |       1 | 2147483647 |       1
+ pg_stat_monitor.pgsm_bucket_time         |     60 |            60 | Sets the time in seconds per bucket.                                                                     |       1 | 2147483647 |       1
  pg_stat_monitor.pgsm_enable              |      1 |             1 | Enable/Disable statistics collector.                                                                     |       0 |          0 |       0
  pg_stat_monitor.pgsm_enable_query_plan   |      0 |             0 | Enable/Disable query plan monitoring                                                                     |       0 |          0 |       0
  pg_stat_monitor.pgsm_histogram_buckets   |     10 |            10 | Sets the maximum number of histogram buckets                                                             |       2 | 2147483647 |       1

--- a/regression/expected/guc_1.out
+++ b/regression/expected/guc_1.out
@@ -14,7 +14,7 @@ select pg_sleep(.5);
 SELECT * FROM pg_stat_monitor_settings ORDER BY name COLLATE "C";
                    name                   | value  | default_value |                                               description                                                | minimum |  maximum   | restart 
 ------------------------------------------+--------+---------------+----------------------------------------------------------------------------------------------------------+---------+------------+---------
- pg_stat_monitor.pgsm_bucket_time         |    300 |           300 | Sets the time in seconds per bucket.                                                                     |       1 | 2147483647 |       1
+ pg_stat_monitor.pgsm_bucket_time         |     60 |            60 | Sets the time in seconds per bucket.                                                                     |       1 | 2147483647 |       1
  pg_stat_monitor.pgsm_enable              |      1 |             1 | Enable/Disable statistics collector.                                                                     |       0 |          0 |       0
  pg_stat_monitor.pgsm_enable_query_plan   |      0 |             0 | Enable/Disable query plan monitoring                                                                     |       0 |          0 |       0
  pg_stat_monitor.pgsm_histogram_buckets   |     10 |            10 | Sets the maximum number of histogram buckets                                                             |       2 | 2147483647 |       1


### PR DESCRIPTION
Changed the default value of pgsm_bucket_time from 300 to 60. Now neither PMM users will need to adjust the default value, nor restart of PG server will be required for this purpose.