### PR TITLE
PG-588: Some queries are not being normalised.

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1535,7 +1535,7 @@ pgss_store(uint64 queryid,
 		 * in the interval where we don't hold the lock below.  That case is
 		 * handled by entry_alloc.
 		 */
-		if (jstate && jstate->clocations_count > 0)
+		if (jstate)
 		{
 			norm_query_len = query_len;
 


### PR DESCRIPTION
There is no specific test case where I can either reproduce or validate the fix. Though, one of the suspects is this condition in pgss_store. Therefore removed, and it requires verification.