### PR TITLE
PG-352: pg_stat_monitor: make error when placed under contrib folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PGFILEDESC = "pg_stat_monitor - execution statistics of SQL statements"
 
 LDFLAGS_SL += $(filter -lm, $(LIBS)) 
 
+TAP_TESTS = 1
 REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/pg_stat_monitor/pg_stat_monitor.conf --inputdir=regression
 REGRESS = basic version guc counters relations database error_insert application_name application_name_unique top_query cmd_type error rows tags histogram
 
@@ -17,50 +18,11 @@ REGRESS = basic version guc counters relations database error_insert application
 # which typical installcheck users do not have (e.g. buildfarm clients).
 # NO_INSTALLCHECK = 1
 
-
 PG_CONFIG = pg_config
-PG_VERSION := $(shell pg_config --version | awk {'print $$1 $$2'})
-MAJOR := $(shell echo $(PG_VERSION) | sed -e 's/\.[^./]*$$//')
-
-ifneq (,$(findstring PostgreSQL14,$(MAJOR)))
-  ifneq (,$(wildcard ../pg_stat_monitor--1.0.14.sql.in))
-    CP := $(shell cp ../pg_stat_monitor--1.0.14.sql.in ../pg_stat_monitor--1.0.sql)
-  endif
-  ifneq (,$(wildcard pg_stat_monitor--1.0.14.sql.in))
-    CP := $(shell cp pg_stat_monitor--1.0.14.sql.in pg_stat_monitor--1.0.sql)
-  endif
-  TAP_TESTS = 1
-endif
-
-ifneq (,$(findstring PostgreSQL13,$(MAJOR)))
-  ifneq (,$(wildcard ../pg_stat_monitor--1.0.13.sql.in))
-    CP := $(shell cp ../pg_stat_monitor--1.0.13.sql.in ../pg_stat_monitor--1.0.sql)
-  endif
-  ifneq (,$(wildcard pg_stat_monitor--1.0.13.sql.in))
-    CP := $(shell cp pg_stat_monitor--1.0.13.sql.in pg_stat_monitor--1.0.sql)
-  endif
-  TAP_TESTS = 1
-endif
-
-ifneq (,$(findstring PostgreSQL12,$(MAJOR)))
-  ifneq (,$(wildcard ../pg_stat_monitor--1.0.sql.in))
-    CP := $(shell cp ../pg_stat_monitor--1.0.sql.in ../pg_stat_monitor--1.0.sql)
-  endif
-  ifneq (,$(wildcard pg_stat_monitor--1.0.sql.in))
-    CP := $(shell cp pg_stat_monitor--1.0.sql.in pg_stat_monitor--1.0.sql)
-  endif
-endif
-
-ifneq (,$(findstring PostgreSQL11,$(MAJOR)))
-  ifneq (,$(wildcard ../pg_stat_monitor--1.0.sql.in))
-    CP := $(shell cp ../pg_stat_monitor--1.0.sql.in ../pg_stat_monitor--1.0.sql)
-  endif
-  ifneq (,$(wildcard pg_stat_monitor--1.0.sql.in))
-    CP := $(shell cp pg_stat_monitor--1.0.sql.in pg_stat_monitor--1.0.sql)
-  endif
-endif
+PGSM_INPUT_SQL_VERSION := 1.0
 
 ifdef USE_PGXS
+MAJORVERSION := $(shell pg_config --version | awk {'print $$2'} | cut -f1 -d".")
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 else
@@ -69,3 +31,20 @@ top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
+
+ifeq ($(shell test $(MAJORVERSION) -gt 12; echo $$?),0)
+PGSM_INPUT_SQL_VERSION := ${PGSM_INPUT_SQL_VERSION}.${MAJORVERSION}
+endif
+
+$(info Using pg_stat_monitor--${PGSM_INPUT_SQL_VERSION}.sql.in file to generate sql filea.)
+
+ifneq (,$(wildcard ../pg_stat_monitor--${PGSM_INPUT_SQL_VERSION}.sql.in))
+  CP := $(shell cp -v ../pg_stat_monitor--${PGSM_INPUT_SQL_VERSION}.sql.in ../pg_stat_monitor--1.0.sql)
+endif
+ifneq (,$(wildcard pg_stat_monitor--${PGSM_INPUT_SQL_VERSION}.sql.in))
+  CP := $(shell cp -v pg_stat_monitor--${PGSM_INPUT_SQL_VERSION}.sql.in pg_stat_monitor--1.0.sql)
+endif
+
+clean:
+	rm -rf ${DATA}
+	rm -rf t/results


### PR DESCRIPTION
The Makefile is refactored and unnecessary conditional statements are removed
in favor of handling version separately.

Also, the clean target is updated to remove generated files including results
folder and the ${DATA} file.