### PR TITLE
PG-206: Add ADOPTERS.md file

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,20 @@
+# List of pg_stat_monitor Adopters
+
+This is the list of organizations and users that publicly shared details of how
+they are using pg_stat_monitor.
+
+Please send us a pull request if you want to be added or removed from this
+list.
+
+The list of organizations that have publicly shared the usage of
+pg_stat_monitor:
+
+| Organization | Description | Success Story |
+| :--- | :--- | :--- |
+| [Example](https://example.com/) | Example company running pg_stat_monitor for dev and production for core application | [English](./adopters/example/README.md) |
+
+The list of users that have publicly shared the usage of pg_stat_monitor. 
+
+| User | Description | Success Story |
+| :--- | :--- | :--- |
+| [Example User](https://github.com/username) | Personal tests of pg_stat_monitor | [English](./adopters/users/username/README.md)  | 


### PR DESCRIPTION
Somehow my initial PR (https://github.com/percona/pg_stat_monitor/pull/196) got lost after some recent git branch reorganization.

Added a basic `ADOPTERS.md` placeholder file for capturing user success stories.

Signed-off-by: Lenz Grimmer <lenz.grimmer@percona.com>