### PR TITLE
PG-311: Fix cpu_time and system_time accumulation.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1358,8 +1358,8 @@ pgss_update_entry(pgssEntry *entry,
             }
 		    if (sys_info)
 		    {
-			    e->counters.sysinfo.utime = (int64)(sys_info->utime - e->counters.sysinfo.utime)/e->counters.calls.calls;
-			    e->counters.sysinfo.stime = (int64)(sys_info->stime - e->counters.sysinfo.stime)/e->counters.calls.calls;
+			    e->counters.sysinfo.utime += (int64)(sys_info->utime - e->counters.sysinfo.utime)/e->counters.calls.calls;
+			    e->counters.sysinfo.stime += (int64)(sys_info->stime - e->counters.sysinfo.stime)/e->counters.calls.calls;
 		    }
 		    if (walusage)
 		    {


### PR DESCRIPTION
Fixed a small typo introduced by commit
eaa9c08e24506529a317c20d419f33304c0d0918: PG-316: Convert blocks
timings to average per buckets.

The e->counters.sysinfo.utime = and e->counters.sysinfo.stime =
operations should be += to accumulate the results and calculate the
average correctly.