### PR TITLE
PG-375: only run code coverage test on merge

### DIFF
--- a/.github/workflows/code-coverage-test.yml
+++ b/.github/workflows/code-coverage-test.yml
@@ -1,8 +1,13 @@
 name: code-coverage-test
-on: ["push", "pull_request"]
+on:
+  pull_request:
+    types:
+      - closed 
 
 jobs:
-  build:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    build:
     name: coverage-test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/postgresql-14-build.yml
+++ b/.github/workflows/postgresql-14-build.yml
@@ -1,5 +1,5 @@
 name: postgresql-14-build
-on: [push]
+on: ["push", "pull_request"]
 
 jobs:
   build:


### PR DESCRIPTION
Right now the code coverage test runs on every push and pull-request. The problem is, that this always fails duo to the missing token within the source branch repository. As we don't need to test the code-coverage on every commit, we can streamline this and focus on the actual merge. Modified postgresql-14-build to keep the build test for every PR.

Signed-off-by: Kai Wagner [kai.wagner@percona.com](mailto:kai.wagner@percona.com)