### PR TITLE
PG-562: Added first and last buckets to histogram for better data distribution.

### DIFF
--- a/pg_stat_monitor--2.0.sql
+++ b/pg_stat_monitor--2.0.sql
@@ -71,7 +71,7 @@ BEGIN
     FOR rec IN
         WITH stat AS (select queryid, bucket, unnest(range()) AS range, 
             unnest(resp_calls)::int freq FROM pg_stat_monitor) select range, 
-            freq, repeat('■', (freq::float / max(freq) over() * 30)::int) AS bar 
+            freq, repeat('■', freq) AS bar 
             FROM stat WHERE queryid = _quryid and bucket = _bucket
     LOOP
         RETURN next rec;

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -3542,7 +3542,6 @@ unpack_sql_state(int sql_state)
 	return buf;
 }
 
-#include <math.h>
 
 /*
  * Calculates the appropriate histogram bucket for a given value.


### PR DESCRIPTION
This commit adds two additional buckets to the histogram: a first bucket that starts from 0 and ends at min_time, and a last bucket that starts from max_time and ends at infinity. These buckets are meant to provide context for the other buckets in the histogram, which are based on the user-specified number of buckets.

For example, if the user specifies three buckets and min_time is 10 and max_time is 50, the resulting histogram will include the following five buckets:

First bucket: 0 - 10
Second bucket: 10 - 20
Third bucket: 20 - 30
Fourth bucket: 30 - 50
Last bucket: 50 - infinity
This allows the user to see how the data is distributed within the full range of values, rather than just within the range of values specified by min_time and max_time.