### PR TITLE
[PG-159] pg_stat_monitor: Bucket start time should be aligned with fi…

### DIFF
--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -310,7 +310,7 @@ typedef struct pgssSharedState
 	Size				extent;				/* current extent of query file */
 	int64				n_writers;			/* number of active writers to query file */
 	pg_atomic_uint64	current_wbucket;
-	pg_atomic_uint64	prev_bucket_usec;
+	pg_atomic_uint64	prev_bucket_sec;
 	uint64				bucket_entry[MAX_BUCKETS];
 	char				bucket_start_time[MAX_BUCKETS][60];   	/* start time of the bucket */
 	LWLock				*errors_lock;		/* protects errors hashtable search/modification */
@@ -336,7 +336,7 @@ do { \
 		x->cur_median_usage = ASSUMED_MEDIAN_INIT; \
 		x->n_writers = 0; \
 		pg_atomic_init_u64(&x->current_wbucket, 0); \
-		pg_atomic_init_u64(&x->prev_bucket_usec, 0); \
+		pg_atomic_init_u64(&x->prev_bucket_sec, 0); \
 		memset(&x->bucket_entry, 0, MAX_BUCKETS * sizeof(uint64)); \
 } while(0)
 


### PR DESCRIPTION
The buckets are now created with the start time a modulus of the bucket time size.
So if we have a 10 second bucket, the start times would reflect that:
- Bucket1: 00:00:00
- Bucket2: 00:00:10
- Bucket3: 00:00:20
...

Previously, the start time of the bucket was aligned with the first query that
arrives in that bucket. However, now the behaviour is changed. So, even if the
first query for bucket 2 arrives at 00:00:13, the start time would still be set
to 00:00:10.

This change now makes the bucketing separated out by fixed time windows so that
external applications can easily consume that data and chart it.

Also, as part of this change, locking of pgss is updated now and extended
to last the bucket related changes.