### PR TITLE
PG-543: pg_stat_monitor: PostgreSQL's pg_stat_statements compatible view.

### DIFF
--- a/pg_stat_monitor--1.0--2.0.sql
+++ b/pg_stat_monitor--1.0--2.0.sql
@@ -10,7 +10,6 @@ DROP FUNCTION pgsm_create_14_view CASCADE;
 DROP FUNCTION pgsm_create_view CASCADE;
 DROP FUNCTION pg_stat_monitor_settings CASCADE;
 
--- pg_stat_monitor internal function, must not call outside from this file.
 CREATE FUNCTION pg_stat_monitor_internal(
     IN showtext             boolean,
     OUT bucket              int8,   -- 0
@@ -18,13 +17,13 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT dbid                oid,
     OUT client_ip           int8,
 
-    OUT queryid             text,  -- 4
-    OUT planid              text,
+    OUT queryid             int8,  -- 4
+    OUT planid              int8,
     OUT query               text,
     OUT query_plan          text,
     OUT pgsm_query_id       int8,
-    OUT top_queryid         text,
-    OUT top_query           text,
+    OUT top_queryid         int8,
+	OUT top_query           text,
 	OUT application_name	text,
 
 	OUT relations			text, -- 11
@@ -32,7 +31,7 @@ CREATE FUNCTION pg_stat_monitor_internal(
 	OUT elevel              int,
     OUT sqlcode             TEXT,
     OUT message             text,
-    OUT bucket_start_time   timestamp,
+    OUT bucket_start_time   timestamptz,
 
 	OUT calls         		int8,  -- 16
 
@@ -42,9 +41,9 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT mean_exec_time      float8,
     OUT stddev_exec_time    float8,
 
-    OUT rows_retrieved      int8,
+    OUT rows                int8,
 
-	OUT plans_calls    	 	int8,  -- 23
+	OUT plans          	 	int8,  -- 23
    
     OUT total_plan_time     float8,
     OUT min_plan_time       float8,
@@ -64,6 +63,7 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT temp_blks_written   int8,
     OUT blk_read_time       float8,
     OUT blk_write_time      float8,
+
     OUT temp_blk_read_time  float8,
     OUT temp_blk_write_time float8,
 
@@ -84,8 +84,8 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT jit_emission_count      int8,
     OUT jit_emission_time       float8,
 
-    OUT toplevel                BOOLEAN,
-    OUT bucket_done             BOOLEAN
+    OUT toplevel            BOOLEAN,
+    OUT bucket_done         BOOLEAN
 )
 RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_0'
@@ -98,12 +98,13 @@ BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
 	bucket_start_time AS bucket_start_time,
-    userid::regrole,
+    userid,
+    userid::regrole AS user,
+    dbid,
     datname,
 	'0.0.0.0'::inet + client_ip AS client_ip,
 	pgsm_query_id,
     queryid,
-    toplevel,
     top_queryid,
     query,
 	comments,
@@ -118,12 +119,12 @@ CREATE VIEW pg_stat_monitor AS SELECT
 	sqlcode,
 	message,
     calls,
-	total_exec_time,
-	min_exec_time,
-	max_exec_time,
-	mean_exec_time,
-	stddev_exec_time,
-	rows_retrieved,
+	total_exec_time AS total_time,
+	min_exec_time AS min_time,
+	max_exec_time AS max_time,
+	mean_exec_time AS mean_time,
+	stddev_exec_time AS stddev_time,
+	rows,
 	shared_blks_hit,
     shared_blks_read,
     shared_blks_dirtied,
@@ -153,7 +154,9 @@ BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
 	bucket_start_time AS bucket_start_time,
-    userid::regrole,
+    userid,
+    userid::regrole AS user,
+    dbid,
     datname,
 	'0.0.0.0'::inet + client_ip AS client_ip,
 	pgsm_query_id,
@@ -178,7 +181,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
 	max_exec_time,
 	mean_exec_time,
 	stddev_exec_time,
-	rows_retrieved,
+	rows,
 	shared_blks_hit,
     shared_blks_read,
     shared_blks_dirtied,
@@ -197,7 +200,9 @@ CREATE VIEW pg_stat_monitor AS SELECT
     wal_records,
     wal_fpi,
     wal_bytes,
-    plans_calls,
+	bucket_done,
+    -- PostgreSQL-13 Specific Coulumns
+	plans,
 	total_plan_time,
 	min_plan_time,
 	max_plan_time,
@@ -215,7 +220,9 @@ BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
 	bucket_start_time AS bucket_start_time,
-    userid::regrole,
+    userid,
+    userid::regrole AS user,
+    dbid,
     datname,
 	'0.0.0.0'::inet + client_ip AS client_ip,
 	pgsm_query_id,
@@ -240,7 +247,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
 	max_exec_time,
 	mean_exec_time,
 	stddev_exec_time,
-	rows_retrieved,
+	rows,
 	shared_blks_hit,
     shared_blks_read,
     shared_blks_dirtied,
@@ -261,7 +268,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
     wal_bytes,
 	bucket_done,
 
-    plans_calls,
+    plans,
 	total_plan_time,
 	min_plan_time,
 	max_plan_time,
@@ -279,9 +286,12 @@ BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
 	bucket_start_time AS bucket_start_time,
-    userid::regrole,
+    userid,
+    userid::regrole AS user,
+    dbid,
     datname,
 	'0.0.0.0'::inet + client_ip AS client_ip,
+	pgsm_query_id,
     queryid,
     toplevel,
     top_queryid,
@@ -303,7 +313,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
 	max_exec_time,
 	mean_exec_time,
 	stddev_exec_time,
-	rows_retrieved,
+	rows,
 	shared_blks_hit,
     shared_blks_read,
     shared_blks_dirtied,
@@ -327,7 +337,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
     wal_bytes,
 	bucket_done,
 
-    plans_calls,
+    plans,
 	total_plan_time,
 	min_plan_time,
 	max_plan_time,
@@ -371,7 +381,6 @@ $$
 $$ LANGUAGE plpgsql;
 
 SELECT pgsm_create_view();
-
 REVOKE ALL ON FUNCTION range FROM PUBLIC;
 REVOKE ALL ON FUNCTION get_cmd_type FROM PUBLIC;
 REVOKE ALL ON FUNCTION decode_error_level FROM PUBLIC;
@@ -384,4 +393,3 @@ REVOKE ALL ON FUNCTION pgsm_create_14_view FROM PUBLIC;
 REVOKE ALL ON FUNCTION pgsm_create_15_view FROM PUBLIC;
 
 GRANT SELECT ON pg_stat_monitor TO PUBLIC;
-

--- a/pg_stat_monitor--2.0.sql
+++ b/pg_stat_monitor--2.0.sql
@@ -87,12 +87,12 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT dbid                oid,
     OUT client_ip           int8,
 
-    OUT queryid             text,  -- 4
-    OUT planid              text,
+    OUT queryid             int8,  -- 4
+    OUT planid              int8,
     OUT query               text,
     OUT query_plan          text,
     OUT pgsm_query_id       int8,
-    OUT top_queryid         text,
+    OUT top_queryid         int8,
 	OUT top_query           text,
 	OUT application_name	text,
 
@@ -111,9 +111,9 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT mean_exec_time      float8,
     OUT stddev_exec_time    float8,
 
-    OUT rows_retrieved      int8,
+    OUT rows                int8,
 
-	OUT plans_calls    	 	int8,  -- 23
+	OUT plans          	 	int8,  -- 23
    
     OUT total_plan_time     float8,
     OUT min_plan_time       float8,
@@ -168,7 +168,9 @@ BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
 	bucket_start_time AS bucket_start_time,
-    userid::regrole,
+    userid,
+    userid::regrole AS user,
+    dbid,
     datname,
 	'0.0.0.0'::inet + client_ip AS client_ip,
 	pgsm_query_id,
@@ -192,7 +194,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
 	max_exec_time AS max_time,
 	mean_exec_time AS mean_time,
 	stddev_exec_time AS stddev_time,
-	rows_retrieved,
+	rows,
 	shared_blks_hit,
     shared_blks_read,
     shared_blks_dirtied,
@@ -222,7 +224,9 @@ BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
 	bucket_start_time AS bucket_start_time,
-    userid::regrole,
+    userid,
+    userid::regrole AS user,
+    dbid,
     datname,
 	'0.0.0.0'::inet + client_ip AS client_ip,
 	pgsm_query_id,
@@ -247,7 +251,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
 	max_exec_time,
 	mean_exec_time,
 	stddev_exec_time,
-	rows_retrieved,
+	rows,
 	shared_blks_hit,
     shared_blks_read,
     shared_blks_dirtied,
@@ -268,7 +272,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
     wal_bytes,
 	bucket_done,
     -- PostgreSQL-13 Specific Coulumns
-	plans_calls,
+	plans,
 	total_plan_time,
 	min_plan_time,
 	max_plan_time,
@@ -286,7 +290,9 @@ BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
 	bucket_start_time AS bucket_start_time,
-    userid::regrole,
+    userid,
+    userid::regrole AS user,
+    dbid,
     datname,
 	'0.0.0.0'::inet + client_ip AS client_ip,
 	pgsm_query_id,
@@ -311,7 +317,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
 	max_exec_time,
 	mean_exec_time,
 	stddev_exec_time,
-	rows_retrieved,
+	rows,
 	shared_blks_hit,
     shared_blks_read,
     shared_blks_dirtied,
@@ -332,7 +338,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
     wal_bytes,
 	bucket_done,
 
-    plans_calls,
+    plans,
 	total_plan_time,
 	min_plan_time,
 	max_plan_time,
@@ -350,7 +356,9 @@ BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
 	bucket_start_time AS bucket_start_time,
-    userid::regrole,
+    userid,
+    userid::regrole AS user,
+    dbid,
     datname,
 	'0.0.0.0'::inet + client_ip AS client_ip,
 	pgsm_query_id,
@@ -375,7 +383,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
 	max_exec_time,
 	mean_exec_time,
 	stddev_exec_time,
-	rows_retrieved,
+	rows,
 	shared_blks_hit,
     shared_blks_read,
     shared_blks_dirtied,
@@ -399,7 +407,7 @@ CREATE VIEW pg_stat_monitor AS SELECT
     wal_bytes,
 	bucket_done,
 
-    plans_calls,
+    plans,
 	total_plan_time,
 	min_plan_time,
 	max_plan_time,

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1860,12 +1860,12 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 			nulls[i++] = true;
 
 		/* queryid at column number 4 */
-		values[i++] = Int64GetDatumFast(queryid);
+		values[i++] = UInt64GetDatum(queryid);
 
 		/* planid at column number 5 */
 		if (planid)
 		{
-			values[i++] = Int64GetDatumFast(planid);
+			values[i++] = UInt64GetDatum(planid);
 		}
 		else
 		{
@@ -1903,7 +1903,7 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 			values[i++] = CStringGetTextDatum("<insufficient privilege>");
 		}
 
-		values[i++] = Int64GetDatumFast(pgsm_query_id);
+		values[i++] = UInt64GetDatum(pgsm_query_id);
 
 		/* state at column number 8 for V1.0 API*/
 		if (api_version <= PGSM_V1_0)
@@ -1912,7 +1912,7 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 		/* parentid at column number 9 */
 		if (tmp.info.parentid != UINT64CONST(0))
 		{
-			values[i++] = Int64GetDatumFast(tmp.info.parentid);
+			values[i++] = UInt64GetDatum(tmp.info.parentid);
 			values[i++] = CStringGetTextDatum(parent_query_txt);
 		}
 		else

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1724,7 +1724,6 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 	MemoryContext oldcontext;
 	PGSM_HASH_SEQ_STATUS hstat;
 	pgssEntry  *entry;
-	char		parentid_txt[32];
 	pgssSharedState *pgss;
 	char	   *query_txt = NULL;
 	char	   *parent_query_txt = NULL;
@@ -1778,15 +1777,13 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 		int			i = 0;
 		Counters	tmp;
 		double		stddev;
-		char		queryid_text[32] = {0};
-		char		planid_text[32] = {0};
 		uint64		queryid = entry->key.queryid;
 		int64		bucketid = entry->key.bucket_id;
 		uint64		dbid = entry->key.dbid;
 		uint64		userid = entry->key.userid;
 		int64		ip = entry->key.ip;
 		uint64		planid = entry->key.planid;
-    uint64		pgsm_query_id = entry->pgsm_query_id;
+		uint64		pgsm_query_id = entry->pgsm_query_id;
 		dsa_area	*query_dsa_area;
 		char 		*query_ptr;
 #if PG_VERSION_NUM < 140000
@@ -1863,14 +1860,12 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 			nulls[i++] = true;
 
 		/* queryid at column number 4 */
-		snprintf(queryid_text, 32, "%08lX", queryid);
-		values[i++] = CStringGetTextDatum(queryid_text);
+		values[i++] = Int64GetDatumFast(queryid);
 
 		/* planid at column number 5 */
 		if (planid)
 		{
-			snprintf(planid_text, 32, "%08lX", planid);
-			values[i++] = CStringGetTextDatum(planid_text);
+			values[i++] = Int64GetDatumFast(planid);
 		}
 		else
 		{
@@ -1917,8 +1912,7 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 		/* parentid at column number 9 */
 		if (tmp.info.parentid != UINT64CONST(0))
 		{
-			snprintf(parentid_txt, 32, "%08lX", tmp.info.parentid);
-			values[i++] = CStringGetTextDatum(parentid_txt);
+			values[i++] = Int64GetDatumFast(tmp.info.parentid);
 			values[i++] = CStringGetTextDatum(parent_query_txt);
 		}
 		else

--- a/regression/expected/rows.out
+++ b/regression/expected/rows.out
@@ -8540,14 +8540,14 @@ SELECt * FROM t2  WHERE b % 2 = 0;
  5000
 (2500 rows)
 
-SELECT query, rows_retrieved FROM pg_stat_monitor ORDER BY query COLLATE "C";
-               query               | rows_retrieved 
------------------------------------+----------------
- SELECT * FROM t1                  |           1000
- SELECT * FROM t1 LIMIT 10         |             10
- SELECT * FROM t2                  |           5000
- SELECT pg_stat_monitor_reset()    |              1
- SELECt * FROM t2  WHERE b % 2 = 0 |           2500
+SELECT query, rows FROM pg_stat_monitor ORDER BY query COLLATE "C";
+               query               | rows 
+-----------------------------------+------
+ SELECT * FROM t1                  | 1000
+ SELECT * FROM t1 LIMIT 10         |   10
+ SELECT * FROM t2                  | 5000
+ SELECT pg_stat_monitor_reset()    |    1
+ SELECt * FROM t2  WHERE b % 2 = 0 | 2500
 (5 rows)
 
 SELECT pg_stat_monitor_reset();

--- a/regression/sql/rows.sql
+++ b/regression/sql/rows.sql
@@ -12,7 +12,7 @@ SELECT * FROM t2;
 SELECT * FROM t1 LIMIT 10;
 SELECt * FROM t2  WHERE b % 2 = 0;
 
-SELECT query, rows_retrieved FROM pg_stat_monitor ORDER BY query COLLATE "C";
+SELECT query, rows FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset();
 
 DROP TABLE t1;

--- a/t/005_settings_pgsm_enable_query_plan.pl
+++ b/t/005_settings_pgsm_enable_query_plan.pl
@@ -63,7 +63,7 @@ PGSM::append_to_file($stdout);
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT planid FROM pg_stat_monitor WHERE calls = 2;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
 trim($stdout);
 isnt($stdout,'',"Test: planid should not be empty");
-ok(length($stdout) == 16, 'Length of planid is 16');
+ok(length($stdout) > 0, 'Length of planid is > 0');
 
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_enable_query_plan = 'no'\n");
 $node->restart();

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -26,48 +26,48 @@ close $conf;
 my %pg_versions_pgsm_columns = ( 15 => "application_name,blk_read_time," .
     "blk_write_time,bucket,bucket_done,bucket_start_time,calls," .
     "client_ip,cmd_type,cmd_type_text,comments,cpu_sys_time,cpu_user_time," .
-    "datname,elevel,jit_emission_count,jit_emission_time,jit_functions," .
+    "datname,dbid,elevel,jit_emission_count,jit_emission_time,jit_functions," .
     "jit_generation_time,jit_inlining_count,jit_inlining_time," .
     "jit_optimization_count,jit_optimization_time," .
     "local_blks_dirtied,local_blks_hit,local_blks_read," .
     "local_blks_written,max_exec_time,max_plan_time,mean_exec_time," .
     "mean_plan_time,message,min_exec_time,min_plan_time,pgsm_query_id,planid," .
-    "plans_calls,query,query_plan,queryid,relations,resp_calls," .
-    "rows_retrieved,shared_blks_dirtied,shared_blks_hit,shared_blks_read," .
+    "plans,query,query_plan,queryid,relations,resp_calls," .
+    "rows,shared_blks_dirtied,shared_blks_hit,shared_blks_read," .
     "shared_blks_written,sqlcode,stddev_exec_time,stddev_plan_time," .
     "temp_blk_read_time,temp_blk_write_time,temp_blks_read,temp_blks_written," .
     "top_query,top_queryid,toplevel,total_exec_time,total_plan_time," .
-    "userid,wal_bytes,wal_fpi,wal_records",
+    "user,userid,wal_bytes,wal_fpi,wal_records",
  14 => "application_name,blk_read_time," .
     "blk_write_time,bucket,bucket_done,bucket_start_time,calls," .
     "client_ip,cmd_type,cmd_type_text,comments,cpu_sys_time,cpu_user_time," .
-    "datname,elevel,local_blks_dirtied,local_blks_hit,local_blks_read," .
+    "datname,dbid,elevel,local_blks_dirtied,local_blks_hit,local_blks_read," .
     "local_blks_written,max_exec_time,max_plan_time,mean_exec_time," .
     "mean_plan_time,message,min_exec_time,min_plan_time,pgsm_query_id,planid," .
-    "plans_calls,query,query_plan,queryid,relations,resp_calls," .
-    "rows_retrieved,shared_blks_dirtied,shared_blks_hit,shared_blks_read," .
+    "plans,query,query_plan,queryid,relations,resp_calls," .
+    "rows,shared_blks_dirtied,shared_blks_hit,shared_blks_read," .
     "shared_blks_written,sqlcode,stddev_exec_time,stddev_plan_time," .
     "temp_blks_read,temp_blks_written,top_query,top_queryid,toplevel," .
-    "total_exec_time,total_plan_time,userid,wal_bytes,wal_fpi,wal_records",
+    "total_exec_time,total_plan_time,user,userid,wal_bytes,wal_fpi,wal_records",
  13 => "application_name,blk_read_time," .
     "blk_write_time,bucket,bucket_done,bucket_start_time,calls," .
     "client_ip,cmd_type,cmd_type_text,comments,cpu_sys_time,cpu_user_time," .
-    "datname,elevel,local_blks_dirtied,local_blks_hit,local_blks_read," .
+    "datname,dbid,elevel,local_blks_dirtied,local_blks_hit,local_blks_read," .
     "local_blks_written,max_exec_time,max_plan_time,mean_exec_time," .
     "mean_plan_time,message,min_exec_time,min_plan_time,pgsm_query_id,planid," .
-    "plans_calls,query,query_plan,queryid,relations,resp_calls," .
-    "rows_retrieved,shared_blks_dirtied,shared_blks_hit,shared_blks_read," .
+    "plans,query,query_plan,queryid,relations,resp_calls," .
+    "rows,shared_blks_dirtied,shared_blks_hit,shared_blks_read," .
     "shared_blks_written,sqlcode,stddev_exec_time,stddev_plan_time," .
     "temp_blks_read,temp_blks_written,top_query,top_queryid,toplevel," .
-    "total_exec_time,total_plan_time,userid,wal_bytes,wal_fpi,wal_records",
+    "total_exec_time,total_plan_time,user,userid,wal_bytes,wal_fpi,wal_records",
  12 => "application_name,blk_read_time,blk_write_time,bucket,bucket_done," .
     "bucket_start_time,calls,client_ip,cmd_type,cmd_type_text,comments," .
-    "cpu_sys_time,cpu_user_time,datname,elevel,local_blks_dirtied," .
+    "cpu_sys_time,cpu_user_time,datname,dbid,elevel,local_blks_dirtied," .
     "local_blks_hit,local_blks_read,local_blks_written,max_time,mean_time," .
     "message,min_time,pgsm_query_id,planid,query,query_plan,queryid,relations,resp_calls," .
-    "rows_retrieved,shared_blks_dirtied,shared_blks_hit,shared_blks_read," .
+    "rows,shared_blks_dirtied,shared_blks_hit,shared_blks_read," .
     "shared_blks_written,sqlcode,stddev_time,temp_blks_read,temp_blks_written," .
-    "top_query,top_queryid,total_time,userid"
+    "top_query,top_queryid,total_time,user,userid"
  );
 
 # Start server


### PR DESCRIPTION
The view now carries all the columns as pg_stat_statements. This required fixing data types of some of the columns, renaming a few, as well inclusion of new columns to make the view fully compatible with pg_stat_statements.