### PR TITLE
PG-608: pg_stat_monitor: Update histogram TAP testcase for sub-ms.

### DIFF
--- a/regression/expected/guc_2.out
+++ b/regression/expected/guc_2.out
@@ -1,0 +1,39 @@
+CREATE EXTENSION pg_stat_monitor;
+SELECT  name
+        , setting
+        , unit
+        , context
+        , vartype
+        , source
+        , min_val
+        , max_val
+        , enumvals
+        , boot_val
+        , reset_val
+        , pending_restart 
+FROM    pg_settings
+WHERE   name     LIKE     'pg_stat_monitor.%'
+ORDER
+BY      name
+COLLATE "C";
+                   name                    | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+-------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time          | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_overflow      | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan    | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets    | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max        | 100000  |      | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min        | 1       |      | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                  | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
+ pg_stat_monitor.pgsm_max_buckets          | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
+ pg_stat_monitor.pgsm_normalized_query     | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target      | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len        | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_shared_buffer  | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_utility        | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+(16 rows)
+
+DROP EXTENSION pg_stat_monitor;

--- a/t/030_histogram.pl
+++ b/t/030_histogram.pl
@@ -157,7 +157,7 @@ PGSM::append_to_debug_file($stdout);
 generate_histogram_with_configurations(1, 10000, 3, 13, "{0,4,4,5,0}", 5, 1, 1);
 
 #Scenario 2
-generate_histogram_with_configurations(20, 40, 20, 2, "{2,0,0,0,0,0,0,0,0,0}", 10, 0, 2);
+generate_histogram_with_configurations(20, 40, 20, 2, "{2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", 22, 0, 2);
 
 #Scenario 3
 generate_histogram_with_configurations(1000, 1010, 6, 2, "{2,0,0,0,0,0,0,0}", 8, 0, 3);
@@ -169,19 +169,22 @@ generate_histogram_with_configurations(1, 10, 3, 2, "{2,0,0,0,0}", 5, 0, 4);
 generate_histogram_with_configurations(0, 2, 2, 2, "{2,0,0}", 3, 0, 5);
 
 #Scenario 6
-generate_histogram_with_configurations(1, 2147483647, 20, 2, "{2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", 21, 0, 6);
+generate_histogram_with_configurations(1, 2147483647, 20, 2, "{2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", 22, 0, 6);
 
 #Scenario 7
-generate_histogram_with_configurations(0, 2147483647, 20, 2, "{2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", 20, 0, 7);
+generate_histogram_with_configurations(0, 2147483647, 20, 2, "{2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", 21, 0, 7);
 
 #Scenario 8
-generate_histogram_with_configurations(0, 2147483648, 20, 2, "{2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", 21, 0, 8);
+generate_histogram_with_configurations(0, 50000000, 20, 2, "{2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", 20, 0, 8);
 
 #Scenario 9
 generate_histogram_with_configurations(-1, 2147483648, 20, 2, "{2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", 22, 0, 9);
 
 #Scenario 10
 generate_histogram_with_configurations(-1, 2147483648, 20, 2, "{2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", 22, 0, 10);
+
+#Scenario 11
+generate_histogram_with_configurations(0, 49999999, 20, 2, "{2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}", 21, 0, 11);
 
 # Drop extension
 $stdout = $node->safe_psql('postgres', 'Drop extension pg_stat_monitor;',  extra_params => ['-a']);


### PR DESCRIPTION
Due to enhancement in the histogram functionality to track queries in sub-ms time brackets, histogram TAP test case required changes to adapt to new behaviour. 

This PR also handles the failing SQL test case, GUC, on PG-11. 