### PR TITLE
PG-277: Fix regression tests (pgsm_overflow_target defaults).

### DIFF
--- a/regression/expected/guc_1.out
+++ b/regression/expected/guc_1.out
@@ -23,7 +23,7 @@ SELECT * FROM pg_stat_monitor_settings ORDER BY name COLLATE "C";
  pg_stat_monitor.pgsm_max                 |    100 |           100 | Sets the maximum size of shared memory in (MB) used for statement's metadata tracked by pg_stat_monitor. |       1 |       1000 |       1
  pg_stat_monitor.pgsm_max_buckets         |     10 |            10 | Sets the maximum number of buckets.                                                                      |       1 |         10 |       1
  pg_stat_monitor.pgsm_normalized_query    |      1 |             1 | Selects whether save query in normalized format.                                                         |       0 |          0 |       0
- pg_stat_monitor.pgsm_overflow_target     |      0 |             1 | Sets the overflow target for pg_stat_monitor                                                             |       0 |          1 |       1
+ pg_stat_monitor.pgsm_overflow_target     |      1 |             1 | Sets the overflow target for pg_stat_monitor                                                             |       0 |          1 |       1
  pg_stat_monitor.pgsm_query_max_len       |   1024 |          1024 | Sets the maximum length of query.                                                                        |    1024 | 2147483647 |       1
  pg_stat_monitor.pgsm_query_shared_buffer |     20 |            20 | Sets the maximum size of shared memory in (MB) used for query tracked by pg_stat_monitor.                |       1 |      10000 |       1
  pg_stat_monitor.pgsm_track_utility       |      1 |             1 | Selects whether utility commands are tracked.                                                            |       0 |          0 |       0


### PR DESCRIPTION
Adjust guc_1.out to match guc.out defaults for pgsm_overflow_target.