### PR TITLE
PG-272: Fix server crash when calling pg_stat_monitor_reset().

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1579,7 +1579,7 @@ pg_stat_monitor_reset(PG_FUNCTION_ARGS)
 	LWLockAcquire(pgss->lock, LW_EXCLUSIVE);
 	hash_entry_dealloc(-1, -1, NULL);
 	/* Reset query buffers. */
-	for (size_t i = 0; i < MAX_BUCKETS; ++i)
+	for (size_t i = 0; i < PGSM_MAX_BUCKETS; ++i)
 	{
 		*(uint64 *)pgss_qbuf[i] = 0;
 	}


### PR DESCRIPTION
The loop that resets the query buffers was incorrecly using MAX_BUCKETS
to indicate the number of buckets to clear, which defaults to 10. If a
user lowers this value the loop would access a pointer beyond the number
of query buffers allocated.

Fix the problem by using the correct PGSM_MAX_BUCKETS GUC as the limit
to the loop.