### PR TITLE
PG-418: Cleanup workflows in github.

### DIFF
--- a/.github/workflows/code-coverage-test.yml
+++ b/.github/workflows/code-coverage-test.yml
@@ -4,7 +4,7 @@ on: ["push", "pull_request"]
 jobs:
   build:
     name: coverage-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone postgres repository
         uses: actions/checkout@v2
@@ -15,17 +15,18 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y docbook-xsl docbook-xsl
-          sudo apt-get install -y libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev
-          sudo apt-get install -y pkg-config clang-9 llvm-9 llvm-9-dev libselinux1-dev python-dev python3-dev uuid-dev liblz4-dev lcov
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev bison flex \
+            libipc-run-perl -y docbook-xsl docbook-xsl libxml2 libxml2-utils \
+            libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev \
+            libsystemd-dev gettext tcl-dev libperl-dev pkg-config clang-11 \
+            llvm-11 llvm-11-dev libselinux1-dev python3-dev uuid-dev \
+            liblz4-dev lcov
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+           /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+           /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
           sudo /usr/bin/perl -MCPAN -e 'install String::Util'
@@ -37,35 +38,41 @@ jobs:
       - name: Build postgres
         run: |
           export PATH="/opt/pgsql/bin:$PATH"
-          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=${prefix}/include' \
-            '--enable-coverage' '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' \
-            '--sysconfdir=/etc' '--localstatedir=/var' '--disable-silent-rules' \
-            '--libdir=${prefix}/lib/x86_64-linux-gnu' \
-            '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--disable-maintainer-mode' \
-            '--disable-dependency-tracking' '--with-icu' '--with-tcl' '--with-perl' \
-            '--with-python' '--with-pam' '--with-openssl' '--with-libxml' '--with-libxslt' \
-            'PYTHON=/usr/bin/python3' '--mandir=/usr/share/postgresql/14/man' \
-            '--docdir=/usr/share/doc/postgresql-doc-14' \
-            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share/' \
-            '--datadir=/usr/share/postgresql/14' '--bindir=/usr/lib/postgresql/14/bin' \
-            '--libdir=/usr/lib/x86_64-linux-gnu/' '--libexecdir=/usr/lib/postgresql/' \
-            '--includedir=/usr/include/postgresql/' '--with-extra-version= (Ubuntu 2:14-x.focal)' \
-            '--enable-nls' '--enable-thread-safety' '--enable-tap-tests' '--enable-debug' \
-            '--enable-dtrace' '--disable-rpath' '--with-uuid=e2fs' '--with-gnu-ld' \
-            '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' \
+            '--includedir=${prefix}/include' '--enable-coverage' \
+            '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' \
+            '--sysconfdir=/etc' '--localstatedir=/var' '--with-icu' \
+            '--libdir=${prefix}/lib/x86_64-linux-gnu' '--with-tcl' \
+            '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--with-perl' \
+            '--with-python' '--with-pam' '--with-openssl' '--with-libxml' \
+            '--with-libxslt' 'PYTHON=/usr/bin/python3' '--enable-nls' \
+            '--mandir=/usr/share/postgresql/14/man' '--enable-thread-safety' \
+            '--docdir=/usr/share/doc/postgresql-doc-14' '--enable-dtrace' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share' \
+            '--datadir=/usr/share/postgresql/14' '--with-uuid=e2fs' \
+            '--bindir=/usr/lib/postgresql/14/bin' '--with-gnu-ld' \
+            '--libdir=/usr/lib/x86_64-linux-gnu' '--enable-tap-tests' \
+            '--libexecdir=/usr/lib/postgresql' '--enable-debug' \
+            '--includedir=/usr/include/postgresql' '--disable-rpath' \
+            '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' \
+            '--with-llvm''TAR=/bin/tar' 'XSLTPROC=xsltproc --nonet' \
             'LLVM_CONFIG=/usr/bin/llvm-config-11' 'CLANG=/usr/bin/clang-11' \
-            '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' 'PROVE=/usr/bin/prove' \
-            'TAR=/bin/tar' 'XSLTPROC=xsltproc --nonet' 'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
-            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' '--with-gssapi' '--with-ldap' \
-            'build_alias=x86_64-linux-gnu' 'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            '--with-systemd' 'MKDIR_P=/bin/mkdir -p' '--with-selinux' \
+            'PROVE=/usr/bin/prove' '--with-gssapi' '--with-ldap' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' \
+            'build_alias=x86_64-linux-gnu' \
+            'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
             'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
            make world
            sudo make install-world
 
       - name: Start postgresql cluster
         run: |
-           /usr/lib/postgresql/14/bin/initdb -D /opt/pgsql/data
-           /usr/lib/postgresql/14/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+          export PATH="/usr/lib/postgresql/14/bin:$PATH"
+          sudo cp /usr/lib/postgresql/14/bin/pg_config /usr/bin
+          initdb -D /opt/pgsql/data
+          pg_ctl -D /opt/pgsql/data -l logfile start
 
       - name: Clone pg_stat_monitor repository
         uses: actions/checkout@v2
@@ -74,18 +81,18 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
-          export PATH="/usr/lib/postgresql/14/bin:$PATH"
-          sudo cp /usr/lib/postgresql/14/bin/pg_config /usr/bin
           make USE_PGXS=1
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Load pg_stat_monitor library and Restart Server
         run: |
-          /usr/lib/postgresql/14/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
-          /usr/lib/postgresql/14/bin/pg_ctl -D /opt/pgsql/data -l logfile start
-        working-directory: src/pg_stat_monitor/
+          export PATH="/usr/lib/postgresql/14/bin:$PATH"
+          pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" \
+            >> /opt/pgsql/data/postgresql.conf
+          pg_ctl -D /opt/pgsql/data -l logfile start
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests & Run code coverage
         run: |
