### PR TITLE
PG-435: Adding new counters that are available in PG15

### DIFF
--- a/pg_stat_monitor--1.0--2.0.sql
+++ b/pg_stat_monitor--1.0--2.0.sql
@@ -62,15 +62,28 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT temp_blks_written   int8,
     OUT blk_read_time       float8,
     OUT blk_write_time      float8,
+    OUT temp_blk_read_time  float8,
+    OUT temp_blk_write_time float8,
+
     OUT resp_calls          text, -- 41
     OUT cpu_user_time       float8,
     OUT cpu_sys_time        float8,
-    OUT wal_records 		int8,
-    OUT wal_fpi 			int8,
-    OUT wal_bytes 			numeric,
-    OUT comments 			TEXT,
-    OUT toplevel            BOOLEAN,
-	OUT bucket_done			BOOLEAN
+    OUT wal_records         int8,
+    OUT wal_fpi             int8,
+    OUT wal_bytes           numeric,
+    OUT comments            TEXT,
+
+    OUT jit_functions           int8,
+    OUT jit_generation_time     float8,
+    OUT jit_inlining_count      int8,
+    OUT jit_inlining_time       float8,
+    OUT jit_optimization_count  int8,
+    OUT jit_optimization_time   float8,
+    OUT jit_emission_count      int8,
+    OUT jit_emission_time       float8,
+
+    OUT toplevel                BOOLEAN,
+    OUT bucket_done             BOOLEAN
 )
 RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_0'
@@ -258,18 +271,97 @@ RETURN 0;
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE FUNCTION pgsm_create_15_view() RETURNS INT AS
+$$
+BEGIN
+CREATE VIEW pg_stat_monitor AS SELECT
+    bucket,
+	bucket_start_time AS bucket_start_time,
+    userid::regrole,
+    datname,
+	'0.0.0.0'::inet + client_ip AS client_ip,
+    queryid,
+    toplevel,
+    top_queryid,
+    query,
+	comments,
+	planid,
+	query_plan,
+    top_query,
+	application_name,
+	string_to_array(relations, ',') AS relations,
+	cmd_type,
+	get_cmd_type(cmd_type) AS cmd_type_text,
+	elevel,
+	sqlcode,
+	message,
+    calls,
+	total_exec_time,
+	min_exec_time,
+	max_exec_time,
+	mean_exec_time,
+	stddev_exec_time,
+	rows_retrieved,
+	shared_blks_hit,
+    shared_blks_read,
+    shared_blks_dirtied,
+    shared_blks_written,
+    local_blks_hit,
+    local_blks_read,
+    local_blks_dirtied,
+    local_blks_written,
+    temp_blks_read,
+    temp_blks_written,
+    blk_read_time,
+    blk_write_time,
+    temp_blk_read_time,
+    temp_blk_write_time,
+
+	(string_to_array(resp_calls, ',')) resp_calls,
+	cpu_user_time,
+	cpu_sys_time,
+    wal_records,
+    wal_fpi,
+    wal_bytes,
+	bucket_done,
+
+    plans_calls,
+	total_plan_time,
+	min_plan_time,
+	max_plan_time,
+	mean_plan_time,
+    stddev_plan_time,
+
+    jit_functions,
+    jit_generation_time,
+    jit_inlining_count,
+    jit_inlining_time,
+    jit_optimization_count,
+    jit_optimization_time,
+    jit_emission_count,
+    jit_emission_time
+
+FROM pg_stat_monitor_internal(TRUE) p, pg_database d  WHERE dbid = oid
+ORDER BY bucket_start_time;
+RETURN 0;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE FUNCTION pgsm_create_view() RETURNS INT AS
 $$
     DECLARE ver integer;
     BEGIN
         SELECT current_setting('server_version_num') INTO ver;
-    IF (ver >= 14000) THEN
+    IF (ver >= 150000) THEN
+        return pgsm_create_15_view();
+    END IF;
+    IF (ver >= 140000) THEN
         return pgsm_create_14_view();
     END IF;
-    IF (ver >= 13000) THEN
+    IF (ver >= 130000) THEN
         return pgsm_create_13_view();
     END IF;
