### PR TITLE
PG-477: Install perl modules in PGSM-PG12 Build workflow.

### DIFF
--- a/.github/workflows/postgresql-12-build.yml
+++ b/.github/workflows/postgresql-12-build.yml
@@ -27,6 +27,9 @@ jobs:
            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
+          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
 
       - name: Create pgsql dir
         run: mkdir -p /opt/pgsql
@@ -95,20 +98,38 @@ jobs:
           make installcheck
         working-directory: src/pg_stat_monitor
 
-      - name: Report on pg_stat_monitor test fail
-        uses: actions/upload-artifact@v2
+      - name: Change dir permissions on fail
         if: ${{ failure() }}
+        run: |
+          sudo chmod -R ugo+rwx t
+          sudo chmod -R ugo+rwx tmp_check
+          exit 2 # regenerate error so that we can upload files in next step
+        working-directory: src/pg_stat_monitor
+
+      - name: Upload logs on fail
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
         with:
           name: Regressions diff and postgresql log
           path: |
             src/pg_stat_monitor/regression.diffs
+            src/pg_stat_monitor/regression.out
             src/pg_stat_monitor/logfile
-          retention-days: 1
+            src/pg_stat_monitor/t/results/
+            src/pg_stat_monitor/tmp_check/log/
+            !src/pg_stat_monitor/tmp_check/**/archives/*
+            !src/pg_stat_monitor/tmp_check/**/backup/*
+            !src/pg_stat_monitor/tmp_check/**/pgdata/*
+            !src/pg_stat_monitor/tmp_check/**/archives/
+            !src/pg_stat_monitor/tmp_check/**/backup/
+            !src/pg_stat_monitor/tmp_check/**/pgdata/
+          if-no-files-found: warn
+          retention-days: 3
 
       - name: Start Server installcheck-world tests
         run: |
           make installcheck-world
- 
+
       - name: Report on installcheck-world test suites fail
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/.github/workflows/postgresql-12-pgdg-package.yml
+++ b/.github/workflows/postgresql-12-pgdg-package.yml
@@ -16,10 +16,16 @@ jobs:
           sudo apt-get update
           sudo apt purge postgresql-client-common postgresql-common \
             postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev python3-dev bison flex \
+            libipc-run-perl wget -y
           sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
+          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
 
       - name: Install PG Distribution Postgresql 12
         run: |
@@ -51,12 +57,30 @@ jobs:
           sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
         working-directory: src/pg_stat_monitor
 
-      - name: Report on test fail
-        uses: actions/upload-artifact@v2
+      - name: Change dir permissions on fail
         if: ${{ failure() }}
+        run: |
+          sudo chmod -R ugo+rwx t
+          sudo chmod -R ugo+rwx tmp_check
+          exit 2 # regenerate error so that we can upload files in next step
+        working-directory: src/pg_stat_monitor
+
+      - name: Upload logs on fail
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
         with:
           name: Regressions diff and postgresql log
           path: |
             src/pg_stat_monitor/regression.diffs
+            src/pg_stat_monitor/regression.out
             src/pg_stat_monitor/logfile
+            src/pg_stat_monitor/t/results/
+            src/pg_stat_monitor/tmp_check/log/
+            !src/pg_stat_monitor/tmp_check/**/archives/*
+            !src/pg_stat_monitor/tmp_check/**/backup/*
+            !src/pg_stat_monitor/tmp_check/**/pgdata/*
+            !src/pg_stat_monitor/tmp_check/**/archives/
+            !src/pg_stat_monitor/tmp_check/**/backup/
+            !src/pg_stat_monitor/tmp_check/**/pgdata/
+          if-no-files-found: warn
           retention-days: 3

--- a/.github/workflows/postgresql-12-ppg-package.yml
+++ b/.github/workflows/postgresql-12-ppg-package.yml
@@ -19,10 +19,16 @@ jobs:
           sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
             zlib1g-dev libssl-dev libpam0g-dev python3-dev bison flex \
             libipc-run-perl wget
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev python3-dev bison flex \
+            libipc-run-perl wget
           sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
+          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
 
       - name: Install percona-release script
         run: |
@@ -60,12 +66,30 @@ jobs:
           sudo -u postgres bash -c 'make installcheck USE_PGXS=1'
         working-directory: src/pg_stat_monitor
 
-      - name: Report on test fail
-        uses: actions/upload-artifact@v2
+      - name: Change dir permissions on fail
         if: ${{ failure() }}
+        run: |
+          sudo chmod -R ugo+rwx t
+          sudo chmod -R ugo+rwx tmp_check
+          exit 2 # regenerate error so that we can upload files in next step
+        working-directory: src/pg_stat_monitor
+
+      - name: Upload logs on fail
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
         with:
           name: Regressions diff and postgresql log
           path: |
             src/pg_stat_monitor/regression.diffs
+            src/pg_stat_monitor/regression.out
             src/pg_stat_monitor/logfile
+            src/pg_stat_monitor/t/results/
+            src/pg_stat_monitor/tmp_check/log/
+            !src/pg_stat_monitor/tmp_check/**/archives/*
+            !src/pg_stat_monitor/tmp_check/**/backup/*
+            !src/pg_stat_monitor/tmp_check/**/pgdata/*
+            !src/pg_stat_monitor/tmp_check/**/archives/
+            !src/pg_stat_monitor/tmp_check/**/backup/
+            !src/pg_stat_monitor/tmp_check/**/pgdata/
+          if-no-files-found: warn
           retention-days: 3


### PR DESCRIPTION
Perl tap tests dependencies were missing, those are being installed now. Furthermore, workflow required some changes to enable logs to be available in case of tap tests failure(s).