@@ -95,7 +102,7 @@ jobs:
           gcov -abcfu guc.c
           gcov -abcfu hash_query.c
           sudo chmod -R ugo+rwx *.gcov*
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Upload
         uses: codecov/codecov-action@v2
@@ -110,7 +117,7 @@ jobs:
           sudo chmod -R ugo+rwx t
           sudo chmod -R ugo+rwx tmp_check
           exit 2 # regenerate error so that we can upload files in next step
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Upload logs on fail
         if: ${{ failure() }}

--- a/.github/workflows/postgresql-11-build.yml
+++ b/.github/workflows/postgresql-11-build.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   build:
     name: pg-11-build-test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone postgres repository
         uses: actions/checkout@v2
@@ -15,17 +15,17 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y docbook-xsl docbook-xsl
-          sudo apt-get install -y libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev
-          sudo apt-get install -y pkg-config clang-9 llvm-9 llvm-9-dev libselinux1-dev python-dev python3-dev uuid-dev liblz4-dev
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev bison flex \
+            libipc-run-perl -y docbook-xsl docbook-xsl libxml2 libxml2-utils \
+            libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev \
+            libsystemd-dev gettext tcl-dev libperl-dev pkg-config clang-11 \
+            llvm-11 llvm-11-dev libselinux1-dev python3-dev uuid-dev liblz4-dev
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
 
       - name: Create pgsql dir
@@ -34,34 +34,41 @@ jobs:
       - name: Build postgres
         run: |
           export PATH="/opt/pgsql/bin:$PATH"
-          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=/usr/include' \
-            '--mandir=/usr/share/man' '--infodir=/usr/share/info' '--sysconfdir=/etc' \
-            '--localstatedir=/var' '--disable-silent-rules' '--libdir=/usr/lib/x86_64-linux-gnu' \
-            'runstatedir=/run' '--disable-maintainer-mode' '--disable-dependency-tracking' \
-            '--with-icu' '--with-tcl' '--with-perl' '--with-python' '--with-pam' '--with-openssl' \
-            '--with-libxml' '--with-libxslt' 'PYTHON=/usr/bin/python3' \
-            '--mandir=/usr/share/postgresql/11/man' '--docdir=/usr/share/doc/postgresql-doc-11' \
-            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share/' \
-            '--datadir=/usr/share/postgresql/11' '--bindir=/usr/lib/postgresql/11/bin' \
-            '--libdir=/usr/lib/x86_64-linux-gnu/' '--libexecdir=/usr/lib/postgresql/' \
-            '--includedir=/usr/include/postgresql/' '--with-extra-version= (Ubuntu 11.x.pgdg20.04+1)' \
-            '--enable-nls' '--enable-thread-safety' '--enable-tap-tests' '--enable-debug' \
-            '--enable-dtrace' '--disable-rpath' '--with-uuid=e2fs' '--with-gnu-ld' \
-            '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
-            'LLVM_CONFIG=/usr/bin/llvm-config-9' 'CLANG=/usr/bin/clang-9' '--with-systemd' \
-            '--with-selinux' 'MKDIR_P=/bin/mkdir -p' 'PROVE=/usr/bin/prove' 'TAR=/bin/tar' \
-            'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
-            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' '--with-gssapi' '--with-ldap' \
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' \
+            '--includedir=/usr/include' '--mandir=/usr/share/man' \
+            '--infodir=/usr/share/info' '--sysconfdir=/etc' '--enable-nls' \
+            '--localstatedir=/var' '--libdir=/usr/lib/x86_64-linux-gnu' \
+            'runstatedir=/run' '--with-icu' '--with-tcl' '--with-perl' \
+            '--with-python' '--with-pam' '--with-openssl' '--with-libxml' \
+            '--with-libxslt' 'PYTHON=/usr/bin/python3' 'MKDIR_P=/bin/mkdir -p' \
+            '--mandir=/usr/share/postgresql/11/man' '--enable-dtrace' \
+            '--docdir=/usr/share/doc/postgresql-doc-11' '--enable-debug' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share' \
+            '--datadir=/usr/share/postgresql/11' '--enable-thread-safety' \
+            '--bindir=/usr/lib/postgresql/11/bin' '--enable-tap-tests' \
+            '--libdir=/usr/lib/x86_64-linux-gnu' '--disable-rpath' \
+            '--libexecdir=/usr/lib/postgresql' '--with-uuid=e2fs' \
+            '--includedir=/usr/include/postgresql' '--with-gnu-ld' \
+            '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' \
+            '--with-llvm' 'LLVM_CONFIG=/usr/bin/llvm-config-11' \
+            'CLANG=/usr/bin/clang-11' '--with-systemd' '--with-selinux' \
+            'PROVE=/usr/bin/prove' 'TAR=/bin/tar' '--with-gssapi' '--with-ldap' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' \
             '--with-includes=/usr/include/mit-krb5' '--with-libs=/usr/lib/mit-krb5' \
-            '--with-libs=/usr/lib/x86_64-linux-gnu/mit-krb5' 'build_alias=x86_64-linux-gnu' \
-            'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' 'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
+            '--with-libs=/usr/lib/x86_64-linux-gnu/mit-krb5' \
+            'build_alias=x86_64-linux-gnu' \
+            'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
+            'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
            make world
            sudo make install-world
 
       - name: Start postgresql cluster
         run: |
-           /usr/lib/postgresql/11/bin/initdb -D /opt/pgsql/data
-           /usr/lib/postgresql/11/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+          export PATH="/usr/lib/postgresql/11/bin:$PATH"
+          sudo cp /usr/lib/postgresql/11/bin/pg_config /usr/bin
+          initdb -D /opt/pgsql/data
+          pg_ctl -D /opt/pgsql/data -l logfile start
 
       - name: Clone pg_stat_monitor repository
         uses: actions/checkout@v2
