### PR TITLE
PG-311: Fix user/system cpu time zero values.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1359,8 +1359,8 @@ pgss_update_entry(pgssEntry *entry,
             }
 		    if (sys_info)
 		    {
-			    e->counters.sysinfo.utime += (int64)(sys_info->utime - e->counters.sysinfo.utime)/e->counters.calls.calls;
-			    e->counters.sysinfo.stime += (int64)(sys_info->stime - e->counters.sysinfo.stime)/e->counters.calls.calls;
+			    e->counters.sysinfo.utime += (sys_info->utime - e->counters.sysinfo.utime)/e->counters.calls.calls;
+			    e->counters.sysinfo.stime += (sys_info->stime - e->counters.sysinfo.stime)/e->counters.calls.calls;
 		    }
 		    if (walusage)
 		    {


### PR DESCRIPTION
Some queries were taking less than one millisecond to execute, since we
store cpu time values in milliseconds in a float, a value of 0.1 (a tenth
of millisecond) cast to int64 would truncate the fractional part and
the result would be zero.

To fix the problem, the cast to (int64) when calculating the average cpu
time was removed, when updating entry statistics in pgss_update_entry()
function.