### PR TITLE
Fixing issue where makefile was not honoring PG's global makefiles when placed under the contrib folder.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,50 +17,11 @@ REGRESS = basic version guc counters relations database error_insert application
 # which typical installcheck users do not have (e.g. buildfarm clients).
 # NO_INSTALLCHECK = 1
 
-
 PG_CONFIG = pg_config
-PG_VERSION := $(shell pg_config --version | awk {'print $$1 $$2'})
-MAJOR := $(shell echo $(PG_VERSION) | sed -e 's/\.[^./]*$$//')
-
-ifneq (,$(findstring PostgreSQL14,$(MAJOR)))
-  ifneq (,$(wildcard ../pg_stat_monitor--1.0.14.sql.in))
-    CP := $(shell cp ../pg_stat_monitor--1.0.14.sql.in ../pg_stat_monitor--1.0.sql)
-  endif
-  ifneq (,$(wildcard pg_stat_monitor--1.0.14.sql.in))
-    CP := $(shell cp pg_stat_monitor--1.0.14.sql.in pg_stat_monitor--1.0.sql)
-  endif
-  TAP_TESTS = 1
-endif
-
-ifneq (,$(findstring PostgreSQL13,$(MAJOR)))
-  ifneq (,$(wildcard ../pg_stat_monitor--1.0.13.sql.in))
-    CP := $(shell cp ../pg_stat_monitor--1.0.13.sql.in ../pg_stat_monitor--1.0.sql)
-  endif
-  ifneq (,$(wildcard pg_stat_monitor--1.0.13.sql.in))
-    CP := $(shell cp pg_stat_monitor--1.0.13.sql.in pg_stat_monitor--1.0.sql)
-  endif
-  TAP_TESTS = 1
-endif
-
-ifneq (,$(findstring PostgreSQL12,$(MAJOR)))
-  ifneq (,$(wildcard ../pg_stat_monitor--1.0.sql.in))
-    CP := $(shell cp ../pg_stat_monitor--1.0.sql.in ../pg_stat_monitor--1.0.sql)
-  endif
-  ifneq (,$(wildcard pg_stat_monitor--1.0.sql.in))
-    CP := $(shell cp pg_stat_monitor--1.0.sql.in pg_stat_monitor--1.0.sql)
-  endif
-endif
-
-ifneq (,$(findstring PostgreSQL11,$(MAJOR)))
-  ifneq (,$(wildcard ../pg_stat_monitor--1.0.sql.in))
-    CP := $(shell cp ../pg_stat_monitor--1.0.sql.in ../pg_stat_monitor--1.0.sql)
-  endif
-  ifneq (,$(wildcard pg_stat_monitor--1.0.sql.in))
-    CP := $(shell cp pg_stat_monitor--1.0.sql.in pg_stat_monitor--1.0.sql)
-  endif
-endif
+PGSM_INPUT_SQL_VERSION := 1.0
 
 ifdef USE_PGXS
+MAJORVERSION := $(shell pg_config --version | awk {'print $$2'} | cut -f1 -d".")
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 else
@@ -69,6 +30,20 @@ top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
+
+ifeq ($(shell test $(MAJORVERSION) -gt 12; echo $$?),0)
+PGSM_INPUT_SQL_VERSION := 1.0.${MAJORVERSION}
+endif
+
+$(info Using pg_stat_monitor--${PGSM_INPUT_SQL_VERSION}.sql.in file to generate sql filea.)
+
+ifneq (,$(wildcard ../pg_stat_monitor--${PGSM_INPUT_SQL_VERSION}.sql.in))
+  CP := $(shell cp -v ../pg_stat_monitor--${PGSM_INPUT_SQL_VERSION}.sql.in ../pg_stat_monitor--1.0.sql)
+endif
+ifneq (,$(wildcard pg_stat_monitor--${PGSM_INPUT_SQL_VERSION}.sql.in))
+  CP := $(shell cp -v pg_stat_monitor--${PGSM_INPUT_SQL_VERSION}.sql.in pg_stat_monitor--1.0.sql)
+endif
+TAP_TESTS = 1
 
 #NEEDTARGET = $(shell test $(VERSION_NUM) -lt 120000 && echo yes)
 #ifeq ($(NEEDTARGET),yes)


### PR DESCRIPTION
PG-352: pg_stat_monitor: make error when placed under contrib folder

Fixing issue where makefile was not honoring PG's global makefiles when placed under the contrib folder. This fix resolves it by setting MAJORVERSION from pg_config and then setting input SQL file version accordingly.

[PG-352](https://jira.percona.com/browse/PG-352)