### PR TITLE
PG-329: Fix creation of pg_stat_monitor_errors view on SQL files.

### DIFF
--- a/pg_stat_monitor--1.0.13.sql.in
+++ b/pg_stat_monitor--1.0.13.sql.in
@@ -241,9 +241,42 @@ $$ language plpgsql;
 --    total_time / greatest(ncalls, 1) as avg_time,
 --    ncalls,
 --    ROUND(CAST(total_time / greatest(sum(total_time) OVER(), 0.00000001) * 100 as numeric), 2)::text || '%' as load_comparison
---FROM pg_stat_monitor_hook_stats();
+-- FROM pg_stat_monitor_hook_stats();
+
+CREATE FUNCTION pg_stat_monitor_errors(
+    OUT severity   int,
+    OUT message    text,
+    OUT msgtime    text,
+    OUT calls      int8
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'pg_stat_monitor_errors'
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION pgsm_log_severity_as_text(severity int) RETURNS TEXT AS
+$$
+SELECT
+	CASE
+		WHEN severity = 0 THEN 'INFO'
+		WHEN severity = 1 THEN 'WARNING'
+		WHEN severity = 2 THEN 'ERROR'
+	END
+$$
+LANGUAGE SQL PARALLEL SAFE;
+
+CREATE VIEW pg_stat_monitor_errors AS SELECT
+    pgsm_log_severity_as_text(severity) as severity, message, msgtime, calls
+FROM pg_stat_monitor_errors();
+
+CREATE FUNCTION pg_stat_monitor_reset_errors()
+RETURNS void
+AS 'MODULE_PATHNAME'
+LANGUAGE C PARALLEL SAFE;
 
 GRANT SELECT ON pg_stat_monitor TO PUBLIC;
 GRANT SELECT ON pg_stat_monitor_settings TO PUBLIC;
+
+GRANT SELECT ON pg_stat_monitor_errors TO PUBLIC;
 -- Don't want this to be available to non-superusers.
 REVOKE ALL ON FUNCTION pg_stat_monitor_reset() FROM PUBLIC;
+REVOKE ALL ON FUNCTION pg_stat_monitor_reset_errors() FROM PUBLIC;

--- a/pg_stat_monitor--1.0.14.sql.in
+++ b/pg_stat_monitor--1.0.14.sql.in
@@ -242,9 +242,42 @@ $$ language plpgsql;
 --    total_time / greatest(ncalls, 1) as avg_time,
 --    ncalls,
 --    ROUND(CAST(total_time / greatest(sum(total_time) OVER(), 0.00000001) * 100 as numeric), 2)::text || '%' as load_comparison
---FROM pg_stat_monitor_hook_stats();
+-- FROM pg_stat_monitor_hook_stats();
+
+CREATE FUNCTION pg_stat_monitor_errors(
+    OUT severity   int,
+    OUT message    text,
+    OUT msgtime    text,
+    OUT calls      int8
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'pg_stat_monitor_errors'
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION pgsm_log_severity_as_text(severity int) RETURNS TEXT AS
+$$
+SELECT
+	CASE
+		WHEN severity = 0 THEN 'INFO'
+		WHEN severity = 1 THEN 'WARNING'
+		WHEN severity = 2 THEN 'ERROR'
+	END
+$$
+LANGUAGE SQL PARALLEL SAFE;
+
+CREATE VIEW pg_stat_monitor_errors AS SELECT
+    pgsm_log_severity_as_text(severity) as severity, message, msgtime, calls
+FROM pg_stat_monitor_errors();
+
+CREATE FUNCTION pg_stat_monitor_reset_errors()
+RETURNS void
+AS 'MODULE_PATHNAME'
+LANGUAGE C PARALLEL SAFE;
 
 GRANT SELECT ON pg_stat_monitor TO PUBLIC;
 GRANT SELECT ON pg_stat_monitor_settings TO PUBLIC;
+
+GRANT SELECT ON pg_stat_monitor_errors TO PUBLIC;
 -- Don't want this to be available to non-superusers.
 REVOKE ALL ON FUNCTION pg_stat_monitor_reset() FROM PUBLIC;
+REVOKE ALL ON FUNCTION pg_stat_monitor_reset_errors() FROM PUBLIC;


### PR DESCRIPTION
After the split into multiple pg_stat_monitor--1.0.XX.sql.in sql files,
where XX is the PostgreSQL version, it was forgotten to add the errors
view to the relevant files, this commit fixes that.