### PR TITLE
PG-552: Remove unnecessary columns from PostgreSQL 11 and 12 views.

### DIFF
--- a/pg_stat_monitor--1.0--2.0.sql
+++ b/pg_stat_monitor--1.0--2.0.sql
@@ -3,3 +3,274 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "ALTER EXTENSION pg_stat_monitor" to load this file. \quit
 
+DROP FUNCTION pg_stat_monitor_internal CASCADE;
+DROP FUNCTION pgsm_create_11_view CASCADE;
+DROP FUNCTION pgsm_create_13_view CASCADE;
+DROP FUNCTION pgsm_create_14_view CASCADE;
+DROP FUNCTION pgsm_create_view CASCADE;
+
+-- pg_stat_monitor internal function, must not call outside from this file.
+CREATE FUNCTION pg_stat_monitor_internal(
+    IN showtext             boolean,
+    OUT bucket              int8,   -- 0
+    OUT userid              oid,
+    OUT dbid                oid,
+    OUT client_ip           int8,
+
+    OUT queryid             text,  -- 4
+    OUT planid              text,
+    OUT query               text,
+    OUT query_plan          text,
+    OUT top_queryid         text,
+    OUT top_query           text,
+	OUT application_name	text,
+
+	OUT relations			text, -- 11
+	OUT cmd_type			int,
+	OUT elevel              int,
+    OUT sqlcode             TEXT,
+    OUT message             text,
+    OUT bucket_start_time   text,
+
+	OUT calls         		int8,  -- 16
+
+    OUT total_exec_time     float8,
+    OUT min_exec_time       float8,
+    OUT max_exec_time       float8,
+    OUT mean_exec_time      float8,
+    OUT stddev_exec_time    float8,
+
+    OUT rows_retrieved      int8,
+
+	OUT plans_calls    	 	int8,  -- 23
+   
+    OUT total_plan_time     float8,
+    OUT min_plan_time       float8,
+    OUT max_plan_time       float8,
+    OUT mean_plan_time      float8,
+    OUT stddev_plan_time    float8,
+
+	OUT shared_blks_hit     int8, -- 29
+    OUT shared_blks_read    int8,
+    OUT shared_blks_dirtied int8,
+    OUT shared_blks_written int8,
+    OUT local_blks_hit      int8,
+    OUT local_blks_read     int8,
+    OUT local_blks_dirtied  int8,
+    OUT local_blks_written  int8,
+    OUT temp_blks_read      int8,
+    OUT temp_blks_written   int8,
+    OUT blk_read_time       float8,
+    OUT blk_write_time      float8,
+    OUT resp_calls          text, -- 41
+    OUT cpu_user_time       float8,
+    OUT cpu_sys_time        float8,
+    OUT wal_records 		int8,
+    OUT wal_fpi 			int8,
+    OUT wal_bytes 			numeric,
+    OUT comments 			TEXT,
+    OUT toplevel            BOOLEAN
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'pg_stat_monitor'
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+
+-- Register a view on the function for ease of use.
+CREATE FUNCTION pgsm_create_11_view() RETURNS INT AS
+$$
+BEGIN
+CREATE VIEW pg_stat_monitor AS SELECT
+    bucket,
+	bucket_start_time AS bucket_start_time,
+    userid::regrole,
+    datname,
+	'0.0.0.0'::inet + client_ip AS client_ip,
+    queryid,
+    toplevel,
+    top_queryid,
+    query,
+	comments,
+	planid,
+	query_plan,
+    top_query,
+	application_name,
+	string_to_array(relations, ',') AS relations,
+	cmd_type,
+	get_cmd_type(cmd_type) AS cmd_type_text,
+	elevel,
+	sqlcode,
+	message,
+    calls,
+	total_exec_time,
+	min_exec_time,
+	max_exec_time,
+	mean_exec_time,
+	stddev_exec_time,
+	rows_retrieved,
+	shared_blks_hit,
+    shared_blks_read,
+    shared_blks_dirtied,
+    shared_blks_written,
+    local_blks_hit,
+    local_blks_read,
+    local_blks_dirtied,
+    local_blks_written,
+    temp_blks_read,
+    temp_blks_written,
+    blk_read_time,
+    blk_write_time,
+	(string_to_array(resp_calls, ',')) resp_calls,
+	cpu_user_time,
+	cpu_sys_time,
+    wal_records,
+    wal_fpi,
+    wal_bytes
+FROM pg_stat_monitor_internal(TRUE) p, pg_database d  WHERE dbid = oid
+ORDER BY bucket_start_time;
+RETURN 0;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE FUNCTION pgsm_create_13_view() RETURNS INT AS
+$$
+BEGIN
+CREATE VIEW pg_stat_monitor AS SELECT
+    bucket,
+	bucket_start_time AS bucket_start_time,
+    userid::regrole,
+    datname,
+	'0.0.0.0'::inet + client_ip AS client_ip,
+    queryid,
+    toplevel,
+    top_queryid,
+    query,
+	comments,
+	planid,
+	query_plan,
+    top_query,
+	application_name,
+	string_to_array(relations, ',') AS relations,
+	cmd_type,
+	get_cmd_type(cmd_type) AS cmd_type_text,
+	elevel,
+	sqlcode,
+	message,
+    calls,
+	total_exec_time,
+	min_exec_time,
+	max_exec_time,
+	mean_exec_time,
+	stddev_exec_time,
+	rows_retrieved,
+	shared_blks_hit,
+    shared_blks_read,
+    shared_blks_dirtied,
+    shared_blks_written,
+    local_blks_hit,
+    local_blks_read,
+    local_blks_dirtied,
+    local_blks_written,
+    temp_blks_read,
+    temp_blks_written,
+    blk_read_time,
+    blk_write_time,
+	(string_to_array(resp_calls, ',')) resp_calls,
+	cpu_user_time,
+	cpu_sys_time,
+    wal_records,
+    wal_fpi,
+    wal_bytes,
+    -- PostgreSQL-13 Specific Coulumns
+    plans_calls
+FROM pg_stat_monitor_internal(TRUE) p, pg_database d  WHERE dbid = oid
+ORDER BY bucket_start_time;
+RETURN 0;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION pgsm_create_14_view() RETURNS INT AS
+$$
+BEGIN
+CREATE VIEW pg_stat_monitor AS SELECT
+    bucket,
+	bucket_start_time AS bucket_start_time,
+    userid::regrole,
+    datname,
+	'0.0.0.0'::inet + client_ip AS client_ip,
+    queryid,
+    toplevel,
+    top_queryid,
+    query,
+	comments,
+	planid,
+	query_plan,
+    top_query,
+	application_name,
+	string_to_array(relations, ',') AS relations,
+	cmd_type,
+	get_cmd_type(cmd_type) AS cmd_type_text,
+	elevel,
+	sqlcode,
+	message,
+    calls,
+	total_exec_time,
+	min_exec_time,
+	max_exec_time,
+	mean_exec_time,
+	stddev_exec_time,
+	rows_retrieved,
+	shared_blks_hit,
+    shared_blks_read,
+    shared_blks_dirtied,
+    shared_blks_written,
+    local_blks_hit,
+    local_blks_read,
+    local_blks_dirtied,
+    local_blks_written,
+    temp_blks_read,
+    temp_blks_written,
+    blk_read_time,
+    blk_write_time,
+	(string_to_array(resp_calls, ',')) resp_calls,
+	cpu_user_time,
+	cpu_sys_time,
+    wal_records,
+    wal_fpi,
+    wal_bytes,
+
+    -- PostgreSQL-14 Specific Columns
+    plans_calls,
+	total_plan_time,
+	min_plan_time,
+	max_plan_time,
+	mean_plan_time,
+    stddev_plan_time
+FROM pg_stat_monitor_internal(TRUE) p, pg_database d  WHERE dbid = oid
+ORDER BY bucket_start_time;
+RETURN 0;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION pgsm_create_view() RETURNS INT AS
+$$
+    DECLARE ver integer;
+    BEGIN
+        SELECT current_setting('server_version_num') INTO ver;
+    IF (ver >= 14000) THEN
+        return pgsm_create_14_view();
+    END IF;
+    IF (ver >= 13000) THEN
+        return pgsm_create_13_view();
+    END IF;
+    IF (ver >= 11000) THEN
+        return pgsm_create_11_view();
+    END IF;
+    RETURN 0;
+    END;
+$$ LANGUAGE plpgsql;
+
+SELECT pgsm_create_view();
+
+GRANT SELECT ON pg_stat_monitor TO PUBLIC;
+

--- a/pg_stat_monitor--1.0.sql
+++ b/pg_stat_monitor--1.0.sql
@@ -195,7 +195,6 @@ CREATE VIEW pg_stat_monitor AS SELECT
     datname,
 	'0.0.0.0'::inet + client_ip AS client_ip,
     queryid,
-    toplevel,
     top_queryid,
     query,
 	comments,
@@ -210,11 +209,11 @@ CREATE VIEW pg_stat_monitor AS SELECT
 	sqlcode,
 	message,
     calls,
-	total_exec_time,
-	min_exec_time,
-	max_exec_time,
-	mean_exec_time,
-	stddev_exec_time,
+	total_exec_time AS total_time,
+	min_exec_time AS min_time,
+	max_exec_time AS max_time,
+	mean_exec_time AS mean_time,
+	stddev_exec_time AS stddev_time,
 	rows_retrieved,
 	shared_blks_hit,
     shared_blks_read,
@@ -373,13 +372,13 @@ $$
     DECLARE ver integer;
     BEGIN
         SELECT current_setting('server_version_num') INTO ver;
-    IF (ver >= 14000) THEN
+    IF (ver >= 140000) THEN
         return pgsm_create_14_view();
     END IF;
-    IF (ver >= 13000) THEN
+    IF (ver >= 130000) THEN
         return pgsm_create_13_view();
     END IF;
-    IF (ver >= 11000) THEN
+    IF (ver >= 110000) THEN
         return pgsm_create_11_view();
     END IF;
     RETURN 0;

--- a/pg_stat_monitor--2.0.sql
+++ b/pg_stat_monitor--2.0.sql
@@ -116,8 +116,9 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT planid              text,
     OUT query               text,
     OUT query_plan          text,
+    OUT state_code 			int8,
     OUT top_queryid         text,
-    OUT top_query           text,
+	OUT top_query           text,
 	OUT application_name	text,
 
 	OUT relations			text, -- 11
@@ -181,7 +182,6 @@ CREATE VIEW pg_stat_monitor AS SELECT
     datname,
 	'0.0.0.0'::inet + client_ip AS client_ip,
     queryid,
-    toplevel,
     top_queryid,
     query,
 	comments,
@@ -197,10 +197,10 @@ CREATE VIEW pg_stat_monitor AS SELECT
 	message,
     calls,
 	total_exec_time,
-	min_exec_time,
-	max_exec_time,
-	mean_exec_time,
-	stddev_exec_time,
+	min_time,
+	max_time,
+	mean_time,
+	stddev_time,
 	rows_retrieved,
 	shared_blks_hit,
     shared_blks_read,
@@ -352,13 +352,13 @@ $$
     DECLARE ver integer;
     BEGIN
         SELECT current_setting('server_version_num') INTO ver;
-    IF (ver >= 14000) THEN
+    IF (ver >= 140000) THEN
         return pgsm_create_14_view();
     END IF;
-    IF (ver >= 13000) THEN
+    IF (ver >= 130000) THEN
         return pgsm_create_13_view();
     END IF;
-    IF (ver >= 11000) THEN
+    IF (ver >= 110000) THEN
         return pgsm_create_11_view();
     END IF;
     RETURN 0;

--- a/pg_stat_monitor--2.0.sql
+++ b/pg_stat_monitor--2.0.sql
@@ -26,19 +26,6 @@ $$ LANGUAGE SQL;
 
 -- Some generic utility function used internally.
 
-CREATE FUNCTION get_state(state_code int8) RETURNS TEXT AS
-$$
-SELECT
-    CASE
-        WHEN state_code = 0 THEN 'PARSING'
-        WHEN state_code = 1 THEN 'PLANNING'
-        WHEN state_code = 2 THEN 'ACTIVE'
-        WHEN state_code = 3 THEN 'FINISHED'
-        WHEN state_code = 4 THEN 'FINISHED WITH ERROR'
-    END
-$$
-LANGUAGE SQL PARALLEL SAFE;
-
 CREATE FUNCTION get_cmd_type (cmd_type INTEGER) RETURNS TEXT AS
 $$
 SELECT
@@ -129,7 +116,6 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT planid              text,
     OUT query               text,
     OUT query_plan          text,
-    OUT state_code 			int8,
     OUT top_queryid         text,
     OUT top_query           text,
 	OUT application_name	text,
@@ -233,9 +219,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
 	cpu_sys_time,
     wal_records,
     wal_fpi,
-    wal_bytes,
-	state_code,
-	get_state(state_code) as state
+    wal_bytes
 FROM pg_stat_monitor_internal(TRUE) p, pg_database d  WHERE dbid = oid
 ORDER BY bucket_start_time;
 RETURN 0;
@@ -292,9 +276,6 @@ CREATE VIEW pg_stat_monitor AS SELECT
     wal_records,
     wal_fpi,
     wal_bytes,
-	state_code,
-	get_state(state_code) as state,
-
     -- PostgreSQL-13 Specific Coulumns
     plans_calls
 FROM pg_stat_monitor_internal(TRUE) p, pg_database d  WHERE dbid = oid
@@ -352,8 +333,6 @@ CREATE VIEW pg_stat_monitor AS SELECT
     wal_records,
     wal_fpi,
     wal_bytes,
-	state_code,
-	get_state(state_code) as state,
 
     -- PostgreSQL-14 Specific Columns
     plans_calls,

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1627,7 +1627,7 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
 		elog(ERROR, "pg_stat_monitor: return type must be a row type");
 
-	if (tupdesc->natts != 50)
+	if (tupdesc->natts != 51)
 		elog(ERROR, "pg_stat_monitor: incorrect number of output arguments, required %d", tupdesc->natts);
 
 	tupstore = tuplestore_begin_heap(true, false, work_mem);
@@ -1772,7 +1772,10 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 			values[i++] = CStringGetTextDatum("<insufficient privilege>");
 		}
 
