### PR TITLE
PG-607: Allow histogram to track queries in sub-ms time brackets

### DIFF
--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -74,7 +74,7 @@
 
 #define JUMBLE_SIZE				1024	/* query serialization buffer size */
 
-#define HISTOGRAM_MAX_TIME		INT_MAX
+#define HISTOGRAM_MAX_TIME		50000000
 #define MAX_RESPONSE_BUCKET 50
 #define INVALID_BUCKET_ID	-1
 #define MAX_BUCKETS			10
@@ -506,8 +506,8 @@ extern int pgsm_query_max_len;
 extern int pgsm_bucket_time;
 extern int pgsm_max_buckets;
 extern int pgsm_histogram_buckets;
-extern int pgsm_histogram_max;
-extern int pgsm_histogram_min;
+extern double pgsm_histogram_min;
+extern double pgsm_histogram_max;
 extern int pgsm_query_shared_buffer;
 extern bool pgsm_track_planning;
 extern bool pgsm_extract_comments;

--- a/regression/expected/guc.out
+++ b/regression/expected/guc.out
@@ -18,14 +18,14 @@ BY      name
 COLLATE "C";
                    name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
 -------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_bucket_time          | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
  pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
  pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f

--- a/regression/expected/guc_1.out
+++ b/regression/expected/guc_1.out
@@ -21,11 +21,11 @@ COLLATE "C";
  pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
  pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_enable_query_plan    | off     |      | postmaster | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
  pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
@@ -33,7 +33,7 @@ COLLATE "C";
  pg_stat_monitor.pgsm_query_max_len        | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
  pg_stat_monitor.pgsm_query_shared_buffer  | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
  pg_stat_monitor.pgsm_track                | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_utility        | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_track_utility        | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
 (16 rows)
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/expected/guc_1.out
+++ b/regression/expected/guc_1.out
@@ -18,14 +18,14 @@ BY      name
 COLLATE "C";
                    name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
 -------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_bucket_time          | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
  pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_query_plan    | off     |      | postmaster | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
  pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
@@ -33,7 +33,7 @@ COLLATE "C";
  pg_stat_monitor.pgsm_query_max_len        | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
  pg_stat_monitor.pgsm_query_shared_buffer  | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
  pg_stat_monitor.pgsm_track                | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_utility        | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_track_utility        | on      |      | user       | bool    | default |         |            |                | on       | on        | f
 (16 rows)
 
 DROP EXTENSION pg_stat_monitor;

--- a/t/expected/001_settings_default.out
+++ b/t/expected/001_settings_default.out
@@ -8,14 +8,14 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name LIKE '%pg_stat_monitor%';
                    name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
 -------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_bucket_time          | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
  pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
  pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
@@ -37,14 +37,14 @@ SELECT datname, substr(query,0,100) AS query, calls FROM pg_stat_monitor ORDER B
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name LIKE '%pg_stat_monitor%';
                    name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
 -------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_bucket_time          | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
  pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
  pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f

--- a/t/expected/001_settings_default.out.12
+++ b/t/expected/001_settings_default.out.12
@@ -8,14 +8,14 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name LIKE '%pg_stat_monitor%';
                    name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
 -------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_bucket_time          | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
  pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
  pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
@@ -36,14 +36,14 @@ SELECT datname, substr(query,0,100) AS query, calls FROM pg_stat_monitor ORDER B
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name LIKE '%pg_stat_monitor%';
                    name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
 -------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time          | 60      |      | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_bucket_time          | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
  pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | integer | default | 10      | 2147483647 |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | integer | default | 0       | 2147483647 |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
  pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f

--- a/t/expected/009_settings_pgsm_histogram_max.out
+++ b/t/expected/009_settings_pgsm_histogram_max.out
@@ -6,9 +6,9 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_max';
-                name                | setting | unit |  context   | vartype | source  | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
-------------------------------------+---------+------+------------+---------+---------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_histogram_max | 100000  |      | postmaster | integer | default | 10      | 2147483647 |          | 100000   | 100000    | f
+                name                | setting | unit |  context   | vartype | source  | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------+---------+------+------------+---------+---------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_histogram_max | 100000  | ms   | postmaster | real    | default | 10      | 5e+07   |          | 100000   | 100000    | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -18,9 +18,9 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_max';
-                name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
-------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_histogram_max | 50      |      | postmaster | integer | configuration file | 10      | 2147483647 |          | 100000   | 50        | f
+                name                | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_histogram_max | 50      | ms   | postmaster | real    | configuration file | 10      | 5e+07   |          | 100000   | 50        | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -30,9 +30,9 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_max';
-                name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
-------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_histogram_max | 1000    |      | postmaster | integer | configuration file | 10      | 2147483647 |          | 100000   | 1000      | f
+                name                | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_histogram_max | 1000    | ms   | postmaster | real    | configuration file | 10      | 5e+07   |          | 100000   | 1000      | f
 (1 row)
 
 DROP EXTENSION pg_stat_monitor;

