### PR TITLE
PG-226: Enable installcheck-world regression.

### DIFF
--- a/.github/workflows/pg11test.yml
+++ b/.github/workflows/pg11test.yml
@@ -12,16 +12,12 @@ jobs:
           repository: 'postgres/postgres'
           ref: 'REL_11_STABLE'
 
-      - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@v2
-        with:
-          path: 'src/pg_stat_monitor'
-
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y
+          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y docbook-xsl docbook-xsl
+          sudo apt-get install -y libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev
           sudo rm -rf /var/lib/postgresql/
           sudo rm -rf /var/log/postgresql/
           sudo rm -rf /etc/postgresql/
@@ -30,41 +26,81 @@ jobs:
           sudo rm -rf /usr/share/postgresql
           sudo rm -rf /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-
       - name: Create pgsql dir
         run: mkdir -p /opt/pgsql
 
       - name: Build postgres
         run: |
           export PATH="/opt/pgsql/bin:$PATH"
-          ./configure --enable-tap-tests --prefix=/opt/pgsql
-           make
-           make install
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=/usr/include' \
+            '--mandir=/usr/share/man' '--infodir=/usr/share/info' '--sysconfdir=/etc' \
+            '--localstatedir=/var' '--disable-silent-rules' '--libdir=/usr/lib/x86_64-linux-gnu' \
+            '--runstatedir=/run' '--disable-maintainer-mode' '--disable-dependency-tracking' \
+            '--with-icu' '--with-tcl' '--with-perl' '--with-python' '--with-pam' '--with-openssl' \
+            '--with-libxml' '--with-libxslt' 'PYTHON=/usr/bin/python3' \
+            '--mandir=/usr/share/postgresql/11/man' '--docdir=/usr/share/doc/postgresql-doc-11' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share/' \
+            '--datadir=/usr/share/postgresql/11' '--bindir=/usr/lib/postgresql/11/bin' \
+            '--libdir=/usr/lib/x86_64-linux-gnu/' '--libexecdir=/usr/lib/postgresql/' \
+            '--includedir=/usr/include/postgresql/' '--with-extra-version= (Ubuntu 11.x.pgdg20.04+1)' \
+            '--enable-nls' '--enable-thread-safety' '--enable-tap-tests' '--enable-debug' \
+            '--enable-dtrace' '--disable-rpath' '--with-uuid=e2fs' '--with-gnu-ld' \
+            '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
+            'LLVM_CONFIG=/usr/bin/llvm-config-9' 'CLANG=/usr/bin/clang-9' '--with-systemd' \
+            '--with-selinux' 'MKDIR_P=/bin/mkdir -p' 'PROVE=/usr/bin/prove' 'TAR=/bin/tar' \
+            'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' '--with-gssapi' '--with-ldap' \
+            '--with-includes=/usr/include/mit-krb5' '--with-libs=/usr/lib/mit-krb5' \
+            '--with-libs=/usr/lib/x86_64-linux-gnu/mit-krb5' 'build_alias=x86_64-linux-gnu' \
+            'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' 'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
+           make world
+           sudo make install-world
 
       - name: Start postgresql cluster
         run: |
-          export PATH="/opt/pgsql/bin:$PATH"
-          /opt/pgsql/bin/initdb -D /opt/pgsql/data
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+           /usr/lib/postgresql/11/bin/initdb -D /opt/pgsql/data
+           /usr/lib/postgresql/11/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
 
       - name: Build pg_stat_monitor
         run: |
-          export PATH="/opt/pgsql/bin:$PATH"
-          sudo cp /opt/pgsql/bin/pg_config /usr/bin
+          export PATH="/usr/lib/postgresql/11/bin:$PATH"
+          sudo cp /usr/lib/postgresql/11/bin/pg_config /usr/bin
           make USE_PGXS=1
-          make USE_PGXS=1 install
+          sudo make USE_PGXS=1 install
         working-directory: src/pg_stat_monitor/
 
+      - name: Load pg_stat_monitor library and Restart Server
+        run: |
+          /usr/lib/postgresql/11/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
+          /usr/lib/postgresql/11/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+        working-directory: src/pg_stat_monitor/
+
+      - name: Start Server installcheck-world tests (without TAP)
+        run: |
+          make installcheck-world
+      - name: Report on installcheck-world test suites fail
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Regressions output files of failed testsuite, and postgresql log
+          path: |
+            **/regression.diffs
+            **/regression.out
+            src/pg_stat_monitor/logfile
+          retention-days: 1
 
       - name: Start pg_stat_monitor_tests
         run: |
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile start
           make installcheck
         working-directory: src/pg_stat_monitor/
 
