### PR TITLE
PG-562: Histogram Ranges/Buckets are not correct.

### DIFF
--- a/guc.c
+++ b/guc.c
@@ -150,7 +150,7 @@ init_guc(void)
 			.guc_max = MAX_RESPONSE_BUCKET,
 			.guc_restart = true,
 			.guc_unit = 0,
-			.guc_value = &PGSM_HISTOGRAM_BUCKETS
+			.guc_value = &PGSM_HISTOGRAM_BUCKETS_USER
 	};
 	DefineIntGUC(&conf[i++]);
 

--- a/pg_stat_monitor--2.0.sql
+++ b/pg_stat_monitor--2.0.sql
@@ -63,7 +63,7 @@ SELECT
 $$
 LANGUAGE SQL PARALLEL SAFE;
 
-CREATE FUNCTION histogram(_bucket int, _quryid text)
+CREATE FUNCTION histogram(_bucket int, _quryid int8)
 RETURNS SETOF RECORD AS $$
 DECLARE
  rec record;
@@ -463,4 +463,3 @@ REVOKE ALL ON FUNCTION pgsm_create_14_view FROM PUBLIC;
 REVOKE ALL ON FUNCTION pgsm_create_15_view FROM PUBLIC;
 
 GRANT SELECT ON pg_stat_monitor TO PUBLIC;
-

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -485,7 +485,15 @@ static const struct config_enum_entry track_options[] =
 #define PGSM_BUCKET_TIME get_conf(5)->guc_variable
 #define PGSM_HISTOGRAM_MIN get_conf(6)->guc_variable
 #define PGSM_HISTOGRAM_MAX get_conf(7)->guc_variable
-#define PGSM_HISTOGRAM_BUCKETS get_conf(8)->guc_variable
+
+/*
+ * Important that we keep user bucket values separate but must add 1
+ * for max outlier queries. However, for min, bucket should only be added
+ * if the minimum value provided by user is greater than 0
+ */
+#define PGSM_HISTOGRAM_BUCKETS_USER get_conf(8)->guc_variable
+#define PGSM_HISTOGRAM_BUCKETS (PGSM_HISTOGRAM_BUCKETS_USER + 1 + (int)(PGSM_HISTOGRAM_MIN > 0))
+
 #define PGSM_QUERY_SHARED_BUFFER get_conf(9)->guc_variable
 #define PGSM_OVERFLOW_TARGET get_conf(10)->guc_variable
 #define PGSM_QUERY_PLAN get_conf(11)->guc_variable

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -485,15 +485,7 @@ static const struct config_enum_entry track_options[] =
 #define PGSM_BUCKET_TIME get_conf(5)->guc_variable
 #define PGSM_HISTOGRAM_MIN get_conf(6)->guc_variable
 #define PGSM_HISTOGRAM_MAX get_conf(7)->guc_variable
-
-/*
- * Important that we keep user bucket values separate but must add 1
- * for max outlier queries. However, for min, bucket should only be added
- * if the minimum value provided by user is greater than 0
- */
 #define PGSM_HISTOGRAM_BUCKETS_USER get_conf(8)->guc_variable
-#define PGSM_HISTOGRAM_BUCKETS (PGSM_HISTOGRAM_BUCKETS_USER + 1 + (int)(PGSM_HISTOGRAM_MIN > 0))
-
 #define PGSM_QUERY_SHARED_BUFFER get_conf(9)->guc_variable
 #define PGSM_OVERFLOW_TARGET get_conf(10)->guc_variable
 #define PGSM_QUERY_PLAN get_conf(11)->guc_variable

--- a/t/009_settings_pgsm_histogram_max.pl
+++ b/t/009_settings_pgsm_histogram_max.pl
@@ -41,18 +41,8 @@ PGSM::append_to_file($stdout);
 ok($cmdret == 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_max = 10\n");
-$node->restart();
-
-($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT pg_stat_monitor_reset();', extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
-ok($cmdret == 0, "Reset PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_max';", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
-ok($cmdret == 0, "Print PGSM EXTENSION Settings");
-PGSM::append_to_file($stdout);
-
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_max = 100\n");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_max = 50\n");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_buckets = 3\n");
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT pg_stat_monitor_reset();', extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);

--- a/t/010_settings_pgsm_histogram_min.pl
+++ b/t/010_settings_pgsm_histogram_min.pl
@@ -41,7 +41,7 @@ PGSM::append_to_file($stdout);
 ok($cmdret == 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_min = 1000\n");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_min = 20\n");
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT pg_stat_monitor_reset();', extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
@@ -52,18 +52,7 @@ PGSM::append_to_file($stdout);
 ok($cmdret == 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_min = 10000\n");
-$node->restart();
-
-($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT pg_stat_monitor_reset();', extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
-ok($cmdret == 0, "Reset PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_min';", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
-ok($cmdret == 0, "Print PGSM EXTENSION Settings");
-PGSM::append_to_file($stdout);
-
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_min = 99999\n");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_min = 100\n");
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT pg_stat_monitor_reset();', extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);

--- a/t/expected/009_settings_pgsm_histogram_max.out
+++ b/t/expected/009_settings_pgsm_histogram_max.out
@@ -20,19 +20,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_max';
                 name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_histogram_max | 10      |      | postmaster | integer | configuration file | 10      | 2147483647 |          | 100000   | 10        | f
-(1 row)
-
-SELECT pg_stat_monitor_reset();
- pg_stat_monitor_reset 
------------------------
- 
-(1 row)
-
-SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_max';
-                name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
-------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_histogram_max | 100     |      | postmaster | integer | configuration file | 10      | 2147483647 |          | 100000   | 100       | f
+ pg_stat_monitor.pgsm_histogram_max | 50      |      | postmaster | integer | configuration file | 10      | 2147483647 |          | 100000   | 50        | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();

--- a/t/expected/010_settings_pgsm_histogram_min.out
+++ b/t/expected/010_settings_pgsm_histogram_min.out
@@ -20,7 +20,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_min';
                 name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_histogram_min | 1000    |      | postmaster | integer | configuration file | 0       | 2147483647 |          | 1        | 1000      | f
+ pg_stat_monitor.pgsm_histogram_min | 20      |      | postmaster | integer | configuration file | 0       | 2147483647 |          | 1        | 20        | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -32,19 +32,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_min';
                 name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_histogram_min | 10000   |      | postmaster | integer | configuration file | 0       | 2147483647 |          | 1        | 10000     | f
-(1 row)
-
-SELECT pg_stat_monitor_reset();
- pg_stat_monitor_reset 
------------------------
- 
-(1 row)
-
-SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_min';
-                name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
-------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_histogram_min | 99999   |      | postmaster | integer | configuration file | 0       | 2147483647 |          | 1        | 99999     | f
+ pg_stat_monitor.pgsm_histogram_min | 100     |      | postmaster | integer | configuration file | 0       | 2147483647 |          | 1        | 100       | f
 (1 row)
 
 DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
Added buckets for queries that take less than minimum histogram time and one for the ones taking more than the max value specified.

Also, in case the buckets end up overlapping, on server start, an error will be thrown informing the user of this issue and requesting a rectification.

Refactored the code to consolidate the calculations in a single function.