@@ -70,23 +77,23 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
-          export PATH="/usr/lib/postgresql/11/bin:$PATH"
-          sudo cp /usr/lib/postgresql/11/bin/pg_config /usr/bin
           make USE_PGXS=1
           sudo make USE_PGXS=1 install
         working-directory: src/pg_stat_monitor/
 
       - name: Load pg_stat_monitor library and Restart Server
         run: |
-          /usr/lib/postgresql/11/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
-          /usr/lib/postgresql/11/bin/pg_ctl -D /opt/pgsql/data -l logfile start
-        working-directory: src/pg_stat_monitor/
+          export PATH="/usr/lib/postgresql/11/bin:$PATH"
+          pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> \
+            /opt/pgsql/data/postgresql.conf
+          pg_ctl -D /opt/pgsql/data -l logfile start
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
           make installcheck
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Report on pg_stat_monitor test fail
         uses: actions/upload-artifact@v2
@@ -106,7 +113,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: Regressions output files of failed testsuite, and postgresql log
+          name: Regressions output files of failed testsuite, and pg log
           path: |
             **/regression.diffs
             **/regression.out

--- a/.github/workflows/postgresql-11-pgdg-package.yml
+++ b/.github/workflows/postgresql-11-pgdg-package.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   build:
     name: pg-11-pgdg-package-test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone pg_stat_monitor repository
         uses: actions/checkout@v2
@@ -14,40 +14,42 @@ jobs:
       - name: Delete old postgresql files
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
 
       - name: Install PG Distribution Postgresql 11
         run: |
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt \
+            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo wget --quiet -O - \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc |
+            sudo apt-key add -
           sudo apt-get -y update
           sudo apt-get -y install postgresql-11 postgresql-server-dev-11
 
-      - name: Change sources owner to postgres
-        run: sudo chown -R postgres:postgres src
+      - name: Change src owner to postgres
+        run: |
+          sudo chown -R postgres:postgres src
 
       - name: Build pg_stat_monitor
         run: |
-          sudo make USE_PGXS=1
+          sudo -u postgres bash -c 'make USE_PGXS=1'
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
           sudo service postgresql stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/11/main/postgresql.conf
+          echo "shared_preload_libraries = 'pg_stat_monitor'" |
+            sudo tee -a /etc/postgresql/11/main/postgresql.conf
           sudo service postgresql start
           sudo psql -V
           sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Report on test fail
         uses: actions/upload-artifact@v2

--- a/.github/workflows/postgresql-11-ppg-package.yml
+++ b/.github/workflows/postgresql-11-ppg-package.yml
@@ -11,53 +11,54 @@ jobs:
         with:
           path: 'src/pg_stat_monitor'
 
-
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl wget -y
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev python3-dev bison flex \
+            libipc-run-perl wget
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
 
       - name: Install percona-release script
         run: |
           sudo apt-get -y update
           sudo apt-get -y upgrade
-          sudo apt-get -y update
           sudo apt-get install -y wget gnupg2 curl lsb-release
-          sudo wget https://repo.percona.com/apt/percona-release_latest.generic_all.deb
+          sudo wget \
+            https://repo.percona.com/apt/percona-release_latest.generic_all.deb
           sudo dpkg -i percona-release_latest.generic_all.deb
 
       - name: Install Percona Distribution Postgresql 11
         run: |
           sudo percona-release setup ppg-11
           sudo apt-get update -y
-          sudo apt-get install -y percona-postgresql-11 percona-postgresql-contrib percona-postgresql-server-dev-all
+          sudo apt-get install -y percona-postgresql-11 \
+            percona-postgresql-contrib percona-postgresql-server-dev-all
 
-      - name: Change sources owner to postgres
-        run: sudo chown -R postgres:postgres src
+      - name: Change src owner to postgres
+        run: |
+          sudo chown -R postgres:postgres src
 
       - name: Build pg_stat_monitor
         run: |
-          sudo make USE_PGXS=1
+          sudo -u postgres bash -c 'make USE_PGXS=1'
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
           sudo service postgresql stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/11/main/postgresql.conf
+          echo "shared_preload_libraries = 'pg_stat_monitor'" | 
+            sudo tee -a /etc/postgresql/11/main/postgresql.conf
           sudo service postgresql start
           sudo psql -V
           sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Report on test fail
         uses: actions/upload-artifact@v2

--- a/.github/workflows/postgresql-12-build.yml
+++ b/.github/workflows/postgresql-12-build.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   build:
     name: pg-12-build-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone postgres repository
         uses: actions/checkout@v2
@@ -15,48 +15,60 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y docbook-xsl docbook-xsl
-          sudo apt-get install -y libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev
-          sudo apt-get install -y pkg-config clang-9 llvm-9 llvm-9-dev libselinux1-dev python-dev python3-dev uuid-dev liblz4-dev
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+           postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+           zlib1g-dev libssl-dev libpam0g-dev bison flex \
+           libipc-run-perl docbook-xsl docbook-xsl libxml2 libxml2-utils \
+           libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev \
+           libsystemd-dev gettext tcl-dev libperl-dev pkg-config clang-11 \
+           llvm-11 llvm-11-dev libselinux1-dev python3-dev uuid-dev liblz4-dev
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+           /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+           /etc/postgresql
           sudo rm -f /usr/bin/pg_config
+
       - name: Create pgsql dir
         run: mkdir -p /opt/pgsql
 
       - name: Build postgres
         run: |
           export PATH="/opt/pgsql/bin:$PATH"
