### PR TITLE
PG-258: Re-enable Coverall code coverage to pg_stat_monitor.

### DIFF
--- a/.github/workflows/coverage_test.yml
+++ b/.github/workflows/coverage_test.yml
@@ -1,0 +1,97 @@
+name: coverage-test
+on: ["push", "pull_request"]
+
+jobs:
+  build:
+    name: coverage-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone postgres repository
+        uses: actions/checkout@v2
+        with:
+          repository: 'postgres/postgres'
+          ref: 'REL_13_STABLE'
+
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
+          ref: 'master'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
+          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y docbook-xsl docbook-xsl
+          sudo apt-get install -y libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev
+          sudo apt-get install -y pkg-config clang-9 llvm-9 llvm-9-dev libselinux1-dev python-dev python3-dev uuid-dev liblz4-dev lcov
+          sudo rm -rf /var/lib/postgresql/
+          sudo rm -rf /var/log/postgresql/
+          sudo rm -rf /etc/postgresql/
+          sudo rm -rf /usr/lib/postgresql
+          sudo rm -rf /usr/include/postgresql
+          sudo rm -rf /usr/share/postgresql
+          sudo rm -rf /etc/postgresql
+          sudo rm -f /usr/bin/pg_config
+      - name: Create pgsql dir
+        run: mkdir -p /opt/pgsql
+
+      - name: Build postgres
+        run: |
+          export PATH="/opt/pgsql/bin:$PATH"
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=${prefix}/include' \
+            '--enable-coverage' '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' \
+            '--sysconfdir=/etc' '--localstatedir=/var' '--disable-silent-rules' \
+            '--libdir=${prefix}/lib/x86_64-linux-gnu' \
+            '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--disable-maintainer-mode' \
+            '--disable-dependency-tracking' '--with-icu' '--with-tcl' '--with-perl' \
+            '--with-python' '--with-pam' '--with-openssl' '--with-libxml' '--with-libxslt' \
+            'PYTHON=/usr/bin/python3' '--mandir=/usr/share/postgresql/13/man' \
+            '--docdir=/usr/share/doc/postgresql-doc-13' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share/' \
+            '--datadir=/usr/share/postgresql/13' '--bindir=/usr/lib/postgresql/13/bin' \
+            '--libdir=/usr/lib/x86_64-linux-gnu/' '--libexecdir=/usr/lib/postgresql/' \
+            '--includedir=/usr/include/postgresql/' '--with-extra-version= (Ubuntu 2:13-x.focal)' \
+            '--enable-nls' '--enable-thread-safety' '--enable-tap-tests' '--enable-debug' \
+            '--enable-dtrace' '--disable-rpath' '--with-uuid=e2fs' '--with-gnu-ld' \
+            '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
+            'LLVM_CONFIG=/usr/bin/llvm-config-11' 'CLANG=/usr/bin/clang-11' \
+            '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' 'PROVE=/usr/bin/prove' \
+            'TAR=/bin/tar' 'XSLTPROC=xsltproc --nonet' 'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' '--with-gssapi' '--with-ldap' \
+            'build_alias=x86_64-linux-gnu' 'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
+           make
+           sudo make install
+
+      - name: Start postgresql cluster
+        run: |
+           /usr/lib/postgresql/13/bin/initdb -D /opt/pgsql/data
+           /usr/lib/postgresql/13/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
+
+      - name: Build pg_stat_monitor
+        run: |
+          export PATH="/usr/lib/postgresql/13/bin:$PATH"
+          sudo cp /usr/lib/postgresql/13/bin/pg_config /usr/bin
+          make USE_PGXS=1
+          sudo make USE_PGXS=1 install
+        working-directory: src/pg_stat_monitor/
+
+      - name: Start pg_stat_monitor_tests & Run code coverage 
+        run: |
+          /usr/lib/postgresql/13/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
+          /usr/lib/postgresql/13/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+          make installcheck
+          make coverage-html
+          lcov --capture --directory . --output-file coverage/lcov.info
+          pip install cpp-coveralls
+          export COVERALLS_REPO_TOKEN="${{ secrets.COVERALL_PG_STAT_MONITOR_TOKEN }}"
+          coveralls --verbose
+        working-directory: src/pg_stat_monitor/
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ![pg13-test](https://github.com/percona/pg_stat_monitor/workflows/pg13-test/badge.svg)
 ![pg14-test](https://github.com/percona/pg_stat_monitor/workflows/pg14-test/badge.svg)
 
+[![Coverage Status](https://coveralls.io/repos/github/percona/pg_stat_monitor/badge.svg)](https://coveralls.io/github/percona/pg_stat_monitor)
+
 # pg_stat_monitor: Query Performance Tool for PostgreSQL
 
 ## Table of Contents


### PR DESCRIPTION
As codecov is not approved by IT due to some known vulnerabilities in the past, reverting back to coverall.io to make sure that at least code coverage is available.