-      - name: Report on test fail
+      - name: Report on pg_stat_monitor test fail
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:

--- a/.github/workflows/pg12test.yml
+++ b/.github/workflows/pg12test.yml
@@ -12,16 +12,12 @@ jobs:
           repository: 'postgres/postgres'
           ref: 'REL_12_STABLE'
 
-      - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@v2
-        with:
-          path: 'src/pg_stat_monitor'
-
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y
+          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y docbook-xsl docbook-xsl
+          sudo apt-get install -y libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev
           sudo rm -rf /var/lib/postgresql/
           sudo rm -rf /var/log/postgresql/
           sudo rm -rf /etc/postgresql/
@@ -30,41 +26,77 @@ jobs:
           sudo rm -rf /usr/share/postgresql
           sudo rm -rf /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-
       - name: Create pgsql dir
         run: mkdir -p /opt/pgsql
 
       - name: Build postgres
         run: |
           export PATH="/opt/pgsql/bin:$PATH"
-          ./configure --enable-tap-tests --prefix=/opt/pgsql
-           make
-           make install
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=/usr/include' '--mandir=/usr/share/man' \
+            '--infodir=/usr/share/info' '--sysconfdir=/etc' '--localstatedir=/var' '--disable-silent-rules' \
+            '--libdir=/usr/lib/x86_64-linux-gnu' '--runstatedir=/run' '--disable-maintainer-mode' \
+            '--disable-dependency-tracking' '--with-icu' '--with-tcl' '--with-perl' '--with-python' \
+            '--with-pam' '--with-openssl' '--with-libxml' '--with-libxslt' 'PYTHON=/usr/bin/python3' \
+            '--mandir=/usr/share/postgresql/12/man' '--docdir=/usr/share/doc/postgresql-doc-12' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share/' '--datadir=/usr/share/postgresql/12' \
+            '--bindir=/usr/lib/postgresql/12/bin' '--libdir=/usr/lib/x86_64-linux-gnu/' '--libexecdir=/usr/lib/postgresql/' \
+            '--includedir=/usr/include/postgresql/' '--with-extra-version= (Ubuntu 12.x.pgdg20.04+1)' '--enable-nls' \
+            '--enable-thread-safety' '--enable-tap-tests' '--enable-debug' '--enable-dtrace' '--disable-rpath' \
+            '--with-uuid=e2fs' '--with-gnu-ld' '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
+            'LLVM_CONFIG=/usr/bin/llvm-config-9' 'CLANG=/usr/bin/clang-9' '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' \
+            'PROVE=/usr/bin/prove' 'TAR=/bin/tar' 'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' '--with-gssapi' '--with-ldap' \
+            '--with-includes=/usr/include/mit-krb5' '--with-libs=/usr/lib/mit-krb5' \
+            '--with-libs=/usr/lib/x86_64-linux-gnu/mit-krb5' 'build_alias=x86_64-linux-gnu' \
+            'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' 'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
+           make world
+           sudo make install-world
 
       - name: Start postgresql cluster
         run: |
-          export PATH="/opt/pgsql/bin:$PATH"
-          /opt/pgsql/bin/initdb -D /opt/pgsql/data
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+           /usr/lib/postgresql/12/bin/initdb -D /opt/pgsql/data
+           /usr/lib/postgresql/12/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
 
       - name: Build pg_stat_monitor
         run: |
-          export PATH="/opt/pgsql/bin:$PATH"
-          sudo cp /opt/pgsql/bin/pg_config /usr/bin
+          export PATH="/usr/lib/postgresql/12/bin:$PATH"
+          sudo cp /usr/lib/postgresql/12/bin/pg_config /usr/bin
           make USE_PGXS=1
-          make USE_PGXS=1 install
+          sudo make USE_PGXS=1 install
         working-directory: src/pg_stat_monitor/
 
+      - name: Load pg_stat_monitor library and Restart Server
+        run: |
+          /usr/lib/postgresql/12/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
+          /usr/lib/postgresql/12/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+        working-directory: src/pg_stat_monitor/
+
+      - name: Start Server installcheck-world tests (without TAP)
+        run: |
+          make installcheck-world
+      - name: Report on installcheck-world test suites fail
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Regressions output files of failed testsuite, and postgresql log
+          path: |
+            **/regression.diffs
+            **/regression.out
+            src/pg_stat_monitor/logfile
+          retention-days: 1
 
       - name: Start pg_stat_monitor_tests
         run: |
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile start
           make installcheck
         working-directory: src/pg_stat_monitor/
 
