### PR TITLE
PG-355: Collect accumulative value of sys_time and user_time.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1347,8 +1347,8 @@ pgss_update_entry(pgssEntry *entry,
 		e->counters.calls.usage += USAGE_EXEC(total_time);
 		if (sys_info)
 		{
-			e->counters.sysinfo.utime = sys_info->utime;
-			e->counters.sysinfo.stime = sys_info->stime;
+			e->counters.sysinfo.utime += sys_info->utime;
+			e->counters.sysinfo.stime += sys_info->stime;
 		}
 		if (walusage)
 		{


### PR DESCRIPTION
Collect accumulative value of sys_time and user_time, because
separate value for each same query will override the previous value.