### PR TITLE
PG-606: New GUC required for enabling/disabling of pgsm_query_id calculation…

### DIFF
--- a/guc.c
+++ b/guc.c
@@ -18,289 +18,262 @@
 
 #include "pg_stat_monitor.h"
 
-GucVariable conf[MAX_SETTINGS];
-static void DefineIntGUC(GucVariable * conf);
-static void DefineIntGUCWithCheck(GucVariable * conf, GucIntCheckHook check);
-static void DefineBoolGUC(GucVariable * conf);
-static void DefineEnumGUC(GucVariable * conf, const struct config_enum_entry *options);
+/* GUC variables */
+int pgsm_max;
+int pgsm_query_max_len;
+int pgsm_bucket_time;
+int pgsm_max_buckets;
+int pgsm_histogram_buckets;
+int pgsm_histogram_max;
+int pgsm_histogram_min;
+int pgsm_query_shared_buffer;
+bool pgsm_track_planning;
+bool pgsm_extract_comments;
+bool pgsm_enable_query_plan;
+bool pgsm_enable_overflow;
+bool pgsm_normalized_query;
+bool pgsm_track_utility;
+bool pgsm_enable_pgsm_query_id;
+int pgsm_track;
+static int pgsm_overflow_target; /* Not used since 2.0 */
 
 /* Check hooks to ensure histogram_min < histogram_max */
 static bool check_histogram_min(int *newval, void **extra, GucSource source);
 static bool check_histogram_max(int *newval, void **extra, GucSource source);