-          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=/usr/include' '--mandir=/usr/share/man' \
-            '--infodir=/usr/share/info' '--sysconfdir=/etc' '--localstatedir=/var' '--disable-silent-rules' \
-            '--libdir=/usr/lib/x86_64-linux-gnu' 'runstatedir=/run' '--disable-maintainer-mode' \
-            '--disable-dependency-tracking' '--with-icu' '--with-tcl' '--with-perl' '--with-python' \
-            '--with-pam' '--with-openssl' '--with-libxml' '--with-libxslt' 'PYTHON=/usr/bin/python3' \
-            '--mandir=/usr/share/postgresql/12/man' '--docdir=/usr/share/doc/postgresql-doc-12' \
-            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share/' '--datadir=/usr/share/postgresql/12' \
-            '--bindir=/usr/lib/postgresql/12/bin' '--libdir=/usr/lib/x86_64-linux-gnu/' '--libexecdir=/usr/lib/postgresql/' \
-            '--includedir=/usr/include/postgresql/' '--with-extra-version= (Ubuntu 12.x.pgdg20.04+1)' '--enable-nls' \
-            '--enable-thread-safety' '--enable-tap-tests' '--enable-debug' '--enable-dtrace' '--disable-rpath' \
-            '--with-uuid=e2fs' '--with-gnu-ld' '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
-            'LLVM_CONFIG=/usr/bin/llvm-config-9' 'CLANG=/usr/bin/clang-9' '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' \
-            'PROVE=/usr/bin/prove' 'TAR=/bin/tar' 'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
-            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' '--with-gssapi' '--with-ldap' \
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' \
+            '--includedir=/usr/include' '--mandir=/usr/share/man' \
+            '--infodir=/usr/share/info' '--sysconfdir=/etc' '--with-gnu-ld' \
+            '--localstatedir=/var' '--libdir=/usr/lib/x86_64-linux-gnu' \
+            'runstatedir=/run' '--with-icu' '--with-tcl' '--with-perl' \
+            '--with-python' '--with-pam' '--with-openssl' '--with-libxml' \
+            '--with-libxslt' 'PYTHON=/usr/bin/python3' '--enable-tap-tests' \
+            '--mandir=/usr/share/postgresql/12/man' '--enable-thread-safety' \
+            '--docdir=/usr/share/doc/postgresql-doc-12' '--enable-debug' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share' \
+            '--datadir=/usr/share/postgresql/12' '--enable-dtrace' \
+            '--bindir=/usr/lib/postgresql/12/bin' '--disable-rpath' \
+            '--libdir=/usr/lib/x86_64-linux-gnu' '--with-pgport=5432' \
+            '--libexecdir=/usr/lib/postgresql' '--with-uuid=e2fs' \
+            '--includedir=/usr/include/postgresql' 'TAR=/bin/tar' \
+            '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
+            'LLVM_CONFIG=/usr/bin/llvm-config-11' 'CLANG=/usr/bin/clang-11' \
+            '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' \
+            'PROVE=/usr/bin/prove' '--with-gssapi' '--with-ldap' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' \
             '--with-includes=/usr/include/mit-krb5' '--with-libs=/usr/lib/mit-krb5' \
-            '--with-libs=/usr/lib/x86_64-linux-gnu/mit-krb5' 'build_alias=x86_64-linux-gnu' \
-            'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' 'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
+            '--with-libs=/usr/lib/x86_64-linux-gnu/mit-krb5' \
+            'build_alias=x86_64-linux-gnu' \
+            'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' '--enable-nls' \
+            'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
+            'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
            make world
            sudo make install-world
 
       - name: Start postgresql cluster
         run: |
-           /usr/lib/postgresql/12/bin/initdb -D /opt/pgsql/data
-           /usr/lib/postgresql/12/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+          export PATH="/usr/lib/postgresql/12/bin:$PATH"
+          sudo cp /usr/lib/postgresql/12/bin/pg_config /usr/bin
+          initdb -D /opt/pgsql/data
+          pg_ctl -D /opt/pgsql/data -l logfile start
 
       - name: Clone pg_stat_monitor repository
         uses: actions/checkout@v2
@@ -65,23 +77,23 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
-          export PATH="/usr/lib/postgresql/12/bin:$PATH"
-          sudo cp /usr/lib/postgresql/12/bin/pg_config /usr/bin
           make USE_PGXS=1
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Load pg_stat_monitor library and Restart Server
         run: |
-          /usr/lib/postgresql/12/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
-          /usr/lib/postgresql/12/bin/pg_ctl -D /opt/pgsql/data -l logfile start
-        working-directory: src/pg_stat_monitor/
+          export PATH="/usr/lib/postgresql/12/bin:$PATH"
+          pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> \
+            /opt/pgsql/data/postgresql.conf
+          pg_ctl -D /opt/pgsql/data -l logfile start
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
           make installcheck
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Report on pg_stat_monitor test fail
         uses: actions/upload-artifact@v2
@@ -101,7 +113,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: Regressions output files of failed testsuite, and postgresql log
+          name: Regressions output files of failed testsuite, and pg log
           path: |
             **/regression.diffs
             **/regression.out

--- a/.github/workflows/postgresql-12-pgdg-package.yml
+++ b/.github/workflows/postgresql-12-pgdg-package.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   build:
     name: pg-12-pgdg-package-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone pg_stat_monitor repository
         uses: actions/checkout@v2
@@ -14,41 +14,42 @@ jobs:
       - name: Delete old postgresql files
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
 
       - name: Install PG Distribution Postgresql 12
         run: |
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt \
+            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo wget --quiet -O - \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc |
+            sudo apt-key add -
           sudo apt-get -y update
           sudo apt-get -y install postgresql-12 postgresql-server-dev-12
 
-      - name: Change sources owner to postgres
+      - name: Change src owner to postgres
         run: |
           sudo chown -R postgres:postgres src
 
       - name: Build pg_stat_monitor
         run: |
