### PR TITLE
DISTPG-427: replaced return with goto exit to not break other extensions

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -3507,11 +3507,11 @@ pgsm_emit_log_hook(ErrorData *edata)
 		goto exit;
 
 	if (IsParallelWorker())
-		return;
+		goto exit;
 
 	/* Check if PostgreSQL has finished its own bootstraping code. */
 	if (MyProc == NULL)
-		return;
+		goto exit;
 
 	if ((edata->elevel == ERROR || edata->elevel == WARNING || edata->elevel == INFO || edata->elevel == DEBUG1))
 	{


### PR DESCRIPTION
Signed-off-by: Kai Wagner <kai.wagner@percona.com>