-
+static bool check_overflow_targer(int *newval, void **extra, GucSource source);
 /*
  * Define (or redefine) custom GUC variables.
  */
 void
 init_guc(void)
 {
-	int			i = 0,
-				j;
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_max",
-			.guc_desc = "Sets the maximum size of shared memory in (MB) used for statement's metadata tracked by pg_stat_monitor.",
-			.guc_default = 256,
-			.guc_min = 10,
-			.guc_max = 10240,
-			.guc_restart = true,
-			.guc_unit = GUC_UNIT_MB,
-			.guc_value = &PGSM_MAX
-	};
-	DefineIntGUC(&conf[i++]);
+	DefineCustomIntVariable("pg_stat_monitor.pgsm_max", /* name */
+ 							"Sets the maximum size of shared memory in (MB) used for statement's metadata tracked by pg_stat_monitor.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_max, /* value address */
+							256, /* boot value */
+							10, /* min value */
+							10240, /* max value */
+							PGC_POSTMASTER, /* context */
+							GUC_UNIT_MB, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_query_max_len",
-			.guc_desc = "Sets the maximum length of query.",
-			.guc_default = 2048,
-			.guc_min = 1024,
-			.guc_max = INT_MAX,
-			.guc_unit = 0,
-			.guc_restart = true,
-			.guc_value = &PGSM_QUERY_MAX_LEN
-	};
-	DefineIntGUC(&conf[i++]);
+	DefineCustomIntVariable("pg_stat_monitor.pgsm_query_max_len", /* name */
+ 							"Sets the maximum length of query.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_query_max_len, /* value address */
+							2048, /* boot value */
+							1024, /* min value */
+							INT_MAX, /* max value */
+							PGC_POSTMASTER, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_track_utility",
-			.guc_desc = "Selects whether utility commands are tracked.",
-			.guc_default = 1,
-			.guc_min = 0,
-			.guc_max = 0,
-			.guc_restart = false,
-			.guc_unit = 0,
-			.guc_value = &PGSM_TRACK_UTILITY
-	};
-	DefineBoolGUC(&conf[i++]);
+	DefineCustomIntVariable("pg_stat_monitor.pgsm_max_buckets", /* name */
+ 							"Sets the maximum number of buckets.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_max_buckets, /* value address */
+							10, /* boot value */
+							1, /* min value */
+							20000, /* max value */
+							PGC_POSTMASTER, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_normalized_query",
-			.guc_desc = "Selects whether save query in normalized format.",
-			.guc_default = 0,
-			.guc_min = 0,
-			.guc_max = 0,
-			.guc_restart = false,
-			.guc_unit = 0,
-			.guc_value = &PGSM_NORMALIZED_QUERY
-	};
-	DefineBoolGUC(&conf[i++]);
+	DefineCustomIntVariable("pg_stat_monitor.pgsm_bucket_time", /* name */
+ 							"Sets the time in seconds per bucket.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_bucket_time, /* value address */
+							60, /* boot value */
+							1, /* min value */
+							INT_MAX, /* max value */
+							PGC_POSTMASTER, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_max_buckets",
-			.guc_desc = "Sets the maximum number of buckets.",
-			.guc_default = 10,
-			.guc_min = 1,
-			.guc_max = 20000,
-			.guc_restart = true,
-			.guc_unit = 0,
-			.guc_value = &PGSM_MAX_BUCKETS
-	};
-	DefineIntGUC(&conf[i++]);
+	DefineCustomIntVariable("pg_stat_monitor.pgsm_histogram_min", /* name */
+ 							"Sets the time in millisecond.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_histogram_min, /* value address */
+							1, /* boot value */
+							0, /* min value */
+							INT_MAX, /* max value */
+							PGC_POSTMASTER, /* context */
+							0, /* flags */
+							check_histogram_min, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_bucket_time",
-			.guc_desc = "Sets the time in seconds per bucket.",
-			.guc_default = 60,
-			.guc_min = 1,
-			.guc_max = INT_MAX,
-			.guc_restart = true,
-			.guc_unit = 0,
-			.guc_value = &PGSM_BUCKET_TIME
-	};
-	DefineIntGUC(&conf[i++]);
+	DefineCustomIntVariable("pg_stat_monitor.pgsm_histogram_max", /* name */
+ 							"Sets the time in millisecond.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_histogram_max, /* value address */
+							100000, /* boot value */
+							10, /* min value */
+							INT_MAX, /* max value */
+							PGC_POSTMASTER, /* context */
+							0, /* flags */
+							check_histogram_max, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_histogram_min",
-			.guc_desc = "Sets the time in millisecond.",
-			.guc_default = 1,
-			.guc_min = 0,
-			.guc_max = INT_MAX,
-			.guc_restart = true,
-			.guc_unit = 0,
-			.guc_value = &PGSM_HISTOGRAM_MIN
-	};
-	DefineIntGUCWithCheck(&conf[i++], check_histogram_min);
+	DefineCustomIntVariable("pg_stat_monitor.pgsm_histogram_buckets", /* name */
+ 							"Sets the maximum number of histogram buckets.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_histogram_buckets, /* value address */
+							20, /* boot value */
+							2, /* min value */
+							MAX_RESPONSE_BUCKET, /* max value */
+							PGC_POSTMASTER, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_histogram_max",
-			.guc_desc = "Sets the time in millisecond.",
-			.guc_default = 100000,
-			.guc_min = 10,
-			.guc_max = INT_MAX,
-			.guc_restart = true,
-			.guc_unit = 0,
-			.guc_value = &PGSM_HISTOGRAM_MAX
-	};
-	DefineIntGUCWithCheck(&conf[i++], check_histogram_max);
+	DefineCustomIntVariable("pg_stat_monitor.pgsm_query_shared_buffer", /* name */
+ 							"Sets the maximum size of shared memory in (MB) used for query tracked by pg_stat_monitor.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_query_shared_buffer, /* value address */
+							20, /* boot value */
+							1, /* min value */
+							10000, /* max value */
+							PGC_POSTMASTER, /* context */
+							GUC_UNIT_MB, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_histogram_buckets",
-			.guc_desc = "Sets the maximum number of histogram buckets",
-			.guc_default = 20,
-			.guc_min = 2,
-			.guc_max = MAX_RESPONSE_BUCKET,
-			.guc_restart = true,
-			.guc_unit = 0,
-			.guc_value = &PGSM_HISTOGRAM_BUCKETS_USER
-	};
-	DefineIntGUC(&conf[i++]);
+	/* deprecated in V 2.0 */
+	DefineCustomIntVariable("pg_stat_monitor.pgsm_overflow_target", /* name */
+ 							"Sets the overflow target for pg_stat_monitor. (Deprecated, use pgsm_enable_overflow)", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_overflow_target, /* value address */
+							1, /* boot value */
+							0, /* min value */
+							1, /* max value */
+							PGC_POSTMASTER, /* context */
+							0, /* flags */
+							check_overflow_targer, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_query_shared_buffer",
-			.guc_desc = "Sets the maximum size of shared memory in (MB) used for query tracked by pg_stat_monitor.",
-			.guc_default = 20,
-			.guc_min = 1,
-			.guc_max = 10000,
-			.guc_restart = true,
-			.guc_unit = GUC_UNIT_MB,
-			.guc_value = &PGSM_QUERY_SHARED_BUFFER
-	};
-	DefineIntGUC(&conf[i++]);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_overflow_target",
-			.guc_desc = "Sets the overflow target for pg_stat_monitor",
-			.guc_default = 1,
-			.guc_min = 0,
-			.guc_max = 1,
-			.guc_restart = true,
-			.guc_unit = 0,
-			.guc_value = &PGSM_OVERFLOW_TARGET
-	};
-	DefineIntGUC(&conf[i++]);
+	DefineCustomBoolVariable("pg_stat_monitor.pgsm_track_utility", /* name */
+ 							"Selects whether utility commands are tracked.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_track_utility, /* value address */
+							true, /* boot value */
+							PGC_USERSET, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_enable_query_plan",
-			.guc_desc = "Enable/Disable query plan monitoring",
-			.guc_default = 0,
-			.guc_min = 0,
-			.guc_max = 0,
-			.guc_restart = false,
-			.guc_unit = 0,
-			.guc_value = &PGSM_QUERY_PLAN
-	};
-	DefineBoolGUC(&conf[i++]);
+	DefineCustomBoolVariable("pg_stat_monitor.pgsm_enable_pgsm_query_id", /* name */
+ 							"Enable/disable PGSM specific query id calculation which is very useful in comparing same query across databases and clusters..", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_enable_pgsm_query_id, /* value address */
+							true, /* boot value */
+							PGC_USERSET, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
+	
+	DefineCustomBoolVariable("pg_stat_monitor.pgsm_normalized_query", /* name */
+ 							"Selects whether save query in normalized format.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_normalized_query, /* value address */
+							false, /* boot value */
+							PGC_USERSET, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_track",
-			.guc_desc = "Selects which statements are tracked by pg_stat_monitor.",
-			.n_options = 3,
-			.guc_default = PGSM_TRACK_TOP,
-			.guc_min = PSGM_TRACK_NONE,
-			.guc_max = PGSM_TRACK_ALL,
-			.guc_restart = false,
-			.guc_unit = 0,
-			.guc_value = &PGSM_TRACK
-	};
-	for (j = 0; j < conf[i].n_options; ++j)
-	{
-		strlcpy(conf[i].guc_options[j], track_options[j].name, sizeof(conf[i].guc_options[j]));
-	}
-	DefineEnumGUC(&conf[i++], track_options);
+	DefineCustomBoolVariable("pg_stat_monitor.pgsm_enable_overflow", /* name */
+ 							"Enable/Disable pg_stat_monitor to grow beyond shared memory into swap space.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_enable_overflow, /* value address */
+							true, /* boot value */
+							PGC_POSTMASTER, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_extract_comments",
-			.guc_desc = "Enable/Disable extracting comments from queries.",
-			.guc_default = 0,
-			.guc_min = 0,
-			.guc_max = 0,
-			.guc_restart = false,
-			.guc_unit = 0,
-			.guc_value = &PGSM_EXTRACT_COMMENTS
-	};
-	DefineBoolGUC(&conf[i++]);
+	DefineCustomBoolVariable("pg_stat_monitor.pgsm_enable_query_plan", /* name */
+ 							"Enable/Disable query plan monitoring.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_enable_query_plan, /* value address */
+							false, /* boot value */
+							PGC_USERSET, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 
+	DefineCustomBoolVariable("pg_stat_monitor.pgsm_extract_comments", /* name */
+ 							"Enable/Disable extracting comments from queries.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_extract_comments, /* value address */
+							false, /* boot value */
+							PGC_USERSET, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
+
+	DefineCustomEnumVariable("pg_stat_monitor.pgsm_track", /* name */
+ 							"Selects which statements are tracked by pg_stat_monitor.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_track, /* value address */
+							PGSM_TRACK_TOP, /* boot value */
+							track_options, /* enum options */
+							PGC_USERSET, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 #if PG_VERSION_NUM >= 130000
-	conf[i] = (GucVariable)
-	{
-		.guc_name = "pg_stat_monitor.pgsm_track_planning",
-			.guc_desc = "Selects whether planning statistics are tracked.",
-			.guc_default = 0,
-			.guc_min = 0,
-			.guc_max = 0,
-			.guc_restart = false,
-			.guc_unit = 0,
-			.guc_value = &PGSM_TRACK_PLANNING
-	};
-	DefineBoolGUC(&conf[i++]);
+	DefineCustomBoolVariable("pg_stat_monitor.pgsm_track_planning", /* name */
+ 							"Selects whether planning statistics are tracked.", /* short_desc */
+ 							NULL, /* long_desc */
+							&pgsm_track_planning, /* value address */
+							false, /* boot value */
+							PGC_USERSET, /* context */
+							0, /* flags */
+							NULL, /* check_hook */
+							NULL, /* assign_hook */
+							NULL /* show_hook */
+							);
 #endif
-}
 
-static void
-DefineIntGUCWithCheck(GucVariable * conf, GucIntCheckHook check)
-{
-	conf->type = PGC_INT;
-	DefineCustomIntVariable(conf->guc_name,
-							conf->guc_desc,
-							NULL,
-							conf->guc_value,
-							conf->guc_default,
-							conf->guc_min,
-							conf->guc_max,
-							conf->guc_restart ? PGC_POSTMASTER : PGC_USERSET,
-							conf->guc_unit,
-							check,
-							NULL,
-							NULL);
-}
-
-static void
-DefineIntGUC(GucVariable * conf)
-{
-	DefineIntGUCWithCheck(conf, NULL);
-}
-
-static void
-DefineBoolGUC(GucVariable * conf)
-{
-	conf->type = PGC_BOOL;
-	DefineCustomBoolVariable(conf->guc_name,
-							 conf->guc_desc,
-							 NULL,
-							 (bool *) conf->guc_value,
-							 conf->guc_default,
-							 conf->guc_restart ? PGC_POSTMASTER : PGC_USERSET,
-							 0,
-							 NULL,
-							 NULL,
-							 NULL);
-}
-
-static void
-DefineEnumGUC(GucVariable * conf, const struct config_enum_entry *options)
-{
-	conf->type = PGC_ENUM;
-	DefineCustomEnumVariable(conf->guc_name,
-							 conf->guc_desc,
-							 NULL,
-							 conf->guc_value,
-							 conf->guc_default,
-							 options,
-							 conf->guc_restart ? PGC_POSTMASTER : PGC_USERSET,
-							 0,
-							 NULL,
-							 NULL,
-							 NULL);
-}
-
-GucVariable *
-get_conf(int i)
-{
-	return &conf[i];
 }
 
 static bool
@@ -310,11 +283,19 @@ check_histogram_min(int *newval, void **extra, GucSource source)
 	 * During module initialization PGSM_HISTOGRAM_MIN is initialized before
 	 * PGSM_HISTOGRAM_MAX, in this case PGSM_HISTOGRAM_MAX will be zero.
 	 */
-	return (PGSM_HISTOGRAM_MAX == 0 || *newval < PGSM_HISTOGRAM_MAX);
+	return (pgsm_histogram_max == 0 || *newval < pgsm_histogram_max);
 }
 
 static bool
 check_histogram_max(int *newval, void **extra, GucSource source)
 {
-	return (*newval > PGSM_HISTOGRAM_MIN);
+	return (*newval > pgsm_histogram_min);
+}
+
+static bool
+check_overflow_targer(int *newval, void **extra, GucSource source)
+{
+	if (source != PGC_S_DEFAULT)
+		elog(WARNING,"pg_stat_monitor.pgsm_overflow_target is deprecated, use pgsm_enable_overflow");
+	return true;
 }

--- a/hash_query.c
+++ b/hash_query.c
@@ -124,7 +124,7 @@ pgsm_startup(void)
 		/* If overflow is enabled, set the DSA size to unlimited,
 		 * and allow the DSA to grow beyond the shared memory space
 		 * into the swap area*/
-		if (PGSM_OVERFLOW_TARGET == OVERFLOW_TARGET_DISK)
+		if (pgsm_enable_overflow)
 			dsa_set_size_limit(dsa, -1);
 
 		pgsmStateLocal.shared_pgsmState = pgsm;

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1389,7 +1389,7 @@ pgsm_update_entry(pgsmEntry *entry,
 					e->counters.time.max_time = exec_total_time;
 			}
 
-			index = get_histogram_bucket(exec_total_time * 1000.0);
+			index = get_histogram_bucket(exec_total_time);
 			e->counters.resp_calls[index]++;
 		}
 

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -52,8 +52,8 @@ PG_MODULE_MAGIC;
 
 #define pgsm_enabled(level) \
     (!IsParallelWorker() && \
-    (PGSM_TRACK == PGSM_TRACK_ALL || \
-    (PGSM_TRACK == PGSM_TRACK_TOP && (level) == 0)))
+    (pgsm_track == PGSM_TRACK_ALL || \
+    (pgsm_track == PGSM_TRACK_TOP && (level) == 0)))
 
 #define _snprintf2(_str_dst, _str_src, _len1, _len2)\
 do                                                      \