-    IF (ver >= 11000) THEN
+    IF (ver >= 110000) THEN
         return pgsm_create_11_view();
     END IF;
     RETURN 0;

--- a/pg_stat_monitor--2.0.sql
+++ b/pg_stat_monitor--2.0.sql
@@ -116,7 +116,6 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT planid              text,
     OUT query               text,
     OUT query_plan          text,
-    OUT state_code 			int8,
     OUT top_queryid         text,
 	OUT top_query           text,
 	OUT application_name	text,
@@ -158,15 +157,29 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT temp_blks_written   int8,
     OUT blk_read_time       float8,
     OUT blk_write_time      float8,
+
+    OUT temp_blk_read_time  float8,
+    OUT temp_blk_write_time float8,
+
     OUT resp_calls          text, -- 41
     OUT cpu_user_time       float8,
     OUT cpu_sys_time        float8,
-    OUT wal_records 		int8,
-    OUT wal_fpi 			int8,
-    OUT wal_bytes 			numeric,
-    OUT comments 			TEXT,
+    OUT wal_records         int8,
+    OUT wal_fpi             int8,
+    OUT wal_bytes           numeric,
+    OUT comments            TEXT,
+
+    OUT jit_functions           int8,
+    OUT jit_generation_time     float8,
+    OUT jit_inlining_count      int8,
+    OUT jit_inlining_time       float8,
+    OUT jit_optimization_count  int8,
+    OUT jit_optimization_time   float8,
+    OUT jit_emission_count      int8,
+    OUT jit_emission_time       float8,
+
     OUT toplevel            BOOLEAN,
-	OUT bucket_done			BOOLEAN
+    OUT bucket_done         BOOLEAN
 )
 RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_0'
@@ -355,11 +368,90 @@ RETURN 0;
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE FUNCTION pgsm_create_15_view() RETURNS INT AS
+$$
+BEGIN
+CREATE VIEW pg_stat_monitor AS SELECT
+    bucket,
+	bucket_start_time AS bucket_start_time,
+    userid::regrole,
+    datname,
+	'0.0.0.0'::inet + client_ip AS client_ip,
+    queryid,
+    toplevel,
+    top_queryid,
+    query,
+	comments,
+	planid,
+	query_plan,
+    top_query,
+	application_name,
+	string_to_array(relations, ',') AS relations,
+	cmd_type,
+	get_cmd_type(cmd_type) AS cmd_type_text,
+	elevel,
+	sqlcode,
+	message,
+    calls,
+	total_exec_time,
+	min_exec_time,
+	max_exec_time,
+	mean_exec_time,
+	stddev_exec_time,
+	rows_retrieved,
+	shared_blks_hit,
+    shared_blks_read,
+    shared_blks_dirtied,
+    shared_blks_written,
+    local_blks_hit,
+    local_blks_read,
+    local_blks_dirtied,
+    local_blks_written,
+    temp_blks_read,
+    temp_blks_written,
+    blk_read_time,
+    blk_write_time,
+    temp_blk_read_time,
+    temp_blk_write_time,
+
+	(string_to_array(resp_calls, ',')) resp_calls,
+	cpu_user_time,
+	cpu_sys_time,
+    wal_records,
+    wal_fpi,
+    wal_bytes,
+	bucket_done,
+
+    plans_calls,
+	total_plan_time,
+	min_plan_time,
+	max_plan_time,
+	mean_plan_time,
+    stddev_plan_time,
+
+    jit_functions,
+    jit_generation_time,
+    jit_inlining_count,
+    jit_inlining_time,
+    jit_optimization_count,
+    jit_optimization_time,
+    jit_emission_count,
+    jit_emission_time
+
+FROM pg_stat_monitor_internal(TRUE) p, pg_database d  WHERE dbid = oid
+ORDER BY bucket_start_time;
+RETURN 0;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE FUNCTION pgsm_create_view() RETURNS INT AS
 $$
     DECLARE ver integer;
     BEGIN
         SELECT current_setting('server_version_num') INTO ver;
+    IF (ver >= 150000) THEN
+        return pgsm_create_15_view();
+    END IF;
     IF (ver >= 140000) THEN
         return pgsm_create_14_view();
     END IF;

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -31,6 +31,7 @@
 #include "catalog/pg_authid.h"
 #include "executor/instrument.h"
 #include "common/ip.h"
