### PR TITLE
PG-581: top_queryid expected output verification and change.

### DIFF
--- a/regression/expected/top_query.out
+++ b/regression/expected/top_query.out
@@ -24,9 +24,9 @@ SELECT add2(1,2);
 (1 row)
 
 SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                            query                             |    top_query     
---------------------------------------------------------------+------------------
- (select $1 + $2)                                             | SELECT add2(1,2)
+                            query                             |     top_query     
+--------------------------------------------------------------+-------------------
+ (select $1 + $2)                                             | SELECT add2(1,2);
  CREATE OR REPLACE FUNCTION add(int, int) RETURNS INTEGER AS +| 
  $$                                                          +| 
  BEGIN                                                       +| 

--- a/regression/expected/top_query_1.out
+++ b/regression/expected/top_query_1.out
@@ -24,8 +24,8 @@ SELECT add2(1,2);
 (1 row)
 
 SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                            query                             |    top_query     
---------------------------------------------------------------+------------------
+                            query                             |     top_query     
+--------------------------------------------------------------+-------------------
  CREATE OR REPLACE FUNCTION add(int, int) RETURNS INTEGER AS +| 
  $$                                                          +| 
  BEGIN                                                       +| 
@@ -37,7 +37,7 @@ SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
          return add($1,$2);                                  +| 
  END;                                                        +| 
  $$ language plpgsql                                          | 
- SELECT (select $1 + $2)                                      | SELECT add2(1,2)
+ SELECT (select $1 + $2)                                      | SELECT add2(1,2);
  SELECT add2(1,2)                                             | 
  SELECT pg_stat_monitor_reset()                               | 
 (5 rows)


### PR DESCRIPTION
top_queryid test case was failing on all PG versions, pushing an update to expected output files. 