### PR TITLE
PG-300: Fix potential duplicate queryid issue.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -181,7 +181,7 @@ static void pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 static void AppendJumble(JumbleState *jstate,
 			 const unsigned char *item, Size size);
 static void JumbleQuery(JumbleState *jstate, Query *query);
-static void JumbleRangeTable(JumbleState *jstate, List *rtable);
+static void JumbleRangeTable(JumbleState *jstate, List *rtable, CmdType cmd_type);
 static void JumbleExpr(JumbleState *jstate, Node *node);
 static void RecordConstLocation(JumbleState *jstate, int location);
 /*
@@ -2233,9 +2233,19 @@ JumbleQuery(JumbleState *jstate, Query *query)
 	APP_JUMB(query->commandType);
 	/* resultRelation is usually predictable from commandType */
 	JumbleExpr(jstate, (Node *) query->cteList);
-	JumbleRangeTable(jstate, query->rtable);
-	JumbleExpr(jstate, (Node *) query->jointree);
-	JumbleExpr(jstate, (Node *) query->targetList);
+
+	JumbleRangeTable(jstate, query->rtable, query->commandType);
+
+    /*
+     * Skip jointree and targetlist in case of insert statment
+     * to avoid queryid duplication problem.
+     */
+	if (query->commandType != CMD_INSERT)
+	{
+		JumbleExpr(jstate, (Node *) query->jointree);
+		JumbleExpr(jstate, (Node *) query->targetList);
+	}
+
 	JumbleExpr(jstate, (Node *) query->onConflict);
 	JumbleExpr(jstate, (Node *) query->returningList);
 	JumbleExpr(jstate, (Node *) query->groupClause);
@@ -2254,13 +2264,16 @@ JumbleQuery(JumbleState *jstate, Query *query)
  * Jumble a range table
  */
 static void
-JumbleRangeTable(JumbleState *jstate, List *rtable)
+JumbleRangeTable(JumbleState *jstate, List *rtable, CmdType cmd_type)
 {
 	ListCell   *lc = NULL;
 
 	foreach(lc, rtable)
 	{
 		RangeTblEntry *rte = lfirst_node(RangeTblEntry, lc);
+
+		if (rte->rtekind != RTE_RELATION && cmd_type == CMD_INSERT)
+			continue;
 
 		APP_JUMB(rte->rtekind);
 		switch (rte->rtekind)


### PR DESCRIPTION
There is some potential problem where there is a chance
that we got a duplicate queryid. This patch will eliminate
that problem.