### PR TITLE
PG-369: Fix wal_bytes values on PG <= 12.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -989,9 +989,9 @@ static void pgss_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		instr_time	duration;
 		uint64		rows;
 		BufferUsage bufusage;
-		WalUsage    walusage;
 		BufferUsage bufusage_start = pgBufferUsage;
 #if PG_VERSION_NUM >= 130000
+		WalUsage    walusage;
 		WalUsage    walusage_start = pgWalUsage;
 #endif
 		INSTR_TIME_SET_CURRENT(start);
@@ -1083,7 +1083,11 @@ static void pgss_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 			INSTR_TIME_GET_MILLISEC(duration), /* total_time */
 			rows,							   /* rows */
 			&bufusage,						   /* bufusage */
+#if PG_VERSION_NUM >= 130000
 			&walusage,						   /* walusage */
+#else
+			NULL,							   /* walusage, NULL for PG <= 12 */
+#endif
 			NULL,							   /* JumbleState */
 			PGSS_FINISHED);					   /* pgssStoreKind */
 	}


### PR DESCRIPTION
Similar to pg_stat_statements, pg_stat_monitor tracks wal data metrics
since PostgreSQL 13, the problem was that for PostgreSQL versions 11 and
12 we left the WalUsage variable declared in the stack unitialized,
thus leading to garbage values.

Fixed the problem by ignoring the WalUsage variable value for PG <= 12.