### PR TITLE
PG-290: Fix crash when enabling debugging log level on PostgreSQL.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1120,6 +1120,9 @@ pg_get_backend_status(void)
 		PgBackendStatus *beentry;
 
 		local_beentry = pgstat_fetch_stat_local_beentry(i);
+		if (!local_beentry)
+			continue;
+
 		beentry = &local_beentry->backendStatus;
 
 		if (beentry->st_procpid == MyProcPid)
@@ -1132,6 +1135,8 @@ static int
 pg_get_application_name(char *application_name)
 {
 	PgBackendStatus *beentry = pg_get_backend_status();
+	if (!beentry)
+		return snprintf(application_name, APPLICATIONNAME_LEN, "%s", "postmaster");
 
 	snprintf(application_name, APPLICATIONNAME_LEN, "%s", beentry->st_appname);
 	return strlen(application_name);
@@ -1153,6 +1158,9 @@ pg_get_client_addr(void)
 	PgBackendStatus *beentry = pg_get_backend_status();
 	char	remote_host[NI_MAXHOST];
 	int		ret;
+
+	if (!beentry)
+		return ntohl(inet_addr("127.0.0.1"));
 
 	memset(remote_host, 0x0, NI_MAXHOST);
 	ret = pg_getnameinfo_all(&beentry->st_clientaddr.addr,
@@ -1478,7 +1486,13 @@ pgss_store(uint64 queryid,
 		return;
 
 	Assert(query != NULL);
-	userid =  GetUserId();
+	if (kind == PGSS_ERROR)
+	{
+		int sec_ctx;
+		GetUserIdAndSecContext((Oid *)&userid, &sec_ctx);
+	}
+	else
+		userid =  GetUserId();
 
 	application_name_len = pg_get_application_name(application_name);
 	planid = plan_info ? plan_info->planid: 0;
@@ -3325,6 +3339,10 @@ pgsm_emit_log_hook(ErrorData *edata)
 		goto exit;
 
 	if (IsParallelWorker())
+		return;
+
+	/* Check if PostgreSQL has finished its own bootstraping code. */
+	if (MyProc == NULL)
 		return;
 
 	if ((edata->elevel == ERROR || edata->elevel == WARNING || edata->elevel == INFO || edata->elevel == DEBUG1))


### PR DESCRIPTION
There were couple issues to handle, the main one was that our log hook
(pgsm_emit_log_hook) was being called after the shared memory hook
completed (pgss_shmem_startup) but before PostgreSQL boostraping code
finished, thus triggering the following assertion during a call to
LWLockAcquire():
Assert(!(proc == NULL && IsUnderPostmaster));

proc is a pointer to MyProc, a PostgreSQL's shared global variable that
was not yet initalized by PostgreSQL.

We must also check for a NULL pointer return in pg_get_backend_status()
the pgstat_fetch_stat_local_beentry() function may return a NULL pointer
during initialization, in which case we use "127.0.0.1" for the client
address, and "postmaster" for application name.