### PR TITLE
PG-276: Fix regression tests.

### DIFF
--- a/regression/expected/guc_1.out
+++ b/regression/expected/guc_1.out
@@ -1,0 +1,39 @@
+CREATE EXTENSION pg_stat_monitor;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+select pg_sleep(.5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM pg_stat_monitor_settings ORDER BY name COLLATE "C";
+                   name                   | value  | default_value |                                               description                                                | minimum |  maximum   | restart 
+------------------------------------------+--------+---------------+----------------------------------------------------------------------------------------------------------+---------+------------+---------
+ pg_stat_monitor.pgsm_bucket_time         |     60 |            60 | Sets the time in seconds per bucket.                                                                     |       1 | 2147483647 |       1
+ pg_stat_monitor.pgsm_enable              |      1 |             1 | Enable/Disable statistics collector.                                                                     |       0 |          0 |       0
+ pg_stat_monitor.pgsm_enable_query_plan   |      0 |             0 | Enable/Disable query plan monitoring                                                                     |       0 |          0 |       0
+ pg_stat_monitor.pgsm_histogram_buckets   |     10 |            10 | Sets the maximum number of histogram buckets                                                             |       2 | 2147483647 |       1
+ pg_stat_monitor.pgsm_histogram_max       | 100000 |        100000 | Sets the time in millisecond.                                                                            |      10 | 2147483647 |       1
+ pg_stat_monitor.pgsm_histogram_min       |      0 |             0 | Sets the time in millisecond.                                                                            |       0 | 2147483647 |       1
+ pg_stat_monitor.pgsm_max                 |    100 |           100 | Sets the maximum size of shared memory in (MB) used for statement's metadata tracked by pg_stat_monitor. |       1 |       1000 |       1
+ pg_stat_monitor.pgsm_max_buckets         |     10 |            10 | Sets the maximum number of buckets.                                                                      |       1 |         10 |       1
+ pg_stat_monitor.pgsm_normalized_query    |      1 |             1 | Selects whether save query in normalized format.                                                         |       0 |          0 |       0
+ pg_stat_monitor.pgsm_overflow_target     |      1 |             1 | Sets the overflow target for pg_stat_monitor                                                             |       0 |          1 |       1
+ pg_stat_monitor.pgsm_query_max_len       |   1024 |          1024 | Sets the maximum length of query.                                                                        |    1024 | 2147483647 |       1
+ pg_stat_monitor.pgsm_query_shared_buffer |     20 |            20 | Sets the maximum size of shared memory in (MB) used for query tracked by pg_stat_monitor.                |       1 |      10000 |       1
+ pg_stat_monitor.pgsm_track_planning      |      1 |             1 | Selects whether planning statistics are tracked.                                                         |       0 |          0 |       0
+ pg_stat_monitor.pgsm_track_utility       |      1 |             1 | Selects whether utility commands are tracked.                                                            |       0 |          0 |       0
+(14 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
The guc_1.out is used for PG >= 13, where query track planning is
available, so it has been restored.