### PR TITLE
PG-453: Normalize query does not work with INSERT statements.        …

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -2227,17 +2227,8 @@ JumbleQuery(JumbleState *jstate, Query *query)
 	JumbleExpr(jstate, (Node *) query->cteList);
 
 	JumbleRangeTable(jstate, query->rtable, query->commandType);
-
-    /*
-     * Skip jointree and targetlist in case of insert statment
-     * to avoid queryid duplication problem.
-     */
-	if (query->commandType != CMD_INSERT)
-	{
-		JumbleExpr(jstate, (Node *) query->jointree);
-		JumbleExpr(jstate, (Node *) query->targetList);
-	}
-
+	JumbleExpr(jstate, (Node *) query->jointree);
+	JumbleExpr(jstate, (Node *) query->targetList);
 	JumbleExpr(jstate, (Node *) query->onConflict);
 	JumbleExpr(jstate, (Node *) query->returningList);
 	JumbleExpr(jstate, (Node *) query->groupClause);


### PR DESCRIPTION
…          

The commit fixes the issue similar to pg_stat_statements. Jumble query skips in    
case of INSERT statements to avoid the duplicate queryid, but in another      
commit we already solved that problem with another way.    