+#include "jit/jit.h"
 #include "funcapi.h"
 #include "access/twophase.h"
 #include "mb/pg_wchar.h"
@@ -255,7 +256,26 @@ typedef struct Blocks
 	int64		temp_blks_written;	/* # of temp blocks written */
 	double		blk_read_time;	/* time spent reading, in msec */
 	double		blk_write_time; /* time spent writing, in msec */
+
+	double      temp_blk_read_time; /* time spent reading temp blocks, in msec */
+	double      temp_blk_write_time;    /* time spent writing temp blocks, in
+                                          * msec */
 }			Blocks;
+
+typedef struct JitInfo
+{
+     int64       jit_functions;  /* total number of JIT functions emitted */
+     double      jit_generation_time;    /* total time to generate jit code */
+     int64       jit_inlining_count; /* number of times inlining time has been
+                                      * > 0 */
+     double      jit_inlining_time;  /* total time to inline jit code */
+     int64       jit_optimization_count; /* number of times optimization time
+                                          * has been > 0 */
+     double      jit_optimization_time;  /* total time to optimize jit code */
+     int64       jit_emission_count; /* number of times emission time has been
+                                      * > 0 */
+     double      jit_emission_time;  /* total time to emit jit code */
+}			JitInfo;
 
 typedef struct SysInfo
 {
@@ -283,11 +303,12 @@ typedef struct Counters
 
 	Blocks		blocks;
 	SysInfo		sysinfo;
+	JitInfo		jitinfo;
 	ErrorInfo	error;
 	Wal_Usage	walusage;
 	int			resp_calls[MAX_RESPONSE_BUCKET];	/* execution time's in
 													 * msec */
-	uint64		state;			/* query state */
+	int64		state;			/* query state */
 } Counters;
 
 /* Some global structure to get the cpu usage, really don't like the idea of global variable */

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -26,14 +26,18 @@ close $conf;
 my %pg_versions_pgsm_columns = ( 15 => "application_name,blk_read_time," .
     "blk_write_time,bucket,bucket_done,bucket_start_time,calls," .
     "client_ip,cmd_type,cmd_type_text,comments,cpu_sys_time,cpu_user_time," .
-    "datname,elevel,local_blks_dirtied,local_blks_hit,local_blks_read," .
+    "datname,elevel,jit_emission_count,jit_emission_time,jit_functions," .
+    "jit_generation_time,jit_inlining_count,jit_inlining_time," .
+    "jit_optimization_count,jit_optimization_time," .
+    "local_blks_dirtied,local_blks_hit,local_blks_read," .
     "local_blks_written,max_exec_time,max_plan_time,mean_exec_time," .
     "mean_plan_time,message,min_exec_time,min_plan_time,planid," .
     "plans_calls,query,query_plan,queryid,relations,resp_calls," .
     "rows_retrieved,shared_blks_dirtied,shared_blks_hit,shared_blks_read," .
     "shared_blks_written,sqlcode,stddev_exec_time,stddev_plan_time," .
-    "temp_blks_read,temp_blks_written,top_query,top_queryid,toplevel," .
-    "total_exec_time,total_plan_time,userid,wal_bytes,wal_fpi,wal_records",
+    "temp_blk_read_time,temp_blk_write_time,temp_blks_read,temp_blks_written," .
+    "top_query,top_queryid,toplevel,total_exec_time,total_plan_time," .
+    "userid,wal_bytes,wal_fpi,wal_records",
  14 => "application_name,blk_read_time," .
     "blk_write_time,bucket,bucket_done,bucket_start_time,calls," .
     "client_ip,cmd_type,cmd_type_text,comments,cpu_sys_time,cpu_user_time," .


### PR DESCRIPTION
In line with pg_stat_statments for PG15, This commit adds eight new cumulative counters for jit operations, making it easier to diagnose how JIT is used in an installation. And two new columns, temp_blk_read_time, and temp_blk_write_time, respectively, show the time spent reading and writing temporary file blocks on disk.
Moreover, The commit also contains a few indentations and API adjustments.