-          sudo make USE_PGXS=1
+          sudo -u postgres bash -c 'make USE_PGXS=1'
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
           sudo service postgresql stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/12/main/postgresql.conf
+          echo "shared_preload_libraries = 'pg_stat_monitor'" |
+            sudo tee -a /etc/postgresql/12/main/postgresql.conf
           sudo service postgresql start
           sudo psql -V
           sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Report on test fail
         uses: actions/upload-artifact@v2

--- a/.github/workflows/postgresql-12-ppg-package.yml
+++ b/.github/workflows/postgresql-12-ppg-package.yml
@@ -14,31 +14,31 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl wget -y
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev python3-dev bison flex \
+            libipc-run-perl wget
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
 
       - name: Install percona-release script
         run: |
           sudo apt-get -y update
           sudo apt-get -y upgrade
-          sudo apt-get -y update
           sudo apt-get install -y wget gnupg2 curl lsb-release
-          sudo wget https://repo.percona.com/apt/percona-release_latest.generic_all.deb
+          sudo wget \
+            https://repo.percona.com/apt/percona-release_latest.generic_all.deb
           sudo dpkg -i percona-release_latest.generic_all.deb
 
       - name: Install Percona Distribution Postgresql 12
         run: |
           sudo percona-release setup ppg-12
           sudo apt-get update -y
-          sudo apt-get install -y percona-postgresql-12 percona-postgresql-contrib percona-postgresql-server-dev-all
+          sudo apt-get install -y percona-postgresql-12 \
+            percona-postgresql-contrib percona-postgresql-server-dev-all
 
       - name: Change src owner to postgres
         run: |
@@ -46,18 +46,19 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
-          sudo make USE_PGXS=1
+          sudo -u postgres bash -c 'make USE_PGXS=1'
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
           sudo service postgresql stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/12/main/postgresql.conf
+          echo "shared_preload_libraries = 'pg_stat_monitor'" | 
+            sudo tee -a /etc/postgresql/12/main/postgresql.conf
           sudo service postgresql start
           sudo psql -V
           sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Report on test fail
         uses: actions/upload-artifact@v2

--- a/.github/workflows/postgresql-13-build.yml
+++ b/.github/workflows/postgresql-13-build.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   build:
     name: pg-13-build-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone postgres repository
         uses: actions/checkout@v2
@@ -15,17 +15,17 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y docbook-xsl docbook-xsl
-          sudo apt-get install -y libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev
-          sudo apt-get install -y pkg-config clang-9 llvm-9 llvm-9-dev libselinux1-dev python-dev python3-dev uuid-dev liblz4-dev
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev bison flex \
+            libipc-run-perl -y docbook-xsl docbook-xsl libxml2 libxml2-utils \
+            libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev \
+            libsystemd-dev gettext tcl-dev libperl-dev pkg-config clang-11 \
+            llvm-11 llvm-11-dev libselinux1-dev python3-dev uuid-dev liblz4-dev
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+           /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+           /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
           sudo /usr/bin/perl -MCPAN -e 'install String::Util'
@@ -37,35 +37,41 @@ jobs:
       - name: Build postgres
         run: |
           export PATH="/opt/pgsql/bin:$PATH"
-          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=${prefix}/include' \
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' \
+            '--includedir=${prefix}/include' \
             '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' \
-            '--sysconfdir=/etc' '--localstatedir=/var' '--disable-silent-rules' \
-            '--libdir=${prefix}/lib/x86_64-linux-gnu' \
-            '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--disable-maintainer-mode' \
-            '--disable-dependency-tracking' '--with-icu' '--with-tcl' '--with-perl' \
-            '--with-python' '--with-pam' '--with-openssl' '--with-libxml' '--with-libxslt' \
+            '--sysconfdir=/etc' '--localstatedir=/var' '--with-icu' \
+            '--libdir=${prefix}/lib/x86_64-linux-gnu' '--with-perl' \
+            '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--enable-debug' \
+            '--with-tcl' '--with-pam' '--with-python' '--with-openssl' \
+            '--with-libxml' '--with-libxslt' '--enable-tap-tests' \
             'PYTHON=/usr/bin/python3' '--mandir=/usr/share/postgresql/13/man' \
             '--docdir=/usr/share/doc/postgresql-doc-13' 'AWK=mawk' \
-            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share/' \
-            '--datadir=/usr/share/postgresql/13' '--bindir=/usr/lib/postgresql/13/bin' \
-            '--libdir=/usr/lib/x86_64-linux-gnu/' '--libexecdir=/usr/lib/postgresql/' \
-            '--includedir=/usr/include/postgresql/' '--with-extra-version= (Ubuntu 2:13-x.focal)' \
-            '--enable-nls' '--enable-thread-safety' '--enable-tap-tests' '--enable-debug' \
-            '--enable-dtrace' '--disable-rpath' '--with-uuid=e2fs' '--with-gnu-ld' \
-            '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
-            'LLVM_CONFIG=/usr/bin/llvm-config-9' 'CLANG=/usr/bin/clang-9' \
-            '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' 'PROVE=/usr/bin/prove' \
-            'TAR=/bin/tar' 'XSLTPROC=xsltproc --nonet' 'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
-            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' '--with-gssapi' '--with-ldap' \
-            'build_alias=x86_64-linux-gnu' 'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share' \
+            '--datadir=/usr/share/postgresql/13' '--enable-nls' \
+            '--bindir=/usr/lib/postgresql/13/bin' '--enable-dtrace' \
+            '--libdir=/usr/lib/x86_64-linux-gnu' '--disable-rpath' \
+            '--libexecdir=/usr/lib/postgresql' '--enable-thread-safety' \
+            '--includedir=/usr/include/postgresql' 'TAR=/bin/tar' \
+            '--with-uuid=e2fs' '--with-gnu-ld' 'XSLTPROC=xsltproc --nonet' \
+            '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' \
+            '--with-llvm' 'LLVM_CONFIG=/usr/bin/llvm-config-11' \
+            'CLANG=/usr/bin/clang-11' '--with-systemd' '--with-selinux' \
+            'MKDIR_P=/bin/mkdir -p' 'PROVE=/usr/bin/prove' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' \
+            '--with-gssapi' '--with-ldap' 'build_alias=x86_64-linux-gnu' \
+            'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
             'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
            make world
            sudo make install-world
 
       - name: Start postgresql cluster
         run: |