--- a/t/expected/010_settings_pgsm_histogram_min.out
+++ b/t/expected/010_settings_pgsm_histogram_min.out
@@ -6,9 +6,9 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_min';
-                name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
-------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_histogram_min | 1       |      | postmaster | integer | configuration file | 0       | 2147483647 |          | 1        | 1         | f
+                name                | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_histogram_min | 1       | ms   | postmaster | real    | configuration file | 0       | 5e+07   |          | 1        | 1         | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -18,9 +18,9 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_min';
-                name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
-------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_histogram_min | 20      |      | postmaster | integer | configuration file | 0       | 2147483647 |          | 1        | 20        | f
+                name                | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_histogram_min | 20      | ms   | postmaster | real    | configuration file | 0       | 5e+07   |          | 1        | 20        | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -30,9 +30,9 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_histogram_min';
-                name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
-------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_histogram_min | 100     |      | postmaster | integer | configuration file | 0       | 2147483647 |          | 1        | 100       | f
+                name                | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_histogram_min | 100     | ms   | postmaster | real    | configuration file | 0       | 5e+07   |          | 1        | 100       | f
 (1 row)
 
 DROP EXTENSION pg_stat_monitor;

--- a/t/expected/011_settings_pgsm_bucket_time.out
+++ b/t/expected/011_settings_pgsm_bucket_time.out
@@ -8,7 +8,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_bucket_time';
                name               | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ----------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time | 10000   |      | postmaster | integer | configuration file | 1       | 2147483647 |          | 60       | 10000     | f
+ pg_stat_monitor.pgsm_bucket_time | 10000   | s    | postmaster | integer | configuration file | 1       | 2147483647 |          | 60       | 10000     | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -20,7 +20,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_bucket_time';
                name               | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ----------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time | 1000    |      | postmaster | integer | configuration file | 1       | 2147483647 |          | 60       | 1000      | f
+ pg_stat_monitor.pgsm_bucket_time | 1000    | s    | postmaster | integer | configuration file | 1       | 2147483647 |          | 60       | 1000      | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -32,7 +32,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_bucket_time';
                name               | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ----------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time | 100     |      | postmaster | integer | configuration file | 1       | 2147483647 |          | 60       | 100       | f
+ pg_stat_monitor.pgsm_bucket_time | 100     | s    | postmaster | integer | configuration file | 1       | 2147483647 |          | 60       | 100       | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -44,7 +44,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_bucket_time';
                name               | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ----------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time | 60      |      | postmaster | integer | configuration file | 1       | 2147483647 |          | 60       | 60        | f
+ pg_stat_monitor.pgsm_bucket_time | 60      | s    | postmaster | integer | configuration file | 1       | 2147483647 |          | 60       | 60        | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -56,7 +56,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_bucket_time';
                name               | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ----------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time | 1       |      | postmaster | integer | configuration file | 1       | 2147483647 |          | 60       | 1         | f
+ pg_stat_monitor.pgsm_bucket_time | 1       | s    | postmaster | integer | configuration file | 1       | 2147483647 |          | 60       | 1         | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -68,7 +68,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_bucket_time';
                name               | setting | unit |  context   | vartype | source  | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ----------------------------------+---------+------+------------+---------+---------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time | 60      |      | postmaster | integer | default | 1       | 2147483647 |          | 60       | 60        | f
+ pg_stat_monitor.pgsm_bucket_time | 60      | s    | postmaster | integer | default | 1       | 2147483647 |          | 60       | 60        | f
 (1 row)
 
 DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
Updated the GUC configuration and the relevant histogram functionality to track queries in lower cardinality than ms. This is done by saving the GUC values for histogram min and max values in real (double) type.

All test cases except for the 030 tap test are passing. The test case needs an update.