### PR TITLE
PG-174: Code cleanup.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -394,7 +394,7 @@ pgss_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 				   jstate,		/* JumbleState */
 				   PGSS_PARSE); /* pgssStoreKind */
 }
-#elif
+#else
 
 /*
  * Post-parse-analysis hook: mark query with a queryId


### PR DESCRIPTION
pg_stat_monitor is a bit longer; therefore, it requires some code cleanup. Therefore I decided to turn these tasks into multiple commits and PR to avoid various changes in one PR. This will ease the review and Q/A process. In this commit, I have done these tasks.

1 - Fixing the compilation issue caused by the previous commit, where we removed the benchmarking code. It was causing problems for PostgreSQL-12.