### PR TITLE
PG-227: Enable PGSM master branch regression/test with latest PG releases.

### DIFF
--- a/.github/workflows/pg11test-pgdg-packages.yml
+++ b/.github/workflows/pg11test-pgdg-packages.yml
@@ -1,0 +1,61 @@
+name: Test-with-pg11-pgdg-packages
+on: [push]
+
+jobs:
+  build:
+    name: pg11-test-with-pgdg-packages
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
+
+      - name: Delete old postgresql files
+        run: |
+          sudo apt-get update
+          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
+          sudo rm -rf /var/lib/postgresql/
+          sudo rm -rf /var/log/postgresql/
+          sudo rm -rf /etc/postgresql/
+          sudo rm -rf /usr/lib/postgresql
+          sudo rm -rf /usr/include/postgresql
+          sudo rm -rf /usr/share/postgresql
+          sudo rm -rf /etc/postgresql
+          sudo rm -f /usr/bin/pg_config
+
+      - name: Install PG Distribution Postgresql 11
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get -y install postgresql-11
+          sudo apt-get update 
+          sudo apt-get -y install postgresql-client-11 
+          sudo apt-get update 
+          sudo apt install postgresql-server-dev-11
+          sudo chown -R postgres:postgres src/
+
+      - name: Build pg_stat_monitor
+        run: |
+          sudo make USE_PGXS=1
+          sudo make USE_PGXS=1 install
+        working-directory: src/pg_stat_monitor/
+
+      - name: Start pg_stat_monitor_tests
+        run: |
+          sudo service postgresql stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/11/main/postgresql.conf
+          sudo service postgresql start
+          sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
+        working-directory: src/pg_stat_monitor/
+
+      - name: Report on test fail
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Regressions diff and postgresql log
+          path: |
+            src/pg_stat_monitor/regression.diffs
+            src/pg_stat_monitor/logfile
+          retention-days: 1

--- a/.github/workflows/pg12test-pgdg-packages.yml
+++ b/.github/workflows/pg12test-pgdg-packages.yml
@@ -1,0 +1,61 @@
+name: Test-with-pg12-pgdg-packages
+on: [push]
+
+jobs:
+  build:
+    name: pg12-test-with-pgdg-packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
+
+      - name: Delete old postgresql files
+        run: |
+          sudo apt-get update
+          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
+          sudo rm -rf /var/lib/postgresql/
+          sudo rm -rf /var/log/postgresql/
+          sudo rm -rf /etc/postgresql/
+          sudo rm -rf /usr/lib/postgresql
+          sudo rm -rf /usr/include/postgresql
+          sudo rm -rf /usr/share/postgresql
+          sudo rm -rf /etc/postgresql
+          sudo rm -f /usr/bin/pg_config
+
+      - name: Install PG Distribution Postgresql 12
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get -y install postgresql-12 
+          sudo apt-get update 
+          sudo apt-get -y install postgresql-client-12 
+          sudo apt-get update
+          sudo apt install postgresql-server-dev-12
+          sudo chown -R postgres:postgres src/
+
+      - name: Build pg_stat_monitor
+        run: |
+          sudo make USE_PGXS=1
+          sudo make USE_PGXS=1 install
+        working-directory: src/pg_stat_monitor/
+
+      - name: Start pg_stat_monitor_tests
+        run: |
+          sudo service postgresql stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/12/main/postgresql.conf
+          sudo service postgresql start
+          sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
+        working-directory: src/pg_stat_monitor/
+
+      - name: Report on test fail
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Regressions diff and postgresql log
+          path: |
+            src/pg_stat_monitor/regression.diffs
+            src/pg_stat_monitor/logfile
+          retention-days: 1

--- a/.github/workflows/pg13test-pgdg-packages.yml
+++ b/.github/workflows/pg13test-pgdg-packages.yml
@@ -1,0 +1,57 @@
+name: Test-with-pg13-pgdg-packages
+on: [push]
+
+jobs:
+  build:
+    name: pg13-test-with-pgdg-packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
+
+      - name: Delete old postgresql files
+        run: |
+          sudo apt-get update
+          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
+          sudo rm -rf /var/lib/postgresql/
+          sudo rm -rf /var/log/postgresql/
+          sudo rm -rf /etc/postgresql/
+          sudo rm -rf /usr/lib/postgresql
+          sudo rm -rf /usr/include/postgresql
+          sudo rm -rf /usr/share/postgresql
+          sudo rm -rf /etc/postgresql
+          sudo rm -f /usr/bin/pg_config
+
+      - name: Install PG Distribution Postgresql 13
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get -y install postgresql-13 postgresql-client-13 postgresql-contrib postgresql-server-dev-13
+          sudo chown -R postgres:postgres src/
+
+      - name: Build pg_stat_monitor
+        run: |
+          sudo make USE_PGXS=1
+          sudo make USE_PGXS=1 install
+        working-directory: src/pg_stat_monitor/
+
+      - name: Start pg_stat_monitor_tests
+        run: |
+          sudo service postgresql stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/13/main/postgresql.conf
+          sudo service postgresql start
+          sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
+        working-directory: src/pg_stat_monitor/
+
+      - name: Report on test fail
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Regressions diff and postgresql log
+          path: |
+            src/pg_stat_monitor/regression.diffs
+            src/pg_stat_monitor/logfile
+          retention-days: 1

--- a/.github/workflows/pg14test-pgdg-packages.yml
+++ b/.github/workflows/pg14test-pgdg-packages.yml
@@ -1,0 +1,61 @@
+name: Test-with-pg14-pgdg-packages
+on: [push]
+
+jobs:
+  build:
+    name: pg14-test-with-pgdg-packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
+
+      - name: Delete old postgresql files
+        run: |
+          sudo apt-get update
+          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
+          sudo rm -rf /var/lib/postgresql/
+          sudo rm -rf /var/log/postgresql/
+          sudo rm -rf /etc/postgresql/
+          sudo rm -rf /usr/lib/postgresql
+          sudo rm -rf /usr/include/postgresql
+          sudo rm -rf /usr/share/postgresql
+          sudo rm -rf /etc/postgresql
+          sudo rm -f /usr/bin/pg_config
+
+      - name: Install PG Distribution Postgresql 14
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main 14" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get -y install postgresql-14
+          sudo apt-get update
+          sudo apt-get -y install postgresql-client-14
+          sudo apt-get update 
+          sudo apt-get -y install postgresql-server-dev-14
+          sudo chown -R postgres:postgres src/
+
+      - name: Build pg_stat_monitor
+        run: |
+          sudo make USE_PGXS=1
+          sudo make USE_PGXS=1 install
+        working-directory: src/pg_stat_monitor/
+
+      - name: Start pg_stat_monitor_tests
+        run: |
+          sudo service postgresql stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/14/main/postgresql.conf
+          sudo service postgresql start
+          sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
+        working-directory: src/pg_stat_monitor/
+
+      - name: Report on test fail
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Regressions diff and postgresql log
+          path: |
+            src/pg_stat_monitor/regression.diffs
+            src/pg_stat_monitor/logfile
+          retention-days: 1


### PR DESCRIPTION
Enable PGSM master branch regression/test with last Postgres release (actual
released packages) for supported server versions. This will make sure that we
would have already tested the PGSM compatibility well before PPG releases are done.