-           /usr/lib/postgresql/13/bin/initdb -D /opt/pgsql/data
-           /usr/lib/postgresql/13/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+          export PATH="/usr/lib/postgresql/13/bin:$PATH"
+          sudo cp /usr/lib/postgresql/13/bin/pg_config /usr/bin
+          initdb -D /opt/pgsql/data
+          pg_ctl -D /opt/pgsql/data -l logfile start
 
       - name: Clone pg_stat_monitor repository
         uses: actions/checkout@v2
@@ -74,24 +80,23 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
-          export PATH="/usr/lib/postgresql/13/bin:$PATH"
-          sudo cp /usr/lib/postgresql/13/bin/pg_config /usr/bin
-          pg_config
           make USE_PGXS=1
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Load pg_stat_monitor library and Restart Server
         run: |
-          /usr/lib/postgresql/13/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
-          /usr/lib/postgresql/13/bin/pg_ctl -D /opt/pgsql/data -l logfile start
-        working-directory: src/pg_stat_monitor/
+          export PATH="/usr/lib/postgresql/13/bin:$PATH"
+          pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> \
+            /opt/pgsql/data/postgresql.conf
+          pg_ctl -D /opt/pgsql/data -l logfile start
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
           make installcheck
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Change dir permissions on fail
         if: ${{ failure() }}
@@ -99,7 +104,7 @@ jobs:
           sudo chmod -R ugo+rwx t
           sudo chmod -R ugo+rwx tmp_check
           exit 2 # regenerate error so that we can upload files in next step
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Upload logs on fail
         if: ${{ failure() }}
@@ -129,7 +134,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: Regressions output files of failed testsuite, and postgresql log
+          name: Regressions output files of failed testsuite, and pg log
           path: |
             **/regression.diffs
             **/regression.out

--- a/.github/workflows/postgresql-13-pgdg-package.yml
+++ b/.github/workflows/postgresql-13-pgdg-package.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   build:
     name: pg-13-pgdg-package-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone pg_stat_monitor repository
         uses: actions/checkout@v2
@@ -14,45 +14,48 @@ jobs:
       - name: Delete old postgresql files
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev python3-dev bison flex \
+            libipc-run-perl wget -y
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl wget -y
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
           sudo /usr/bin/perl -MCPAN -e 'install String::Util'
           sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
 
       - name: Install PG Distribution Postgresql 13
         run: |
-          sudo wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt \
+            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo wget --quiet -O - \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc |
+            sudo apt-key add -
           sudo apt update
           sudo apt -y install postgresql-13 postgresql-server-dev-13
 
-      - name: Change sources owner to postgres
+      - name: Change src owner to postgres
         run: |
           sudo chown -R postgres:postgres src
 
       - name: Build pg_stat_monitor
         run: |
-          sudo make USE_PGXS=1
+          sudo -u postgres bash -c 'make USE_PGXS=1'
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
           sudo service postgresql stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/13/main/postgresql.conf
+          echo "shared_preload_libraries = 'pg_stat_monitor'" |
+            sudo tee -a /etc/postgresql/13/main/postgresql.conf
           sudo service postgresql start
           sudo psql -V
           sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Change dir permissions on fail
         if: ${{ failure() }}
@@ -60,7 +63,7 @@ jobs:
           sudo chmod -R ugo+rwx t
           sudo chmod -R ugo+rwx tmp_check
           exit 2 # regenerate error so that we can upload files in next step
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Upload logs on fail
         if: ${{ failure() }}

--- a/.github/workflows/postgresql-13-ppg-package.yml
+++ b/.github/workflows/postgresql-13-ppg-package.yml
@@ -14,16 +14,15 @@ jobs:
       - name: Delete old postgresql files
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev python3-dev bison flex \
+            libipc-run-perl wget
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl wget -y
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
           sudo /usr/bin/perl -MCPAN -e 'install String::Util'
           sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
@@ -32,16 +31,17 @@ jobs:
         run: |
           sudo apt-get -y update
           sudo apt-get -y upgrade
-          sudo apt-get -y update
           sudo apt-get install -y wget gnupg2 curl lsb-release
-          sudo wget https://repo.percona.com/apt/percona-release_latest.generic_all.deb
+          sudo wget \
+            https://repo.percona.com/apt/percona-release_latest.generic_all.deb
           sudo dpkg -i percona-release_latest.generic_all.deb
 
       - name: Install Percona Distribution Postgresql 13
         run: |
           sudo percona-release setup ppg-13
           sudo apt-get update -y
-          sudo apt-get install -y percona-postgresql-13 percona-postgresql-contrib percona-postgresql-server-dev-all
+          sudo apt-get install -y percona-postgresql-13 \
+            percona-postgresql-contrib percona-postgresql-server-dev-all
 
       - name: Change src owner to postgres
         run: |
@@ -49,18 +49,19 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
-          sudo make USE_PGXS=1
+          sudo -u postgres bash -c 'make USE_PGXS=1'
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
           sudo service postgresql stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/13/main/postgresql.conf
+          echo "shared_preload_libraries = 'pg_stat_monitor'" | 
+            sudo tee -a /etc/postgresql/13/main/postgresql.conf
           sudo service postgresql start
           sudo psql -V
           sudo -u postgres bash -c 'make installcheck USE_PGXS=1' 
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Change dir permissions on fail
         if: ${{ failure() }}
