### PR TITLE
PG-259: Fixed PGSM build in Test-with-pg13-pgdg-packages GH action. 

### DIFF
--- a/.github/workflows/pg11test-pgdg-packages.yml
+++ b/.github/workflows/pg11test-pgdg-packages.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
+          export PATH="/usr/lib/postgresql/11/bin:$PATH"
+          sudo cp /usr/lib/postgresql/11/bin/pg_config /usr/bin
           sudo make USE_PGXS=1
           sudo make USE_PGXS=1 install
         working-directory: src/pg_stat_monitor/

--- a/.github/workflows/pg12test-pgdg-packages.yml
+++ b/.github/workflows/pg12test-pgdg-packages.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
+          export PATH="/usr/lib/postgresql/12/bin:$PATH"
+          sudo cp /usr/lib/postgresql/12/bin/pg_config /usr/bin
           sudo make USE_PGXS=1
           sudo make USE_PGXS=1 install
         working-directory: src/pg_stat_monitor/

--- a/.github/workflows/pg13test-pgdg-packages.yml
+++ b/.github/workflows/pg13test-pgdg-packages.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
+          export PATH="/usr/lib/postgresql/13/bin:$PATH"
+          sudo cp /usr/lib/postgresql/13/bin/pg_config /usr/bin
           sudo make USE_PGXS=1
           sudo make USE_PGXS=1 install
         working-directory: src/pg_stat_monitor/

--- a/.github/workflows/pg14test-pgdg-packages.yml
+++ b/.github/workflows/pg14test-pgdg-packages.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
+          export PATH="/usr/lib/postgresql/14/bin:$PATH"
+          sudo cp /usr/lib/postgresql/14/bin/pg_config /usr/bin
           sudo make USE_PGXS=1
           sudo make USE_PGXS=1 install
         working-directory: src/pg_stat_monitor/


### PR DESCRIPTION
PGSM build was failing in pg13-pgdg regressions as it was not able to find postgres.h. Similarly applied same change to 11,12 & 14 to make sure build is consistent and doesn't fail.  