### PR TITLE
PG-234: Fix loading both pg_stat_monitor and pg_stat_statements.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1046,7 +1046,8 @@ static void pgss_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
                                     context, params, queryEnv,
 									dest,
 									qc);
-            standard_ProcessUtility(pstmt, queryString,
+            else
+				standard_ProcessUtility(pstmt, queryString,
                                         readOnlyTree,
 										context, params, queryEnv,
 										dest,
@@ -1057,7 +1058,8 @@ static void pgss_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
                                     context, params, queryEnv,
 									dest,
 									qc);
-            standard_ProcessUtility(pstmt, queryString,
+            else
+				standard_ProcessUtility(pstmt, queryString,
 										context, params, queryEnv,
 										dest,
                                         qc);
@@ -1067,7 +1069,8 @@ static void pgss_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 									context, params, queryEnv,
 									dest,
 									completionTag);
-			standard_ProcessUtility(pstmt, queryString,
+			else
+				standard_ProcessUtility(pstmt, queryString,
 										context, params, queryEnv,
 										dest,
                                         completionTag);


### PR DESCRIPTION
If both modules are loaded then pg_stat_monitor detects that and avoid
calling standard_ProcessUtility() in ProcessUtility_hook hook, as
calling it twice is an error and triggers an assertion on PostgreSQL.

On PostgreSQL 13, pg_stat_monitor must be loaded after
pg_stat_statements, as pg_stat_statements doesn't do such verifications,
it end calling standard_ProcessUtility() and other functions even if
another module is registered, that is an error.

They fixed this problem with pg_stat_statements in PostgreSQL 14 and onward.