-		/* parentid at column number 8 */
+		/* state at column number 8 */
+		values[i++] = Int64GetDatumFast(tmp.state);
+
+		/* parentid at column number 9 */
 		if (tmp.info.parentid != UINT64CONST(0))
 		{
 			snprintf(parentid_txt, 32, "%08lX", tmp.info.parentid);

--- a/regression/expected/application_name.out
+++ b/regression/expected/application_name.out
@@ -12,12 +12,11 @@ SELECT 1 AS num;
 (1 row)
 
 SELECT query,application_name FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                                     query                                     |      application_name       
--------------------------------------------------------------------------------+-----------------------------
- SELECT 1 AS num                                                               | pg_regress/application_name
- SELECT pg_stat_monitor_reset()                                                | pg_regress/application_name
- SELECT query,application_name FROM pg_stat_monitor ORDER BY query COLLATE "C" | pg_regress/application_name
-(3 rows)
+             query              |      application_name       
+--------------------------------+-----------------------------
+ SELECT 1 AS num                | pg_regress/application_name
+ SELECT pg_stat_monitor_reset() | pg_regress/application_name
+(2 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/regression/expected/application_name_unique.out
+++ b/regression/expected/application_name_unique.out
@@ -20,15 +20,14 @@ SELECT 1 AS num;
 (1 row)
 
 SELECT query,application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
-                                              query                                              |          application_name          
--------------------------------------------------------------------------------------------------+------------------------------------
- SELECT 1 AS num                                                                                 | naeem
- SELECT 1 AS num                                                                                 | psql
- SELECT pg_stat_monitor_reset()                                                                  | pg_regress/application_name_unique
- SELECT query,application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C" | psql
- Set application_name = 'naeem'                                                                  | naeem
- Set application_name = 'psql'                                                                   | psql
-(6 rows)
+             query              |          application_name          
+--------------------------------+------------------------------------
+ SELECT 1 AS num                | naeem
+ SELECT 1 AS num                | psql
+ SELECT pg_stat_monitor_reset() | pg_regress/application_name_unique
+ Set application_name = 'naeem' | naeem
+ Set application_name = 'psql'  | psql
+(5 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/regression/expected/basic.out
+++ b/regression/expected/basic.out
@@ -12,12 +12,11 @@ SELECT 1 AS num;
 (1 row)
 
 SELECT query FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                            query                             
---------------------------------------------------------------
+             query              
+--------------------------------
  SELECT 1 AS num
  SELECT pg_stat_monitor_reset()
- SELECT query FROM pg_stat_monitor ORDER BY query COLLATE "C"
-(3 rows)
+(2 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/regression/expected/cmd_type.out
+++ b/regression/expected/cmd_type.out
@@ -24,20 +24,19 @@ SELECT b FROM t2 FOR UPDATE;
 TRUNCATE t1;
 DROP TABLE t1;
 SELECT query, cmd_type,  cmd_type_text FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                                         query                                          | cmd_type | cmd_type_text 
-----------------------------------------------------------------------------------------+----------+---------------
- CREATE TABLE t1 (a INTEGER)                                                            |        0 | 
- CREATE TABLE t2 (b INTEGER)                                                            |        0 | 
- DELETE FROM t1                                                                         |        4 | DELETE
- DROP TABLE t1                                                                          |        0 | 
- INSERT INTO t1 VALUES(1)                                                               |        3 | INSERT
- SELECT a FROM t1                                                                       |        1 | SELECT
- SELECT b FROM t2 FOR UPDATE                                                            |        1 | SELECT
- SELECT pg_stat_monitor_reset()                                                         |        1 | SELECT
- SELECT query, cmd_type,  cmd_type_text FROM pg_stat_monitor ORDER BY query COLLATE "C" |        1 | SELECT
- TRUNCATE t1                                                                            |        0 | 
- UPDATE t1 SET a = 2                                                                    |        2 | UPDATE
-(11 rows)
+             query              | cmd_type | cmd_type_text 
+--------------------------------+----------+---------------
+ CREATE TABLE t1 (a INTEGER)    |        0 | 
+ CREATE TABLE t2 (b INTEGER)    |        0 | 
+ DELETE FROM t1                 |        4 | DELETE
+ DROP TABLE t1                  |        0 | 
+ INSERT INTO t1 VALUES(1)       |        3 | INSERT
+ SELECT a FROM t1               |        1 | SELECT
+ SELECT b FROM t2 FOR UPDATE    |        1 | SELECT
+ SELECT pg_stat_monitor_reset() |        1 | SELECT
+ TRUNCATE t1                    |        0 | 
+ UPDATE t1 SET a = 2            |        2 | UPDATE
+(10 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/regression/expected/counters_1.out
+++ b/regression/expected/counters_1.out
@@ -64,7 +64,6 @@ SELECT query,calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 ---------------------------------------------------------------------------------------------------+-------
  SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a                   |  1000
  SELECT pg_stat_monitor_reset()                                                                    |     1
- SELECT query,calls FROM pg_stat_monitor ORDER BY query COLLATE "C"                                |     1
  do $$                                                                                            +|     1
  declare                                                                                          +| 
     n integer:= 1;                                                                                +| 

--- a/regression/expected/database_1.out
+++ b/regression/expected/database_1.out
@@ -32,7 +32,6 @@ SELECT datname, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 --------------------+---------------------------------------
  db1                | SELECT * FROM t1,t2 WHERE t1.a = t2.b
  db2                | SELECT * FROM t3,t4 WHERE t3.c = t4.d
- contrib_regression | SELECT datname, query FROM pg_stat_monitor ORDER BY query COLLATE "C"
  contrib_regression | SELECT pg_stat_monitor_reset()
 (3 rows)
 

--- a/regression/expected/error.out
+++ b/regression/expected/error.out
@@ -21,22 +21,21 @@ RAISE WARNING 'warning message';
 END $$;
 WARNING:  warning message
 SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C",elevel;
-                                             query                                             | elevel | sqlcode |              message              
------------------------------------------------------------------------------------------------+--------+---------+-----------------------------------
- ELECET * FROM unknown;                                                                        |     21 | 42601   | syntax error at or near "ELECET"
- SELECT * FROM unknown;                                                                        |     21 | 42P01   | relation "unknown" does not exist
- SELECT 1/0;                                                                                   |     21 | 22012   | division by zero
- SELECT pg_stat_monitor_reset()                                                                |      0 |         | 
- SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C",elevel |      0 |         | 
- do $$                                                                                        +|      0 |         | 
- BEGIN                                                                                        +|        |         | 
- RAISE WARNING 'warning message';                                                             +|        |         | 
- END $$                                                                                        |        |         | 
- do $$                                                                                        +|     19 | 01000   | warning message
- BEGIN                                                                                        +|        |         | 
- RAISE WARNING 'warning message';                                                             +|        |         | 
- END $$;                                                                                       |        |         | 
-(7 rows)
+              query               | elevel | sqlcode |              message              
+----------------------------------+--------+---------+-----------------------------------
+ ELECET * FROM unknown;           |     20 | 42601   | syntax error at or near "ELECET"
+ SELECT * FROM unknown;           |     20 | 42P01   | relation "unknown" does not exist
+ SELECT 1/0;                      |     20 | 22012   | division by zero
+ SELECT pg_stat_monitor_reset()   |      0 |         | 
+ do $$                           +|      0 |         | 
+ BEGIN                           +|        |         | 
+ RAISE WARNING 'warning message';+|        |         | 
+ END $$                           |        |         | 
+ do $$                           +|     19 | 01000   | warning message
+ BEGIN                           +|        |         | 
+ RAISE WARNING 'warning message';+|        |         | 
+ END $$;                          |        |         | 
+(6 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/regression/expected/error_insert.out
+++ b/regression/expected/error_insert.out
@@ -17,14 +17,13 @@ ERROR:  duplicate key value violates unique constraint "company_pkey"
 DETAIL:  Key (id)=(1) already exists.
 Drop Table if exists Company;
 SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C",elevel;
-                                             query                                             | elevel | sqlcode |                            message                            
------------------------------------------------------------------------------------------------+--------+---------+---------------------------------------------------------------
- Drop Table if exists Company                                                                  |      0 |         | 
- INSERT  INTO Company(ID, Name) VALUES (1, 'Percona')                                          |      0 |         | 
- INSERT  INTO Company(ID, Name) VALUES (1, 'Percona');                                         |     21 | 23505   | duplicate key value violates unique constraint "company_pkey"
- SELECT pg_stat_monitor_reset()                                                                |      0 |         | 
- SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C",elevel |      0 |         | 
-(5 rows)
+                         query                         | elevel | sqlcode |                            message                            
+-------------------------------------------------------+--------+---------+---------------------------------------------------------------
+ Drop Table if exists Company                          |      0 |         | 
+ INSERT  INTO Company(ID, Name) VALUES (1, 'Percona')  |      0 |         | 
+ INSERT  INTO Company(ID, Name) VALUES (1, 'Percona'); |     20 | 23505   | duplicate key value violates unique constraint "company_pkey"
+ SELECT pg_stat_monitor_reset()                        |      0 |         | 
+(4 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/regression/expected/histogram_1.out
+++ b/regression/expected/histogram_1.out
@@ -45,14 +45,13 @@ INFO:  Sleep 5 seconds
 (1 row)
 
 SELECT substr(query, 0,50) as query, calls, resp_calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                       query                       | calls |      resp_calls       
----------------------------------------------------+-------+-----------------------
- SELECT pg_sleep(i)                                |     5 | {0,0,0,0,0,0,3,2,0,0}
- SELECT pg_stat_monitor_reset()                    |     1 | {1,0,0,0,0,0,0,0,0,0}
- SELECT substr(query, 0,50) as query, calls, resp_ |     1 | {1,0,0,0,0,0,0,0,0,0}
- Set pg_stat_monitor.pgsm_track='all'              |     1 | {1,0,0,0,0,0,0,0,0,0}
- select run_pg_sleep(5)                            |     1 | {0,0,0,0,0,0,0,0,1,0}
-(5 rows)
+                query                 | calls |      resp_calls       
+--------------------------------------+-------+-----------------------
+ SELECT pg_sleep(i)                   |     5 | {0,0,0,0,0,0,3,2,0,0}
+ SELECT pg_stat_monitor_reset()       |     1 | {1,0,0,0,0,0,0,0,0,0}
+ Set pg_stat_monitor.pgsm_track='all' |     1 | {1,0,0,0,0,0,0,0,0,0}
+ select run_pg_sleep(5)               |     1 | {0,0,0,0,0,0,0,0,1,0}
+(4 rows)
 
 select * from generate_histogram();
        range        | freq |              bar               

--- a/regression/expected/relations.out
+++ b/regression/expected/relations.out
@@ -37,15 +37,14 @@ SELECT * FROM foo1, foo2, foo3, foo4;
 (0 rows)
 
 SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
-                                  query                                  |                     relations                     
--------------------------------------------------------------------------+---------------------------------------------------
- SELECT * FROM foo1                                                      | {public.foo1}
- SELECT * FROM foo1, foo2                                                | {public.foo1,public.foo2}
- SELECT * FROM foo1, foo2, foo3                                          | {public.foo1,public.foo2,public.foo3}
- SELECT * FROM foo1, foo2, foo3, foo4                                    | {public.foo1,public.foo2,public.foo3,public.foo4}
- SELECT pg_stat_monitor_reset()                                          | 
- SELECT query, relations from pg_stat_monitor ORDER BY query collate "C" | {public.pg_stat_monitor*,pg_catalog.pg_database}
-(6 rows)
+                query                 |                     relations                     
+--------------------------------------+---------------------------------------------------
+ SELECT * FROM foo1                   | {public.foo1}
+ SELECT * FROM foo1, foo2             | {public.foo1,public.foo2}
+ SELECT * FROM foo1, foo2, foo3       | {public.foo1,public.foo2,public.foo3}
+ SELECT * FROM foo1, foo2, foo3, foo4 | {public.foo1,public.foo2,public.foo3,public.foo4}
+ SELECT pg_stat_monitor_reset()       | 
+(5 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
@@ -89,15 +88,14 @@ SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3, sch4.foo4;
 (0 rows)
 
 SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
-                                  query                                  |                    relations                     
--------------------------------------------------------------------------+--------------------------------------------------
- SELECT * FROM sch1.foo1                                                 | {sch1.foo1}
- SELECT * FROM sch1.foo1, sch2.foo2                                      | {sch1.foo1,sch2.foo2}
- SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3                           | {sch1.foo1,sch2.foo2,sch3.foo3}
- SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3, sch4.foo4                | {sch1.foo1,sch2.foo2,sch3.foo3,sch4.foo4}
- SELECT pg_stat_monitor_reset()                                          | 
- SELECT query, relations from pg_stat_monitor ORDER BY query collate "C" | {public.pg_stat_monitor*,pg_catalog.pg_database}
-(6 rows)
+                          query                           |                 relations                 
+----------------------------------------------------------+-------------------------------------------
+ SELECT * FROM sch1.foo1                                  | {sch1.foo1}
+ SELECT * FROM sch1.foo1, sch2.foo2                       | {sch1.foo1,sch2.foo2}
+ SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3            | {sch1.foo1,sch2.foo2,sch3.foo3}
+ SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3, sch4.foo4 | {sch1.foo1,sch2.foo2,sch3.foo3,sch4.foo4}
+ SELECT pg_stat_monitor_reset()                           | 
+(5 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
@@ -122,13 +120,12 @@ SELECT * FROM sch1.foo1, sch2.foo2, foo1, foo2;
 (0 rows)
 
 SELECT query, relations from pg_stat_monitor ORDER BY query;
-                            query                            |                    relations                     
--------------------------------------------------------------+--------------------------------------------------
- SELECT * FROM sch1.foo1, foo1                               | {sch1.foo1,public.foo1}
- SELECT * FROM sch1.foo1, sch2.foo2, foo1, foo2              | {sch1.foo1,sch2.foo2,public.foo1,public.foo2}
- SELECT pg_stat_monitor_reset()                              | 
- SELECT query, relations from pg_stat_monitor ORDER BY query | {public.pg_stat_monitor*,pg_catalog.pg_database}
-(4 rows)
+                     query                      |                   relations                   
+------------------------------------------------+-----------------------------------------------
+ SELECT * FROM sch1.foo1, foo1                  | {sch1.foo1,public.foo1}
+ SELECT * FROM sch1.foo1, sch2.foo2, foo1, foo2 | {sch1.foo1,sch2.foo2,public.foo1,public.foo2}
+ SELECT pg_stat_monitor_reset()                 | 
+(3 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
@@ -168,15 +165,14 @@ SELECT * FROM v1,v2,v3,v4;
 (0 rows)
 
 SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
-                                  query                                  |                                           relations                                           
--------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------
- SELECT * FROM v1                                                        | {public.v1*,public.foo1}
- SELECT * FROM v1,v2                                                     | {public.v1*,public.foo1,public.v2*,public.foo2}
- SELECT * FROM v1,v2,v3                                                  | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3}
- SELECT * FROM v1,v2,v3,v4                                               | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3,public.v4*,public.foo4}
- SELECT pg_stat_monitor_reset()                                          | 
- SELECT query, relations from pg_stat_monitor ORDER BY query collate "C" | {public.pg_stat_monitor*,pg_catalog.pg_database}
-(6 rows)
+             query              |                                           relations                                           
+--------------------------------+-----------------------------------------------------------------------------------------------
+ SELECT * FROM v1               | {public.v1*,public.foo1}
+ SELECT * FROM v1,v2            | {public.v1*,public.foo1,public.v2*,public.foo2}
+ SELECT * FROM v1,v2,v3         | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3}
+ SELECT * FROM v1,v2,v3,v4      | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3,public.v4*,public.foo4}
+ SELECT pg_stat_monitor_reset() | 
+(5 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/regression/expected/rows.out
+++ b/regression/expected/rows.out
@@ -8541,15 +8541,14 @@ SELECt * FROM t2  WHERE b % 2 = 0;
 (2500 rows)
 
 SELECT query, rows_retrieved FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                                    query                                     | rows_retrieved 
-------------------------------------------------------------------------------+----------------
- SELECT * FROM t1                                                             |           1000
- SELECT * FROM t1 LIMIT 10                                                    |             10
- SELECT * FROM t2                                                             |           5000
- SELECT pg_stat_monitor_reset()                                               |              1
- SELECT query, rows_retrieved FROM pg_stat_monitor ORDER BY query COLLATE "C" |              0
- SELECt * FROM t2  WHERE b % 2 = 0                                            |           2500
-(6 rows)
+               query               | rows_retrieved 
+-----------------------------------+----------------
+ SELECT * FROM t1                  |           1000
+ SELECT * FROM t1 LIMIT 10         |             10
+ SELECT * FROM t2                  |           5000
+ SELECT pg_stat_monitor_reset()    |              1
+ SELECt * FROM t2  WHERE b % 2 = 0 |           2500
+(5 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/regression/expected/tags.out
+++ b/regression/expected/tags.out
@@ -17,8 +17,7 @@ SELECT query, comments FROM pg_stat_monitor ORDER BY query COLLATE "C";
 --------------------------------------------------------------------------+----------------------------------------------------------
  SELECT 1 AS num /* { "application", psql_app, "real_ip", 192.168.1.3) */ | /* { "application", psql_app, "real_ip", 192.168.1.3) */
  SELECT pg_stat_monitor_reset()                                           | 
- SELECT query, comments FROM pg_stat_monitor ORDER BY query COLLATE "C"   | 
-(3 rows)
+(2 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/regression/expected/top_query.out
+++ b/regression/expected/top_query.out
@@ -24,24 +24,23 @@ SELECT add2(1,2);
 (1 row)
 
 SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                                  query                                  |    top_query     
--------------------------------------------------------------------------+------------------
- (select $1 + $2)                                                        | SELECT add2(1,2)
- CREATE OR REPLACE FUNCTION add(int, int) RETURNS INTEGER AS            +| 
- $$                                                                     +| 
- BEGIN                                                                  +| 
-         return (select $1 + $2);                                       +| 
- END; $$ language plpgsql                                                | 
- CREATE OR REPLACE function add2(int, int) RETURNS int as               +| 
- $$                                                                     +| 
- BEGIN                                                                  +| 
-         return add($1,$2);                                             +| 
- END;                                                                   +| 
- $$ language plpgsql                                                     | 
- SELECT add2(1,2)                                                        | 
- SELECT pg_stat_monitor_reset()                                          | 
- SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C" | 
-(6 rows)
+                            query                            |    top_query     
+-------------------------------------------------------------+------------------
+ CREATE OR REPLACE FUNCTION add(int, int) RETURNS INTEGER AS+| 
+ $$                                                         +| 
+ BEGIN                                                      +| 
+         return (select $1 + $2);                           +| 
+ END; $$ language plpgsql                                    | 
+ CREATE OR REPLACE function add2(int, int) RETURNS int as   +| 
+ $$                                                         +| 
+ BEGIN                                                      +| 
+         return add($1,$2);                                 +| 
+ END;                                                       +| 
+ $$ language plpgsql                                         | 
+ SELECT (select $1 + $2)                                     | SELECT add2(1,2)
+ SELECT add2(1,2)                                            | 
+ SELECT pg_stat_monitor_reset()                              | 
+(5 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/t/expected/001_settings_default.out
+++ b/t/expected/001_settings_default.out
@@ -26,12 +26,11 @@ SELECT * from pg_stat_monitor_settings;
 (15 rows)
 
 select datname, substr(query,0,100) as query, calls from pg_stat_monitor order by datname, query, calls desc Limit 20;
- datname  |                                                query                                                | calls 
-----------+-----------------------------------------------------------------------------------------------------+-------
- postgres | SELECT * from pg_stat_monitor_settings                                                              |     1
- postgres | SELECT pg_stat_monitor_reset()                                                                      |     1
- postgres | select datname, substr(query,0,100) as query, calls from pg_stat_monitor order by datname, query, c |     1
-(3 rows)
+ datname  |                 query                  | calls 
+----------+----------------------------------------+-------
+ postgres | SELECT * from pg_stat_monitor_settings |     1
+ postgres | SELECT pg_stat_monitor_reset()         |     1
+(2 rows)
 
 SELECT * from pg_stat_monitor_settings;
                    name                   | value  | default_value |                                               description                                                | minimum |  maximum   |    options     | restart 


### PR DESCRIPTION
PG-552: Remove unnecessary columns from PostgreSQL 11 and 12 views.
    
There was a typo while checking the PostgreSQL version in the SQL file. This commit
 will fix the typo, and only the necessary columns will be visible in the view.