@@ -68,7 +69,7 @@ jobs:
           sudo chmod -R ugo+rwx t
           sudo chmod -R ugo+rwx tmp_check
           exit 2 # regenerate error so that we can upload files in next step
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Upload logs on fail
         if: ${{ failure() }}

--- a/.github/workflows/postgresql-14-build.yml
+++ b/.github/workflows/postgresql-14-build.yml
@@ -4,7 +4,7 @@ on: ["push", "pull_request"]
 jobs:
   build:
     name: pg-14-build-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone postgres repository
         uses: actions/checkout@v2
@@ -15,17 +15,18 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl -y docbook-xsl docbook-xsl
-          sudo apt-get install -y libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev
-          sudo apt-get install -y pkg-config clang-9 llvm-9 llvm-9-dev libselinux1-dev python-dev python3-dev uuid-dev liblz4-dev
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev bison flex \
+            libipc-run-perl -y docbook-xsl docbook-xsl libxml2 libxml2-utils \
+            libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev \
+            libsystemd-dev gettext tcl-dev libperl-dev pkg-config clang-11 \
+            llvm-11 llvm-11-dev libselinux1-dev python3-dev \
+            uuid-dev liblz4-dev
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+           /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+           /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
           sudo /usr/bin/perl -MCPAN -e 'install String::Util'
@@ -37,35 +38,40 @@ jobs:
       - name: Build postgres
         run: |
           export PATH="/opt/pgsql/bin:$PATH"
-          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=${prefix}/include' \
-            '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' \
-            '--sysconfdir=/etc' '--localstatedir=/var' '--disable-silent-rules' \
-            '--libdir=${prefix}/lib/x86_64-linux-gnu' \
-            '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--disable-maintainer-mode' \
-            '--disable-dependency-tracking' '--with-icu' '--with-tcl' '--with-perl' \
-            '--with-python' '--with-pam' '--with-openssl' '--with-libxml' '--with-libxslt' \
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' \
+            '--includedir=${prefix}/include' '--mandir=${prefix}/share/man' \
+            '--infodir=${prefix}/share/info' '--sysconfdir=/etc' \
+            '--localstatedir=/var' '--libdir=${prefix}/lib/x86_64-linux-gnu' \
+            '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--with-icu' \
+            '--with-tcl' '--with-perl' '--with-python' '--with-pam' \
+            '--with-openssl' '--with-libxml' '--with-libxslt' '--with-ldap' \
             'PYTHON=/usr/bin/python3' '--mandir=/usr/share/postgresql/14/man' \
-            '--docdir=/usr/share/doc/postgresql-doc-14' \
-            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share/' \
-            '--datadir=/usr/share/postgresql/14' '--bindir=/usr/lib/postgresql/14/bin' \
-            '--libdir=/usr/lib/x86_64-linux-gnu/' '--libexecdir=/usr/lib/postgresql/' \
-            '--includedir=/usr/include/postgresql/' '--with-extra-version= (Ubuntu 2:14-x.focal)' \
-            '--enable-nls' '--enable-thread-safety' '--enable-tap-tests' '--enable-debug' \
-            '--enable-dtrace' '--disable-rpath' '--with-uuid=e2fs' '--with-gnu-ld' \
-            '--with-pgport=5432' '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
+            '--docdir=/usr/share/doc/postgresql-doc-14' '--with-pgport=5432' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share' \
+            '--datadir=/usr/share/postgresql/14' '--with-uuid=e2fs' \
+            '--bindir=/usr/lib/postgresql/14/bin' '--enable-tap-tests' \
+            '--libdir=/usr/lib/x86_64-linux-gnu' '--enable-debug' \
+            '--libexecdir=/usr/lib/postgresql' '--with-gnu-ld' \
+            '--includedir=/usr/include/postgresql' '--enable-dtrace' \
+            '--enable-nls' '--enable-thread-safety' '--disable-rpath' \
+            '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
             'LLVM_CONFIG=/usr/bin/llvm-config-11' 'CLANG=/usr/bin/clang-11' \
-            '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' 'PROVE=/usr/bin/prove' \
-            'TAR=/bin/tar' 'XSLTPROC=xsltproc --nonet' 'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
-            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' '--with-gssapi' '--with-ldap' \
-            'build_alias=x86_64-linux-gnu' 'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' \
+            'PROVE=/usr/bin/prove' 'TAR=/bin/tar' 'XSLTPROC=xsltproc --nonet' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' \
+            'build_alias=x86_64-linux-gnu' '--with-gssapi' \
+            'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
             'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
            make world
            sudo make install-world
 
       - name: Start postgresql cluster
         run: |
-           /usr/lib/postgresql/14/bin/initdb -D /opt/pgsql/data
-           /usr/lib/postgresql/14/bin/pg_ctl -D /opt/pgsql/data -l logfile start
+          export PATH="/usr/lib/postgresql/14/bin:$PATH"
+          sudo cp /usr/lib/postgresql/14/bin/pg_config /usr/bin
+          initdb -D /opt/pgsql/data
+          pg_ctl -D /opt/pgsql/data -l logfile start
 
       - name: Clone pg_stat_monitor repository
         uses: actions/checkout@v2
@@ -74,18 +80,18 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
-          export PATH="/usr/lib/postgresql/14/bin:$PATH"
-          sudo cp /usr/lib/postgresql/14/bin/pg_config /usr/bin
           make USE_PGXS=1
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Load pg_stat_monitor library and Restart Server
         run: |
