### PR TITLE
PG-365:  change version in META.json file to dev

### DIFF
--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "pg_stat_monitor",
    "abstract": "PostgreSQL Query Performance Monitoring Tool",
    "description": "pg_stat_monitor is a PostgreSQL Query Performance Monitoring tool, based on PostgreSQL's contrib module pg_stat_statements. PostgreSQL’s pg_stat_statements provides the basic statistics, which is sometimes not enough. The major shortcoming in pg_stat_statements is that it accumulates all the queries and their statistics and does not provide aggregated statistics nor histogram information. In this case, a user would need to calculate the aggregates, which is quite an expensive operation.",
-   "version": "0.9.2-beta1",
+   "version": "dev",
    "maintainer": [
       "ibrar.ahmed@percona.com"
    ],
@@ -12,7 +12,7 @@
          "abstract": "PostgreSQL Query Performance Monitoring Tool",
          "file": "pg_stat_monitor--1.0.sql",
          "docfile": "README.md",
-         "version": "0.9.2-beta1"
+         "version": "dev"
       }
    },
    "prereqs": {
@@ -23,6 +23,7 @@
       }
    },
    "resources": {
+      "homepage": "https://percona.github.io/pg_stat_monitor/",
       "bugtracker": {
          "web": "https://jira.percona.com/projects/PG/issues"
       },


### PR DESCRIPTION
The META.json file had still an old release reference. Fixed that by changing it to "dev" for the main branch.

Added the "homepage" reference as requested in the PG-365 ticket.

Signed-off-by: Kai Wagner <kai.wagner@percona.com>