### PR TITLE
PG-433: Codecov code coverage with PGSM GH repo

### DIFF
--- a/.github/workflows/code-coverage-test.yml
+++ b/.github/workflows/code-coverage-test.yml
@@ -1,13 +1,8 @@
-name: coverage_test
-on:
-  pull_request:
-    types:
-      - closed 
+name: code-coverage-test
+on: ["push", "pull_request"]
 
 jobs:
-  if_merged:
-    if: github.event.pull_request.merged == true
-    build:
+  build:
     name: coverage-test
     runs-on: ubuntu-latest
     steps:
@@ -96,12 +91,18 @@ jobs:
         run: |
           make installcheck
           /usr/lib/postgresql/14/bin/psql -d postgres -p 5432 -c "\list"
-          make coverage-html
-          lcov --capture --directory . --output-file coverage/lcov.info
-          pip install cpp-coveralls
-          export COVERALLS_REPO_TOKEN="${{ secrets.COVERALL_PG_STAT_MONITOR_TOKEN }}"
-          coveralls --verbose
+          gcov -abcfu pg_stat_monitor.c
+          gcov -abcfu guc.c
+          gcov -abcfu hash_query.c
+          sudo chmod -R ugo+rwx *.gcov*
         working-directory: src/pg_stat_monitor/
+
+      - name: Upload
+        uses: codecov/codecov-action@v2
+        with:
+          verbose: true
+          working-directory: ./src/pg_stat_monitor
+          files: ./pg_stat_monitor.c.gcov,./hash_query.c.gcov,./guc.c.gcov
 
       - name: Change dir permissions on fail
         if: ${{ failure() }}

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ dkms.conf
 
 ## IDE
 .idea
+
+## DS_Store
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 ![PostgreSQL-13](https://github.com/percona/pg_stat_monitor/workflows/postgresql-13-build/badge.svg) ![PostgreSQL-13-Package](https://github.com/percona/pg_stat_monitor/workflows/postgresql-13-package/badge.svg)
 ![PostgreSQL-14](https://github.com/percona/pg_stat_monitor/workflows/postgresql-14-build/badge.svg) ![PostgreSQL-14-Package](https://github.com/percona/pg_stat_monitor/workflows/postgresql-14-package/badge.svg)
 
-[![Coverage Status](https://coveralls.io/repos/github/percona/pg_stat_monitor/badge.svg?branch=main)](https://coveralls.io/github/percona/pg_stat_monitor?branch=main)
-
+[![Code coverage](https://codecov.io/gh/percona/pg_stat_monitor/branch/main/graph/badge.svg)](https://codecov.io/gh/percona/pg_stat_monitor)
 # pg_stat_monitor: Query Performance Monitoring Tool for PostgreSQL
 
 ## Table of Contents


### PR DESCRIPTION
1) Updated code coverage workflow with required changes so that we point to
Codecov onwards for coverage stats.
2) Updated README.md file so that badge for Code Coverage, points to CodeCov
coverage stats for PGSM.
3) Added .DS_STORE to .gitignore file.