-          /usr/lib/postgresql/14/bin/pg_ctl -D /opt/pgsql/data -l logfile stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" >> /opt/pgsql/data/postgresql.conf
-          /usr/lib/postgresql/14/bin/pg_ctl -D /opt/pgsql/data -l logfile start
-        working-directory: src/pg_stat_monitor/
+          export PATH="/usr/lib/postgresql/14/bin:$PATH"
+          pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> \
+            /opt/pgsql/data/postgresql.conf
+          pg_ctl -D /opt/pgsql/data -l logfile start
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
@@ -98,7 +104,7 @@ jobs:
           sudo chmod -R ugo+rwx t
           sudo chmod -R ugo+rwx tmp_check
           exit 2 # regenerate error so that we can upload files in next step
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Upload logs on fail
         if: ${{ failure() }}

--- a/.github/workflows/postgresql-14-pgdg-package.yml
+++ b/.github/workflows/postgresql-14-pgdg-package.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   build:
     name: pg-14-pgdg-package-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone pg_stat_monitor repository
         uses: actions/checkout@v2
@@ -14,45 +14,47 @@ jobs:
       - name: Delete old postgresql files
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev wget \
+            zlib1g-dev libssl-dev libpam0g-dev bison flex libipc-run-perl
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl wget -y
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
           sudo /usr/bin/perl -MCPAN -e 'install String::Util'
           sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
 
       - name: Install PG Distribution Postgresql 14
         run: |
-          sudo wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt \
+            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo wget --quiet -O - \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc |
+            sudo apt-key add -
           sudo apt update
           sudo apt -y install postgresql-14 postgresql-server-dev-14
 
-      - name: Change sources owner to postgres
+      - name: Change src owner to postgres
         run: |
           sudo chown -R postgres:postgres src
 
       - name: Build pg_stat_monitor
         run: |
-          sudo make USE_PGXS=1
+          sudo -u postgres bash -c 'make USE_PGXS=1'
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
           sudo service postgresql stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/14/main/postgresql.conf
+          echo "shared_preload_libraries = 'pg_stat_monitor'" | 
+            sudo tee -a /etc/postgresql/14/main/postgresql.conf
           sudo service postgresql start
           sudo psql -V
           sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Change dir permissions on fail
         if: ${{ failure() }}
@@ -60,7 +62,7 @@ jobs:
           sudo chmod -R ugo+rwx t
           sudo chmod -R ugo+rwx tmp_check
           exit 2 # regenerate error so that we can upload files in next step
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Upload logs on fail
         if: ${{ failure() }}

--- a/.github/workflows/postgresql-14-ppg-package.yml
+++ b/.github/workflows/postgresql-14-ppg-package.yml
@@ -14,16 +14,15 @@ jobs:
       - name: Delete old postgresql files
         run: |
           sudo apt-get update
-          sudo apt purge postgresql-client-common postgresql-common postgresql postgresql*
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /var/log/postgresql/
-          sudo rm -rf /etc/postgresql/
-          sudo rm -rf /usr/lib/postgresql
-          sudo rm -rf /usr/include/postgresql
-          sudo rm -rf /usr/share/postgresql
-          sudo rm -rf /etc/postgresql
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev python3-dev bison flex \
+            libipc-run-perl wget 
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo apt-get install libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev python-dev bison flex libipc-run-perl wget -y
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
           sudo /usr/bin/perl -MCPAN -e 'install String::Util'
           sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
@@ -32,16 +31,17 @@ jobs:
         run: |
           sudo apt-get -y update
           sudo apt-get -y upgrade
-          sudo apt-get -y update
           sudo apt-get install -y wget gnupg2 curl lsb-release
-          sudo wget https://repo.percona.com/apt/percona-release_latest.generic_all.deb
+          sudo wget \
+            https://repo.percona.com/apt/percona-release_latest.generic_all.deb
           sudo dpkg -i percona-release_latest.generic_all.deb
 
       - name: Install Percona Distribution Postgresql 14
         run: |
           sudo percona-release setup ppg-14
           sudo apt-get update -y
-          sudo apt-get install -y percona-postgresql-14 percona-postgresql-contrib percona-postgresql-server-dev-all
+          sudo apt-get install -y percona-postgresql-14 \
+            percona-postgresql-contrib percona-postgresql-server-dev-all
 
       - name: Change src owner to postgres
         run: |
@@ -49,18 +49,19 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: |
-          sudo make USE_PGXS=1
+          sudo -u postgres bash -c 'make USE_PGXS=1'
           sudo make USE_PGXS=1 install
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Start pg_stat_monitor_tests
         run: |
           sudo service postgresql stop
-          echo "shared_preload_libraries = 'pg_stat_monitor'" | sudo tee -a /etc/postgresql/14/main/postgresql.conf
+          echo "shared_preload_libraries = 'pg_stat_monitor'" | 
+            sudo tee -a /etc/postgresql/14/main/postgresql.conf
           sudo service postgresql start
           sudo psql -V
           sudo -u postgres bash -c 'make installcheck USE_PGXS=1' 
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Change dir permissions on fail
         if: ${{ failure() }}
@@ -68,7 +69,7 @@ jobs:
           sudo chmod -R ugo+rwx t
           sudo chmod -R ugo+rwx tmp_check
           exit 2 # regenerate error so that we can upload files in next step
-        working-directory: src/pg_stat_monitor/
+        working-directory: src/pg_stat_monitor
 
       - name: Upload logs on fail
         if: ${{ failure() }}

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ dkms.conf
 
 ## DS_Store
 *.DS_Store
+
+## .vscode
+.vscode/
+.vscode/*


### PR DESCRIPTION
1- Removed unsupported options from configure.
2- Reformatted files to break lines at 80 charachters.
3- Moved multiple 'apt install' and rm commands into a single one.
4- All workflows use and install llvm + clang version 11.
5- Updated workflows to ubuntu 22.04 where we are building PG server.
6- Added .vscode folder/files to .gitignore file.