### PR TITLE
PG-576 - Segmentation fault caused by pg_stat_monitor unique queryid creation mechanism.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1520,7 +1520,11 @@ pgss_store(uint64 queryid,
 			pgsm_query_id = pgss_hash_string(norm_query, norm_query_len);
 
 			/* Free up norm_query if we don't intend to show normalized version in the view */
-			if (!PGSM_NORMALIZED_QUERY)
+			if (PGSM_NORMALIZED_QUERY)
+			{
+				query_len = norm_query_len;
+			}
+			else
 			{
 				if (norm_query)
 					pfree(norm_query);
@@ -1559,7 +1563,7 @@ pgss_store(uint64 queryid,
 							   queryid,
 							   pgss_qbuf,
 							   norm_query ? norm_query : query,
-							   norm_query ? norm_query_len : query_len,
+							   query_len,
 							   &query_entry->query_pos))
 			{
 				LWLockRelease(pgss->lock);


### PR DESCRIPTION
This fix resolves the issue with incorrect query length in case of a normalized query when the query length exceeds PGSM_QUERY_MAX_LEN.