### PR TITLE
PG-603: Fix/Update String::Util module in TAP test perl.

### DIFF
--- a/.github/workflows/code-coverage-test.yml
+++ b/.github/workflows/code-coverage-test.yml
@@ -29,8 +29,7 @@ jobs:
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Create pgsql dir
         run: mkdir -p /opt/pgsql

--- a/.github/workflows/postgresql-12-build.yml
+++ b/.github/workflows/postgresql-12-build.yml
@@ -28,8 +28,7 @@ jobs:
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Create pgsql dir
         run: mkdir -p /opt/pgsql

--- a/.github/workflows/postgresql-12-pgdg-package.yml
+++ b/.github/workflows/postgresql-12-pgdg-package.yml
@@ -24,8 +24,7 @@ jobs:
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install PG Distribution Postgresql 12
         run: |

--- a/.github/workflows/postgresql-12-ppg-package.yml
+++ b/.github/workflows/postgresql-12-ppg-package.yml
@@ -27,8 +27,7 @@ jobs:
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install percona-release script
         run: |

--- a/.github/workflows/postgresql-13-build.yml
+++ b/.github/workflows/postgresql-13-build.yml
@@ -28,8 +28,7 @@ jobs:
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Create pgsql dir
         run: mkdir -p /opt/pgsql

--- a/.github/workflows/postgresql-13-pgdg-package.yml
+++ b/.github/workflows/postgresql-13-pgdg-package.yml
@@ -24,8 +24,7 @@ jobs:
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install PG Distribution Postgresql 13
         run: |

--- a/.github/workflows/postgresql-13-ppg-package.yml
+++ b/.github/workflows/postgresql-13-ppg-package.yml
@@ -24,8 +24,7 @@ jobs:
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install percona-release script
         run: |

--- a/.github/workflows/postgresql-14-build.yml
+++ b/.github/workflows/postgresql-14-build.yml
@@ -29,8 +29,7 @@ jobs:
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Create pgsql dir
         run: mkdir -p /opt/pgsql

--- a/.github/workflows/postgresql-14-pgdg-package.yml
+++ b/.github/workflows/postgresql-14-pgdg-package.yml
@@ -23,8 +23,7 @@ jobs:
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install PG Distribution Postgresql 14
         run: |

--- a/.github/workflows/postgresql-14-ppg-package.yml
+++ b/.github/workflows/postgresql-14-ppg-package.yml
@@ -24,8 +24,7 @@ jobs:
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install percona-release script
         run: |

--- a/.github/workflows/postgresql-15-build.yml
+++ b/.github/workflows/postgresql-15-build.yml
@@ -29,8 +29,7 @@ jobs:
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Create pgsql dir
         run: mkdir -p /opt/pgsql

--- a/.github/workflows/postgresql-15-pgdg-package.yml
+++ b/.github/workflows/postgresql-15-pgdg-package.yml
@@ -23,8 +23,7 @@ jobs:
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install PG Distribution Postgresql 15
         run: |

--- a/.github/workflows/postgresql-15-ppg-package.yml
+++ b/.github/workflows/postgresql-15-ppg-package.yml
@@ -24,8 +24,7 @@ jobs:
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
           sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
-          sudo /usr/bin/perl -MCPAN -e 'install String::Util'
-          sudo /usr/bin/perl -MCPAN -e 'install Data::Str2Num'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install percona-release script
         run: |

--- a/t/001_settings_default.pl
+++ b/t/001_settings_default.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/002_settings_pgsm_track_planning.pl
+++ b/t/002_settings_pgsm_track_planning.pl
@@ -5,7 +5,7 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
+use Text::Trim qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/003_settings_pgms_extract_comments.pl
+++ b/t/003_settings_pgms_extract_comments.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/004_settings_pgsm_track.pl
+++ b/t/004_settings_pgsm_track.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/005_settings_pgsm_enable_query_plan.pl
+++ b/t/005_settings_pgsm_enable_query_plan.pl
@@ -5,7 +5,7 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
+use Text::Trim qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/006_settings_pgsm_overflow_target.pl
+++ b/t/006_settings_pgsm_overflow_target.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/007_settings_pgsm_query_shared_buffer.pl
+++ b/t/007_settings_pgsm_query_shared_buffer.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/008_settings_pgsm_histogram_buckets.pl
+++ b/t/008_settings_pgsm_histogram_buckets.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/009_settings_pgsm_histogram_max.pl
+++ b/t/009_settings_pgsm_histogram_max.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/010_settings_pgsm_histogram_min.pl
+++ b/t/010_settings_pgsm_histogram_min.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/011_settings_pgsm_bucket_time.pl
+++ b/t/011_settings_pgsm_bucket_time.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/012_settings_pgsm_max_buckets.pl
+++ b/t/012_settings_pgsm_max_buckets.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/013_settings_pgsm_normalized_query.pl
+++ b/t/013_settings_pgsm_normalized_query.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/014_settings_pgsm_track_utility.pl
+++ b/t/014_settings_pgsm_track_utility.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/015_settings_pgsm_query_max_len.pl
+++ b/t/015_settings_pgsm_query_max_len.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/016_settings_pgsm_max.pl
+++ b/t/016_settings_pgsm_max.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/017_execution_stats.pl
+++ b/t/017_execution_stats.pl
@@ -5,7 +5,7 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
+use Text::Trim qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/019_insufficient_shared_space.pl
+++ b/t/019_insufficient_shared_space.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/020_buffer_overflow.pl
+++ b/t/020_buffer_overflow.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/021_misc_1.pl
+++ b/t/021_misc_1.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/022_misc_2.pl
+++ b/t/022_misc_2.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/024_check_timings.pl
+++ b/t/024_check_timings.pl
@@ -5,7 +5,7 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
+use Text::Trim qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/025_compare_pgss.pl
+++ b/t/025_compare_pgss.pl
@@ -5,7 +5,7 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
+use Text::Trim qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/026_shared_blocks.pl
+++ b/t/026_shared_blocks.pl
@@ -5,7 +5,7 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
+use Text::Trim qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/027_local_blocks.pl
+++ b/t/027_local_blocks.pl
@@ -5,7 +5,7 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
+use Text::Trim qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/028_temp_block.pl
+++ b/t/028_temp_block.pl
@@ -5,7 +5,7 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
+use Text::Trim qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/029_bucket_done.pl
+++ b/t/029_bucket_done.pl
@@ -5,7 +5,6 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/030_histogram.pl
+++ b/t/030_histogram.pl
@@ -5,7 +5,7 @@ use warnings;
 use File::Basename;
 use File::Compare;
 use File::Copy;
-use String::Util qw(trim);
+use Text::Trim qw(trim);
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/pgsm.pm
+++ b/t/pgsm.pm
@@ -1,6 +1,5 @@
 package PGSM;
 
-use String::Util qw(trim);
 use File::Basename;
 use File::Compare;
 use Test::More;


### PR DESCRIPTION
Removed use of String::Util perl module from TAP test cases, and now using Text::Trim module instead, as that is more stable. Also removed the Data::Str2Num perl module as it was not needed any more.