### PR TITLE
PG-449: Despite pgsm_extract_comments='no', comments are still visible.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1511,7 +1511,9 @@ pgss_store(uint64 queryid,
 
 	planid = plan_info ? plan_info->planid : 0;
 
-	extract_query_comments(query, comments, sizeof(comments));
+	/* Extract comments if enabled. */
+	if (PGSM_EXTRACT_COMMENTS)
+		extract_query_comments(query, comments, sizeof(comments));
 
 	prev_bucket_id = pg_atomic_read_u64(&pgss->current_wbucket);
 	bucketid = get_next_wbucket(pgss);


### PR DESCRIPTION
Check for GUC (pgsm_extract_comments) was missing.