-      - name: Report on test fail
+      - name: Report on pg_stat_monitor test fail
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:

--- a/.github/workflows/pg13test.yml
+++ b/.github/workflows/pg13test.yml
@@ -12,16 +12,12 @@ jobs:
           repository: 'postgres/postgres'
           ref: 'REL_13_STABLE'
 
-      - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@v2
-        with:
-          path: 'src/pg_stat_monitor'
-
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y
+          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y docbook-xsl docbook-xsl
+          sudo apt-get install -y libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev
           sudo rm -rf /var/lib/postgresql/
           sudo rm -rf /var/log/postgresql/
           sudo rm -rf /etc/postgresql/
@@ -30,41 +26,82 @@ jobs:
           sudo rm -rf /usr/share/postgresql
           sudo rm -rf /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-
       - name: Create pgsql dir
         run: mkdir -p /opt/pgsql
 
       - name: Build postgres
         run: |
           export PATH="/opt/pgsql/bin:$PATH"
-          ./configure --enable-tap-tests --prefix=/opt/pgsql
-           make
-           make install
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=${prefix}/include' \
+            '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' \
+            '--sysconfdir=/etc' '--localstatedir=/var' '--disable-silent-rules' \
+            '--libdir=${prefix}/lib/x86_64-linux-gnu' \
+            '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--disable-maintainer-mode' \
+            '--disable-dependency-tracking' '--with-icu' '--with-tcl' '--with-perl' \
+            '--with-python' '--with-pam' '--with-openssl' '--with-libxml' '--with-libxslt' \
+            'PYTHON=/usr/bin/python3' '--mandir=/usr/share/postgresql/13/man' \
+            '--docdir=/usr/share/doc/postgresql-doc-13' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share/' \
+            '--datadir=/usr/share/postgresql/13' '--bindir=/usr/lib/postgresql/13/bin' \
+            '--libdir=/usr/lib/x86_64-linux-gnu/' '--libexecdir=/usr/lib/postgresql/' \
+            '--includedir=/usr/include/postgresql/' '--with-extra-version= (Ubuntu 2:13-x.focal)' \
+            '--enable-nls' '--enable-thread-safety' '--enable-tap-tests' '--enable-debug' \
+            '--enable-dtrace' '--disable-rpath' '--with-uuid=e2fs' '--with-gnu-ld' \
+            '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
+            'LLVM_CONFIG=/usr/bin/llvm-config-11' 'CLANG=/usr/bin/clang-11' \
+            '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' 'PROVE=/usr/bin/prove' \
+            'TAR=/bin/tar' 'XSLTPROC=xsltproc --nonet' 'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' '--with-gssapi' '--with-ldap' \
+            'build_alias=x86_64-linux-gnu' 'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
+           make world
+           sudo make install-world
 
       - name: Start postgresql cluster
         run: |
-          export PATH="/opt/pgsql/bin:$PATH"
-          /opt/pgsql/bin/initdb -D /opt/pgsql/data
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+           /usr/lib/postgresql/13/bin/initdb -D /opt/pgsql/data
+           /usr/lib/postgresql/13/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
 
       - name: Build pg_stat_monitor
         run: |
-          export PATH="/opt/pgsql/bin:$PATH"
-          sudo cp /opt/pgsql/bin/pg_config /usr/bin
+          export PATH="/usr/lib/postgresql/13/bin:$PATH"
+          sudo cp /usr/lib/postgresql/13/bin/pg_config /usr/bin
           make USE_PGXS=1
-          make USE_PGXS=1 install
+          sudo make USE_PGXS=1 install
         working-directory: src/pg_stat_monitor/
 
+      - name: Load pg_stat_monitor library and Restart Server
+        run: |
+          /usr/lib/postgresql/13/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
+          /usr/lib/postgresql/13/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+        working-directory: src/pg_stat_monitor/
+
+      - name: Start Server installcheck-world tests (without TAP)
+        run: |
+          make installcheck-world
+      - name: Report on installcheck-world test suites fail
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Regressions output files of failed testsuite, and postgresql log
+          path: |
+            **/regression.diffs
+            **/regression.out
+            src/pg_stat_monitor/logfile
+          retention-days: 1
 
       - name: Start pg_stat_monitor_tests
         run: |
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile start
           make installcheck
         working-directory: src/pg_stat_monitor/
 
-      - name: Report on test fail
+      - name: Report on pg_stat_monitor test fail
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:

--- a/.github/workflows/pg14test.yml
+++ b/.github/workflows/pg14test.yml
@@ -12,16 +12,12 @@ jobs:
           repository: 'postgres/postgres'
           ref: 'REL_14_STABLE'
 
-      - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@v2
-        with:
-          path: 'src/pg_stat_monitor'
-
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y
+          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y docbook-xsl docbook-xsl
+          sudo apt-get install -y libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev
           sudo rm -rf /var/lib/postgresql/
           sudo rm -rf /var/log/postgresql/
           sudo rm -rf /etc/postgresql/
@@ -30,41 +26,82 @@ jobs:
           sudo rm -rf /usr/share/postgresql
           sudo rm -rf /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-
       - name: Create pgsql dir
         run: mkdir -p /opt/pgsql
 
       - name: Build postgres
         run: |
           export PATH="/opt/pgsql/bin:$PATH"
-          ./configure --enable-tap-tests --prefix=/opt/pgsql
-           make
-           make install
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=${prefix}/include' \
+            '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' \
+            '--sysconfdir=/etc' '--localstatedir=/var' '--disable-silent-rules' \
+            '--libdir=${prefix}/lib/x86_64-linux-gnu' \
+            '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--disable-maintainer-mode' \
+            '--disable-dependency-tracking' '--with-icu' '--with-tcl' '--with-perl' \
+            '--with-python' '--with-pam' '--with-openssl' '--with-libxml' '--with-libxslt' \
+            'PYTHON=/usr/bin/python3' '--mandir=/usr/share/postgresql/14/man' \
+            '--docdir=/usr/share/doc/postgresql-doc-14' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share/' \
+            '--datadir=/usr/share/postgresql/14' '--bindir=/usr/lib/postgresql/14/bin' \
+            '--libdir=/usr/lib/x86_64-linux-gnu/' '--libexecdir=/usr/lib/postgresql/' \
+            '--includedir=/usr/include/postgresql/' '--with-extra-version= (Ubuntu 2:14-x.focal)' \
+            '--enable-nls' '--enable-thread-safety' '--enable-tap-tests' '--enable-debug' \
+            '--enable-dtrace' '--disable-rpath' '--with-uuid=e2fs' '--with-gnu-ld' \
+            '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
+            'LLVM_CONFIG=/usr/bin/llvm-config-11' 'CLANG=/usr/bin/clang-11' \
+            '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' 'PROVE=/usr/bin/prove' \
+            'TAR=/bin/tar' 'XSLTPROC=xsltproc --nonet' 'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' '--with-gssapi' '--with-ldap' \
+            'build_alias=x86_64-linux-gnu' 'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
+           make world
+           sudo make install-world
 
       - name: Start postgresql cluster
         run: |
-          export PATH="/opt/pgsql/bin:$PATH"
-          /opt/pgsql/bin/initdb -D /opt/pgsql/data
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+           /usr/lib/postgresql/14/bin/initdb -D /opt/pgsql/data
+           /usr/lib/postgresql/14/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
 
       - name: Build pg_stat_monitor
         run: |
-          export PATH="/opt/pgsql/bin:$PATH"
-          sudo cp /opt/pgsql/bin/pg_config /usr/bin
+          export PATH="/usr/lib/postgresql/14/bin:$PATH"
+          sudo cp /usr/lib/postgresql/14/bin/pg_config /usr/bin
           make USE_PGXS=1
-          make USE_PGXS=1 install
+          sudo make USE_PGXS=1 install
         working-directory: src/pg_stat_monitor/
 
+      - name: Load pg_stat_monitor library and Restart Server
+        run: |
+          /usr/lib/postgresql/14/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
+          /usr/lib/postgresql/14/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+        working-directory: src/pg_stat_monitor/
+
+      - name: Start Server installcheck-world tests (without TAP)
+        run: |
+          make installcheck-world
+      - name: Report on installcheck-world test suites fail
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Regressions output files of failed testsuite, and postgresql log
+          path: |
+            **/regression.diffs
+            **/regression.out
+            src/pg_stat_monitor/logfile
+          retention-days: 1
 
       - name: Start pg_stat_monitor_tests
         run: |
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
-          /opt/pgsql/bin/pg_ctl -D /opt/pgsql/data -l logfile start
           make installcheck
         working-directory: src/pg_stat_monitor/
 
-      - name: Report on test fail
+      - name: Report on pg_stat_monitor test fail
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
1) Enabled configure and build with proper flags and environment to make sure that
built server is aligned with pg and ppg package distribution in terms of features
and configurations.
2) Enabled installcheck-world regression test suites of the pg server, to verify
the stability and compatibility of pg server after loading pg_stat_monitor in
server.