@@ -429,7 +429,7 @@ pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, JumbleState *
 	 */
 	if (query->utilityStmt)
 	{
-		if (PGSM_TRACK_UTILITY && !PGSM_HANDLED_UTILITY(query->utilityStmt))
+		if (pgsm_track_utility && !PGSM_HANDLED_UTILITY(query->utilityStmt))
 			query->queryId = UINT64CONST(0);
 
 		return;
@@ -465,7 +465,7 @@ pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, JumbleState *
 	norm_query_len = query_len;
 
 	/* Generate a normalized query */
-	if (jstate && jstate->clocations_count > 0)
+	if (jstate && jstate->clocations_count > 0 && (pgsm_enable_pgsm_query_id || pgsm_normalized_query) )
 	{
 		norm_query = generate_normalized_query(jstate, 
 												query_text,   		/* query */
@@ -498,7 +498,7 @@ pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, JumbleState *
 	 * In case of query_text, request the function to duplicate it so that
 	 * it is put in the relevant memory context.
 	 */
-	if (PGSM_NORMALIZED_QUERY && norm_query)
+	if (pgsm_normalized_query && norm_query)
 		pgsm_add_to_list(entry, norm_query, norm_query_len);
 	else
 	{
@@ -685,7 +685,7 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 	pgsmEntry  *entry = NULL;
 
 	/* Extract the plan information in case of SELECT statement */
-	if (queryDesc->operation == CMD_SELECT && PGSM_QUERY_PLAN)
+	if (queryDesc->operation == CMD_SELECT && pgsm_enable_query_plan)
 	{
 		plan_info.plan_len = snprintf(plan_info.plan_text, PLAN_TEXT_LEN, "%s", pgsm_explain(queryDesc));
 		plan_info.planid = pgsm_hash_string(plan_info.plan_text, plan_info.plan_len);
@@ -831,7 +831,7 @@ pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, Par
 
 
 	if (pgsm_enabled(plan_nested_level + exec_nested_level) &&
-		PGSM_TRACK_PLANNING && query_string && parse->queryId != UINT64CONST(0))
+		pgsm_track_planning && query_string && parse->queryId != UINT64CONST(0))
 	{
 		instr_time	start;
 		instr_time	duration;
@@ -970,7 +970,7 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 	 * since we are already measuring the statement's costs at the utility
 	 * level.
 	 */
-	if (PGSM_TRACK_UTILITY && pgsm_enabled(exec_nested_level))
+	if (pgsm_track_utility && pgsm_enabled(exec_nested_level))
 		pstmt->queryId = UINT64CONST(0);
 #endif
 
@@ -988,7 +988,7 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 	 *
 	 * Likewise, we don't track execution of DEALLOCATE.
 	 */
-	if (PGSM_TRACK_UTILITY && pgsm_enabled(exec_nested_level) &&
+	if (pgsm_track_utility && pgsm_enabled(exec_nested_level) &&
 		PGSM_HANDLED_UTILITY(parsetree))
 	{
 		pgsmEntry  *entry;
@@ -1325,7 +1325,7 @@ pgsm_update_entry(pgsmEntry *entry,
 			SpinLockAcquire(&e->mutex);
 
 		/* Extract comments if enabled and only when the query has completed with or without error */
-		if (PGSM_EXTRACT_COMMENTS && kind == PGSM_STORE
+		if (pgsm_extract_comments && kind == PGSM_STORE
 			&& !e->counters.info.comments[0] && comments_len > 0)
 			_snprintf(e->counters.info.comments, comments, comments_len + 1, COMMENTS_LEN);
 
@@ -1409,7 +1409,7 @@ pgsm_update_entry(pgsmEntry *entry,
 			e->counters.info.num_relations = num_relations;
 			_snprintf2(e->counters.info.relations, relations, num_relations, REL_LEN);
 
-			if (exec_nested_level > 0 && e->counters.info.parentid == 0 && PGSM_TRACK == PGSM_TRACK_ALL)
+			if (exec_nested_level > 0 && e->counters.info.parentid == 0 && pgsm_track == PGSM_TRACK_ALL)
 			{
 				if (exec_nested_level >= 0 && exec_nested_level < max_stack_depth)
 				{
@@ -1775,8 +1775,8 @@ pgsm_store(pgsmEntry *entry)
 		char		*query_buff;
 
 		/* New query, truncate length if necessary. */
-		if (query_len > PGSM_QUERY_MAX_LEN)
-			query_len = PGSM_QUERY_MAX_LEN;
+		if (query_len > pgsm_query_max_len)
+			query_len = pgsm_query_max_len;
 
 		/* Save the query text in raw dsa area */
 		query_dsa_area = get_dsa_area_for_query_text();
@@ -1929,7 +1929,7 @@ IsBucketValid(uint64 bucketid)
 
 	TimestampDifference(pgsm->bucket_start_time[bucketid], current_tz,&secs, &microsecs);
 
-	if (secs > (PGSM_BUCKET_TIME * PGSM_MAX_BUCKETS))
+	if (secs > (pgsm_bucket_time * pgsm_max_buckets))
 		return false;
 	return true;
 }
@@ -2051,7 +2051,7 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 		 * In case that query plan is enabled, there is no need to show 0
 		 * planid query
 		 */
-		if (tmp.info.cmd_type == CMD_SELECT && PGSM_QUERY_PLAN && planid == 0)
+		if (tmp.info.cmd_type == CMD_SELECT && pgsm_enable_query_plan && planid == 0)
 			continue;
 
 		if (!IsBucketValid(bucketid))
@@ -2139,7 +2139,10 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 			values[i++] = CStringGetTextDatum("<insufficient privilege>");
 		}
 
-		values[i++] = UInt64GetDatum(pgsm_query_id);
+		if (pgsm_query_id)		
+			values[i++] = UInt64GetDatum(pgsm_query_id);
+		else
+			nulls[i++] = true;
 
 		/* parentid at column number 9 */
 		if (tmp.info.parentid != UINT64CONST(0))
@@ -2379,7 +2382,7 @@ get_next_wbucket(pgsmSharedState *pgsm)
 	 * definitely make the while condition to fail, we can stop the loop as
 	 * another thread has already updated prev_bucket_sec.
 	 */
-	while ((tv.tv_sec - (uint)current_bucket_sec) >= ((uint)PGSM_BUCKET_TIME))
+	while ((tv.tv_sec - (uint)current_bucket_sec) >= ((uint)pgsm_bucket_time))
 	{
 		if (pg_atomic_compare_exchange_u64(&pgsm->prev_bucket_sec, &current_bucket_sec, (uint64)tv.tv_sec))
 		{
@@ -2393,7 +2396,7 @@ get_next_wbucket(pgsmSharedState *pgsm)
 	if (update_bucket)
 	{
 
-		new_bucket_id = (tv.tv_sec / PGSM_BUCKET_TIME) % PGSM_MAX_BUCKETS;
+		new_bucket_id = (tv.tv_sec / pgsm_bucket_time) % pgsm_max_buckets;
 
 		/* Update bucket id and retrieve the previous one. */
 		prev_bucket_id = pg_atomic_exchange_u64(&pgsm->current_wbucket, new_bucket_id);
@@ -2404,7 +2407,7 @@ get_next_wbucket(pgsmSharedState *pgsm)
 		LWLockRelease(pgsm->lock);
 
 		/* Allign the value in prev_bucket_sec to the bucket start time */
-		tv.tv_sec = (tv.tv_sec) - (tv.tv_sec % PGSM_BUCKET_TIME);
+		tv.tv_sec = (tv.tv_sec) - (tv.tv_sec % pgsm_bucket_time);
 
 		pg_atomic_exchange_u64(&pgsm->prev_bucket_sec, (uint64)tv.tv_sec);
 
@@ -2428,10 +2431,16 @@ get_next_wbucket(pgsmSharedState *pgsm)
 uint64
 get_pgsm_query_id_hash(const char *norm_query, int norm_len)
 {
-	char *query = palloc(norm_len + 1);
-	char *q_iter = query;
+	char *query;
+	char *q_iter;
 	char *norm_q_iter = (char *)norm_query;
 	uint64 pgsm_query_id = 0;
+
+	if (!pgsm_enable_pgsm_query_id)
+		return 0;
+
+	query = palloc(norm_len + 1);
+	q_iter = query;
 
 	while (norm_q_iter && *norm_q_iter && norm_q_iter < (norm_query + norm_len))
 	{
@@ -3540,12 +3549,12 @@ set_histogram_bucket_timings(void)
 	int64 b2_end;
 	int b_count;
 
-	hist_bucket_min = PGSM_HISTOGRAM_MIN;
-	hist_bucket_max = PGSM_HISTOGRAM_MAX;
-	hist_bucket_count_user = PGSM_HISTOGRAM_BUCKETS_USER;
+	hist_bucket_min = pgsm_histogram_min;
+	hist_bucket_max = pgsm_histogram_max;
+	hist_bucket_count_user = pgsm_histogram_buckets;
 	b_count = hist_bucket_count_user;
 
-	if (PGSM_HISTOGRAM_BUCKETS_USER >= 2)
+	if (pgsm_histogram_buckets >= 2)
 	{
 		for (; hist_bucket_count_user > 0; hist_bucket_count_user--)
 		{

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -518,22 +518,6 @@ extern bool pgsm_track_utility;
 extern bool pgsm_enable_pgsm_query_id;
 extern int pgsm_track;
 
-//#define PGSM_MAX pgsm_max
-// #define PGSM_QUERY_MAX_LEN pgsm_query_max_len
-// #define PGSM_TRACK_UTILITY pgsm_track_utility
-// #define PGSM_NORMALIZED_QUERY pgsm_normalized_query
-// #define PGSM_MAX_BUCKETS pgsm_max_buckets
-// #define PGSM_BUCKET_TIME pgsm_bucket_time
-// #define PGSM_HISTOGRAM_MIN pgsm_histogram_min
-// #define PGSM_HISTOGRAM_MAX pgsm_histogram_max
-// #define PGSM_HISTOGRAM_BUCKETS_USER pgsm_histogram_buckets
-// #define PGSM_QUERY_SHARED_BUFFER pgsm_query_shared_buffer
-// #define PGSM_OVERFLOW_TARGET get_conf(10)->guc_variable
-// #define PGSM_QUERY_PLAN pgsm_enable_query_plan
-// #define PGSM_TRACK pgsm_track
-//#define PGSM_EXTRACT_COMMENTS pgsm_extract_comments
-//#define PGSM_TRACK_PLANNING pgsm_track_planning
-
 #define DECLARE_HOOK(hook, ...) \
         static hook(__VA_ARGS__);
 #define HOOK(name) name

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -92,8 +92,8 @@
 /* the assumption of query max nested level */
 #define DEFAULT_MAX_NESTED_LEVEL	10
 
-#define MAX_QUERY_BUF						(PGSM_QUERY_SHARED_BUFFER * 1024 * 1024)
-#define MAX_BUCKETS_MEM 					(PGSM_MAX * 1024 * 1024)
+#define MAX_QUERY_BUF						(pgsm_query_shared_buffer * 1024 * 1024)
+#define MAX_BUCKETS_MEM 					(pgsm_max * 1024 * 1024)
 #define BUCKETS_MEM_OVERFLOW() 				((hash_get_num_entries(pgsm_hash) * sizeof(pgsmEntry)) >= MAX_BUCKETS_MEM)
 #define MAX_BUCKET_ENTRIES 					(MAX_BUCKETS_MEM / sizeof(pgsmEntry))
 #define QUERY_BUFFER_OVERFLOW(x,y)  		((x + y + sizeof(uint64) + sizeof(uint64)) > MAX_QUERY_BUF)
@@ -167,23 +167,6 @@ extern volatile bool __pgsm_do_not_capture_error;
 	#define	PGSM_HASH_SEQ_STATUS	HASH_SEQ_STATUS
 #endif
 
-typedef struct GucVariables
-{
-	enum config_type type;		/* PGC_BOOL, PGC_INT, PGC_REAL, PGC_STRING,
-								 * PGC_ENUM */
-	int			guc_variable;
-	char		guc_name[TEXT_LEN];
-	char		guc_desc[TEXT_LEN];
-	int			guc_default;
-	int			guc_min;
-	int			guc_max;
-	int			guc_unit;
-	int		   *guc_value;
-	bool		guc_restart;
-	int			n_options;
-	char		guc_options[MAX_ENUM_OPTIONS][32];
-}			GucVariable;
-
 
 #if PG_VERSION_NUM < 130000
 typedef struct WalUsage
@@ -194,11 +177,6 @@ typedef struct WalUsage
 } WalUsage;
 #endif
 
-typedef enum OVERFLOW_TARGET
-{
-	OVERFLOW_TARGET_NONE = 0,
-	OVERFLOW_TARGET_DISK
-}			OVERFLOW_TARGET;
 
 typedef enum pgsmStoreKind
 {
@@ -475,7 +453,6 @@ typedef struct JumbleState
 
 /* guc.c */
 void		init_guc(void);
-GucVariable *get_conf(int i);
 
 /* hash_create.c */
 dsa_area   		*get_dsa_area_for_query_text(void);
@@ -498,6 +475,10 @@ void		pgsm_startup(void);
 /* hash_query.c */
 void		pgsm_startup(void);
 
+/* guc.c */
+void		init_guc(void);
+
+/* GUC variables*/
 /*---- GUC variables ----*/
 typedef enum
 {
@@ -520,21 +501,38 @@ typedef enum
 	HISTOGRAM_COUNT
 } HistogramTimingType;
 
-#define PGSM_MAX get_conf(0)->guc_variable
-#define PGSM_QUERY_MAX_LEN get_conf(1)->guc_variable
-#define PGSM_TRACK_UTILITY get_conf(2)->guc_variable
-#define PGSM_NORMALIZED_QUERY get_conf(3)->guc_variable
-#define PGSM_MAX_BUCKETS get_conf(4)->guc_variable
-#define PGSM_BUCKET_TIME get_conf(5)->guc_variable
-#define PGSM_HISTOGRAM_MIN get_conf(6)->guc_variable
-#define PGSM_HISTOGRAM_MAX get_conf(7)->guc_variable
-#define PGSM_HISTOGRAM_BUCKETS_USER get_conf(8)->guc_variable
-#define PGSM_QUERY_SHARED_BUFFER get_conf(9)->guc_variable
-#define PGSM_OVERFLOW_TARGET get_conf(10)->guc_variable
-#define PGSM_QUERY_PLAN get_conf(11)->guc_variable
-#define PGSM_TRACK get_conf(12)->guc_variable
-#define PGSM_EXTRACT_COMMENTS get_conf(13)->guc_variable
-#define PGSM_TRACK_PLANNING get_conf(14)->guc_variable
+extern int pgsm_max;
+extern int pgsm_query_max_len;
+extern int pgsm_bucket_time;
+extern int pgsm_max_buckets;
+extern int pgsm_histogram_buckets;
+extern int pgsm_histogram_max;
+extern int pgsm_histogram_min;
+extern int pgsm_query_shared_buffer;
+extern bool pgsm_track_planning;
+extern bool pgsm_extract_comments;
+extern bool pgsm_enable_query_plan;
+extern bool pgsm_enable_overflow;
+extern bool pgsm_normalized_query;
+extern bool pgsm_track_utility;
+extern bool pgsm_enable_pgsm_query_id;
+extern int pgsm_track;
+
+//#define PGSM_MAX pgsm_max
+// #define PGSM_QUERY_MAX_LEN pgsm_query_max_len
+// #define PGSM_TRACK_UTILITY pgsm_track_utility
+// #define PGSM_NORMALIZED_QUERY pgsm_normalized_query
+// #define PGSM_MAX_BUCKETS pgsm_max_buckets
+// #define PGSM_BUCKET_TIME pgsm_bucket_time
+// #define PGSM_HISTOGRAM_MIN pgsm_histogram_min
+// #define PGSM_HISTOGRAM_MAX pgsm_histogram_max
+// #define PGSM_HISTOGRAM_BUCKETS_USER pgsm_histogram_buckets
+// #define PGSM_QUERY_SHARED_BUFFER pgsm_query_shared_buffer
+// #define PGSM_OVERFLOW_TARGET get_conf(10)->guc_variable
+// #define PGSM_QUERY_PLAN pgsm_enable_query_plan
+// #define PGSM_TRACK pgsm_track
+//#define PGSM_EXTRACT_COMMENTS pgsm_extract_comments
+//#define PGSM_TRACK_PLANNING pgsm_track_planning
 
 #define DECLARE_HOOK(hook, ...) \
         static hook(__VA_ARGS__);

--- a/regression/expected/guc.out
+++ b/regression/expected/guc.out
@@ -16,23 +16,25 @@ WHERE   name     LIKE     'pg_stat_monitor.%'
 ORDER
 BY      name
 COLLATE "C";
-                   name                   | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time         | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_query_plan   | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets   | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max       | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min       | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                 | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
- pg_stat_monitor.pgsm_max_buckets         | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
- pg_stat_monitor.pgsm_normalized_query    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target     | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len       | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
- pg_stat_monitor.pgsm_query_shared_buffer | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
- pg_stat_monitor.pgsm_track               | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_planning      | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_track_utility       | on      |      | user       | bool    | default |         |            |                | on       | on        | f
-(15 rows)
+                   name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
+ pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
+ pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target      | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len        | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_shared_buffer  | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_planning       | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_track_utility        | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+(17 rows)
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/expected/guc_1.out
+++ b/regression/expected/guc_1.out
@@ -16,22 +16,24 @@ WHERE   name     LIKE     'pg_stat_monitor.%'
 ORDER
 BY      name
 COLLATE "C";
-                   name                   | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time         | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_query_plan   | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets   | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max       | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min       | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                 | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
- pg_stat_monitor.pgsm_max_buckets         | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
- pg_stat_monitor.pgsm_normalized_query    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target     | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len       | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
- pg_stat_monitor.pgsm_query_shared_buffer | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
- pg_stat_monitor.pgsm_track               | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_utility       | on      |      | user       | bool    | default |         |            |                | on       | on        | f
-(14 rows)
+                   name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
+ pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
+ pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target      | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len        | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_shared_buffer  | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_utility        | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+(16 rows)
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/expected/pgsm_query_id.out
+++ b/regression/expected/pgsm_query_id.out
@@ -67,25 +67,35 @@ SELECT *, ADD(1, 2) FROM t1;
 ---+-----
 (0 rows)
 
+set pg_stat_monitor.pgsm_enable_pgsm_query_id = off;
 SELECT * FROM t3;
+ c 
+---
+(0 rows)
+
+set pg_stat_monitor.pgsm_enable_pgsm_query_id = on;
+SELECT * FROM t3 where c = 20;
  c 
 ---
 (0 rows)
 
 \c contrib_regression
 SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_query_id, query, datname;
-      datname       |    pgsm_query_id     |             query              | calls 
---------------------+----------------------+--------------------------------+-------
- db2                | -5029137034974447432 | SELECT * FROM t3               |     1
- contrib_regression |   689150021118383254 | SELECT pg_stat_monitor_reset() |     1
- db1                |  1897482803466821995 | SELECT * FROM t2               |     3
- db1                |  1988437669671417938 | SELECT * FROM t1               |     1
- db2                |  1988437669671417938 | SELECT * FROM t1               |     1
- db1                |  2864453209316739369 | select $1 + $2                 |     1
- db2                |  2864453209316739369 | select $1 + $2                 |     1
- db1                |  8140395000078788481 | SELECT *, ADD(1, 2) FROM t1    |     1
- db2                |  8140395000078788481 | SELECT *, ADD(1, 2) FROM t1    |     1
-(9 rows)
+      datname       |    pgsm_query_id    |                        query                        | calls 
+--------------------+---------------------+-----------------------------------------------------+-------
+ contrib_regression |  689150021118383254 | SELECT pg_stat_monitor_reset()                      |     1
+ db1                | 1897482803466821995 | SELECT * FROM t2                                    |     3
+ db1                | 1988437669671417938 | SELECT * FROM t1                                    |     1
+ db2                | 1988437669671417938 | SELECT * FROM t1                                    |     1
+ db1                | 2864453209316739369 | select $1 + $2                                      |     1
+ db2                | 2864453209316739369 | select $1 + $2                                      |     1
+ db2                | 6220142855706866455 | set pg_stat_monitor.pgsm_enable_pgsm_query_id = on  |     1
+ db2                | 6633979598391393345 | SELECT * FROM t3 where c = 20                       |     1
+ db1                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
+ db2                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
+ db2                |                     | SELECT * FROM t3                                    |     1
+ db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     1
+(12 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/regression/sql/pgsm_query_id.sql
+++ b/regression/sql/pgsm_query_id.sql
@@ -41,7 +41,12 @@ More comments to check for spaces.
 \c db2
 SELECT * FROM t1;
 SELECT *, ADD(1, 2) FROM t1;
+
+set pg_stat_monitor.pgsm_enable_pgsm_query_id = off;
 SELECT * FROM t3;
+set pg_stat_monitor.pgsm_enable_pgsm_query_id = on;
+SELECT * FROM t3 where c = 20;
+
 
 \c contrib_regression
 SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_query_id, query, datname;

--- a/t/006_settings_pgsm_overflow_target.pl
+++ b/t/006_settings_pgsm_overflow_target.pl
@@ -19,7 +19,7 @@ my $pgdata = $node->data_dir;
 # UPDATE postgresql.conf to include/load pg_stat_monitor library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_overflow_target = 0\n";
+print $conf "pg_stat_monitor.pgsm_enable_overflow = false\n";
 close $conf;
 
 # Start server
@@ -36,18 +36,18 @@ PGSM::append_to_file($stdout);
 ok($cmdret == 0, "Reset PGSM EXTENSION");
 PGSM::append_to_file($stdout);
 
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_overflow_target';", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_enable_overflow';", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
 ok($cmdret == 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_overflow_target = 1\n");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_enable_overflow = true\n");
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT pg_stat_monitor_reset();', extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
 ok($cmdret == 0, "Reset PGSM EXTENSION");
 PGSM::append_to_file($stdout);
 
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_overflow_target';", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_enable_overflow';", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
 ok($cmdret == 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 

--- a/t/019_insufficient_shared_space.pl
+++ b/t/019_insufficient_shared_space.pl
@@ -19,7 +19,7 @@ my $pgdata = $node->data_dir;
 # UPDATE postgresql.conf to include/load pg_stat_monitor library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_overflow_target = 0\n";
+print $conf "pg_stat_monitor.pgsm_enable_overflow = false\n";
 print $conf "pg_stat_monitor.pgsm_max = 1\n";
 print $conf "pg_stat_monitor.pgsm_query_shared_buffer = 1\n";
 close $conf;
@@ -42,7 +42,7 @@ PGSM::append_to_file($stdout);
 ok($cmdret == 0, "Reset PGSM EXTENSION");
 PGSM::append_to_file($stdout);
 
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_overflow_target';", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_enable_overflow';", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
 ok($cmdret == 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
@@ -58,14 +58,14 @@ PGSM::append_to_file($stdout);
 ok($cmdret == 0, "SELECT count(queryid) FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_overflow_target = 1\n");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_enable_overflow = true\n");
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT pg_stat_monitor_reset();', extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
 ok($cmdret == 0, "Reset PGSM EXTENSION");
 PGSM::append_to_file($stdout);
 
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_overflow_target';", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_enable_overflow';", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
 ok($cmdret == 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 

--- a/t/020_buffer_overflow.pl
+++ b/t/020_buffer_overflow.pl
@@ -19,7 +19,7 @@ my $pgdata = $node->data_dir;
 # UPDATE postgresql.conf to include/load pg_stat_monitor library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_overflow_target = 0\n";
+print $conf "pg_stat_monitor.pgsm_enable_overflow = false\n";
 print $conf "pg_stat_monitor.pgsm_bucket_time = 1\n";
 print $conf "pg_stat_monitor.pgsm_max_buckets = 2\n"; 
 print $conf "pg_stat_monitor.pgsm_max = 1\n";
@@ -61,7 +61,7 @@ PGSM::append_to_file($stdout);
 ok($cmdret == 0, "SELECT count(queryid) FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_overflow_target = 1\n");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_enable_overflow = true\n");
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT pg_stat_monitor_reset();', extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);

--- a/t/021_misc_1.pl
+++ b/t/021_misc_1.pl
@@ -19,7 +19,7 @@ my $pgdata = $node->data_dir;
 # UPDATE postgresql.conf to include/load pg_stat_monitor library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_overflow_target = 0\n";
+print $conf "pg_stat_monitor.pgsm_enable_overflow = false\n";
 print $conf "pg_stat_monitor.pgsm_max = 1\n";
 print $conf "pg_stat_monitor.pgsm_query_shared_buffer = 1\n";
 print $conf "pg_stat_monitor.pgsm_query_max_len =10000\n";
@@ -64,7 +64,7 @@ PGSM::append_to_file($stdout);
 ok($cmdret == 0, "SELECT count(queryid) FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_overflow_target = 1\n");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_enable_overflow = true\n");
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT pg_stat_monitor_reset();', extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);

--- a/t/022_misc_2.pl
+++ b/t/022_misc_2.pl
@@ -19,7 +19,7 @@ my $pgdata = $node->data_dir;
 # UPDATE postgresql.conf to include/load pg_stat_monitor library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_overflow_target = 0\n";
+print $conf "pg_stat_monitor.pgsm_enable_overflow = false\n";
 print $conf "pg_stat_monitor.pgsm_max = 1\n";
 print $conf "pg_stat_monitor.pgsm_query_shared_buffer = 1\n";
 print $conf "pg_stat_monitor.pgsm_query_max_len =10000\n";
@@ -74,7 +74,7 @@ $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_min = 0\n"
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_max = 100000\n");
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_histogram_buckets = 10\n");
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_query_shared_buffer = 20\n");
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_overflow_target = 1\n");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_enable_overflow = true\n");
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_enable_query_plan = 'no'\n");
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'top'\n");
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_extract_comments = 'no'\n");

--- a/t/expected/001_settings_default.out
+++ b/t/expected/001_settings_default.out
@@ -6,25 +6,26 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name LIKE '%pg_stat_monitor%';
-                   name                   | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time         | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_overflow     | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_query_plan   | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets   | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max       | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min       | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                 | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
- pg_stat_monitor.pgsm_max_buckets         | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
- pg_stat_monitor.pgsm_normalized_query    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target     | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len       | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
- pg_stat_monitor.pgsm_query_shared_buffer | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
- pg_stat_monitor.pgsm_track               | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_planning      | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_track_utility       | on      |      | user       | bool    | default |         |            |                | on       | on        | f
-(16 rows)
+                   name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
+ pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
+ pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target      | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len        | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_shared_buffer  | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_planning       | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_track_utility        | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+(17 rows)
 
 SELECT datname, substr(query,0,100) AS query, calls FROM pg_stat_monitor ORDER BY datname, query, calls DESC Limit 20;
  datname  |                                                query                                                | calls 
@@ -34,25 +35,26 @@ SELECT datname, substr(query,0,100) AS query, calls FROM pg_stat_monitor ORDER B
 (2 rows)
 
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name LIKE '%pg_stat_monitor%';
-                   name                   | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time         | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_overflow     | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_query_plan   | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets   | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max       | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min       | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                 | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
- pg_stat_monitor.pgsm_max_buckets         | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
- pg_stat_monitor.pgsm_normalized_query    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target     | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len       | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
- pg_stat_monitor.pgsm_query_shared_buffer | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
- pg_stat_monitor.pgsm_track               | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_planning      | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_track_utility       | on      |      | user       | bool    | default |         |            |                | on       | on        | f
-(16 rows)
+                   name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
+ pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
+ pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target      | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len        | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_shared_buffer  | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_planning       | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_track_utility        | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+(17 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/t/expected/001_settings_default.out
+++ b/t/expected/001_settings_default.out
@@ -9,6 +9,7 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
                    name                   | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
 ------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
  pg_stat_monitor.pgsm_bucket_time         | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_overflow     | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_query_plan   | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_extract_comments    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_histogram_buckets   | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
@@ -23,7 +24,7 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_track               | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
  pg_stat_monitor.pgsm_track_planning      | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_track_utility       | on      |      | user       | bool    | default |         |            |                | on       | on        | f
-(15 rows)
+(16 rows)
 
 SELECT datname, substr(query,0,100) AS query, calls FROM pg_stat_monitor ORDER BY datname, query, calls DESC Limit 20;
  datname  |                                                query                                                | calls 
@@ -36,6 +37,7 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
                    name                   | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
 ------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
  pg_stat_monitor.pgsm_bucket_time         | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_overflow     | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_query_plan   | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_extract_comments    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_histogram_buckets   | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
@@ -50,7 +52,7 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_track               | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
  pg_stat_monitor.pgsm_track_planning      | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_track_utility       | on      |      | user       | bool    | default |         |            |                | on       | on        | f
-(15 rows)
+(16 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/t/expected/001_settings_default.out.12
+++ b/t/expected/001_settings_default.out.12
@@ -6,23 +6,25 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name LIKE '%pg_stat_monitor%';
-                   name                   | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time         | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_query_plan   | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets   | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max       | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min       | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                 | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
- pg_stat_monitor.pgsm_max_buckets         | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
- pg_stat_monitor.pgsm_normalized_query    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target     | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len       | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
- pg_stat_monitor.pgsm_query_shared_buffer | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
- pg_stat_monitor.pgsm_track               | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_utility       | on      |      | user       | bool    | default |         |            |                | on       | on        | f
-(14 rows)
+                   name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
+ pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
+ pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target      | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len        | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_shared_buffer  | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_utility        | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+(16 rows)
 
 SELECT datname, substr(query,0,100) AS query, calls FROM pg_stat_monitor ORDER BY datname, query, calls DESC Limit 20;
  datname  |                                                query                                                | calls 
@@ -32,23 +34,25 @@ SELECT datname, substr(query,0,100) AS query, calls FROM pg_stat_monitor ORDER B
 (2 rows)
 
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name LIKE '%pg_stat_monitor%';
-                   name                   | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time         | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_query_plan   | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets   | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max       | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min       | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                 | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
- pg_stat_monitor.pgsm_max_buckets         | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
- pg_stat_monitor.pgsm_normalized_query    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target     | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len       | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
- pg_stat_monitor.pgsm_query_shared_buffer | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
- pg_stat_monitor.pgsm_track               | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_utility       | on      |      | user       | bool    | default |         |            |                | on       | on        | f
-(14 rows)
+                   name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
+ pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
+ pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target      | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len        | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_shared_buffer  | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_utility        | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+(16 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/t/expected/006_settings_pgsm_overflow_target.out
+++ b/t/expected/006_settings_pgsm_overflow_target.out
@@ -5,10 +5,10 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_overflow_target';
+SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_enable_overflow';
                  name                 | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
 --------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_overflow_target | 0       |      | postmaster | integer | configuration file | 0       | 1       |          | 1        | 0         | f
+ pg_stat_monitor.pgsm_enable_overflow | off     |      | postmaster | bool    | configuration file |         |         |          | on       | off       | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -17,10 +17,10 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_overflow_target';
+SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_enable_overflow';
                  name                 | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
 --------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_overflow_target | 1       |      | postmaster | integer | configuration file | 0       | 1       |          | 1        | 1         | f
+ pg_stat_monitor.pgsm_enable_overflow | on      |      | postmaster | bool    | configuration file |         |         |          | on       | on        | f
 (1 row)
 
 DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION

Adds a new GUC pg_stat_monitor.pgsm_enable_pgsm_query_id to enable/disable pgsm query id calculation. Apart from that patch also refactors the GUC-related code to match PostgreSQL conventions.

Moreover, the commit also changes the pgsm_enable_overflow GUC to boolean instead of enum.