### PR TITLE
PG-555 :Infrastructure to allow multiple SQL APIs

### DIFF
--- a/pg_stat_monitor--1.0--2.0.sql
+++ b/pg_stat_monitor--1.0--2.0.sql
@@ -72,7 +72,7 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT toplevel            BOOLEAN
 )
 RETURNS SETOF record
-AS 'MODULE_PATHNAME', 'pg_stat_monitor'
+AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_0'
 LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
 
 -- Register a view on the function for ease of use.

--- a/pg_stat_monitor--2.0.sql
+++ b/pg_stat_monitor--2.0.sql
@@ -168,7 +168,7 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT toplevel            BOOLEAN
 )
 RETURNS SETOF record
-AS 'MODULE_PATHNAME', 'pg_stat_monitor'
+AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_0'
 LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
 
 -- Register a view on the function for ease of use.


### PR DESCRIPTION
Creating the infrastructure that'll allow using newer versions of the loadable module with old SQL declarations.
Also updating the build version to 2.0.0-dev