### PR TITLE
PG-289 - Don't fail to build with C11 compilers

### DIFF
--- a/guc.c
+++ b/guc.c
@@ -34,7 +34,7 @@ static bool check_histogram_max(int *newval, void **extra, GucSource source);
 void
 init_guc(void)
 {
-	int i = 0;
+	int i = 0, j;
 
 	conf[i] = (GucVariable) {
 		.guc_name = "pg_stat_monitor.pgsm_max",
@@ -191,7 +191,7 @@ init_guc(void)
 		.guc_unit = 0,
 		.guc_value = &PGSM_TRACK
 	};
-	for (int j = 0; j < conf[i].n_options; ++j) {
+	for (j = 0; j < conf[i].n_options; ++j) {
 		strlcpy(conf[i].guc_options[j], track_options[j].name, sizeof(conf[i].guc_options[j]));
 	}
 	DefineEnumGUC(&conf[i++], track_options);

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -3399,8 +3399,9 @@ pg_stat_monitor_settings(PG_FUNCTION_ARGS)
 
         if (conf->type == PGC_ENUM)
         {
+	    size_t i;
             strcat(options, conf->guc_options[0]);
-            for (size_t i = 1; i < conf->n_options; ++i)
+            for (i = 1; i < conf->n_options; ++i)
             {
                 strcat(options, ", ");
                 strcat(options, conf->guc_options[i]);


### PR DESCRIPTION
error: ‘for’ loop initial declarations are only allowed in C99 mode