### PR TITLE
PG-582: blk_read_time and blk_write_time are not being rounded.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -2061,13 +2061,13 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 		values[i++] = Int64GetDatumFast(tmp.blocks.local_blks_written);
 		values[i++] = Int64GetDatumFast(tmp.blocks.temp_blks_read);
 		values[i++] = Int64GetDatumFast(tmp.blocks.temp_blks_written);
-		values[i++] = Float8GetDatumFast(tmp.blocks.blk_read_time);
-		values[i++] = Float8GetDatumFast(tmp.blocks.blk_write_time);
+		values[i++] = Float8GetDatumFast(roundf(tmp.blocks.blk_read_time, 4));
+		values[i++] = Float8GetDatumFast(roundf(tmp.blocks.blk_write_time, 4));
 
 		if (api_version >= PGSM_V2_0)
 		{
-			values[i++] = Float8GetDatumFast(tmp.blocks.temp_blk_read_time);
-			values[i++] = Float8GetDatumFast(tmp.blocks.temp_blk_write_time);
+			values[i++] = Float8GetDatumFast(roundf(tmp.blocks.temp_blk_read_time, 4));
+			values[i++] = Float8GetDatumFast(roundf(tmp.blocks.temp_blk_write_time, 4));
 		}
 
 		/* resp_calls at column number 41 */

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -2107,13 +2107,13 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 			if (api_version >= PGSM_V2_0)
 			{
 				values[i++] = Int64GetDatumFast(tmp.jitinfo.jit_functions);
-				values[i++] = Float8GetDatumFast(tmp.jitinfo.jit_generation_time);
+				values[i++] = Float8GetDatumFast(roundf(tmp.jitinfo.jit_generation_time, 4));
 				values[i++] = Int64GetDatumFast(tmp.jitinfo.jit_inlining_count);
-				values[i++] = Float8GetDatumFast(tmp.jitinfo.jit_inlining_time);
+				values[i++] = Float8GetDatumFast(roundf(tmp.jitinfo.jit_inlining_time, 4));
 				values[i++] = Int64GetDatumFast(tmp.jitinfo.jit_optimization_count);
-				values[i++] = Float8GetDatumFast(tmp.jitinfo.jit_optimization_time);
+				values[i++] = Float8GetDatumFast(roundf(tmp.jitinfo.jit_optimization_time, 4));
 				values[i++] = Int64GetDatumFast(tmp.jitinfo.jit_emission_count);
-				values[i++] = Float8GetDatumFast(tmp.jitinfo.jit_emission_time);
+				values[i++] = Float8GetDatumFast(roundf(tmp.jitinfo.jit_emission_time, 4));
 			}
 
 		}


### PR DESCRIPTION
Added the round off within the internal function so that values for blk_read_time, blk_write_time are rounded off to 4 decimal places.

Additionally, added rounding off for the PG15+ columns of temp_blk_read_time and temp_blk_write_time.