### PR TITLE
Adding pg-16 build and PGDG workflows.

### DIFF
--- a/.github/workflows/postgresql-16-build.yml
+++ b/.github/workflows/postgresql-16-build.yml
@@ -1,0 +1,145 @@
+name: postgresql-16-build
+on: [push]
+
+jobs:
+  build:
+    name: pg-16-build-test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone postgres repository
+        uses: actions/checkout@v2
+        with:
+          repository: 'postgres/postgres'
+          ref: 'REL_16_STABLE'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev bison flex \
+            libipc-run-perl -y docbook-xsl docbook-xsl libxml2 libxml2-utils \
+            libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev \
+            libsystemd-dev gettext tcl-dev libperl-dev pkg-config clang-11 \
+            llvm-11 llvm-11-dev libselinux1-dev python3-dev \
+            uuid-dev liblz4-dev
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+           /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+           /etc/postgresql
+          sudo rm -f /usr/bin/pg_config
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
+
+      - name: Create pgsql dir
+        run: mkdir -p /opt/pgsql
+
+      - name: Build postgres
+        run: |
+          export PATH="/opt/pgsql/bin:$PATH"
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' \
+            '--includedir=${prefix}/include' '--mandir=${prefix}/share/man' \
+            '--infodir=${prefix}/share/info' '--sysconfdir=/etc' \
+            '--localstatedir=/var' '--libdir=${prefix}/lib/x86_64-linux-gnu' \
+            '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--with-icu' \
+            '--with-tcl' '--with-perl' '--with-python' '--with-pam' \
+            '--with-openssl' '--with-libxml' '--with-libxslt' '--with-ldap' \
+            'PYTHON=/usr/bin/python3' '--mandir=/usr/share/postgresql/16/man' \
+            '--docdir=/usr/share/doc/postgresql-doc-16' '--with-pgport=5432' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share' \
+            '--datadir=/usr/share/postgresql/16' '--with-uuid=e2fs' \
+            '--bindir=/usr/lib/postgresql/16/bin' '--enable-tap-tests' \
+            '--libdir=/usr/lib/x86_64-linux-gnu' '--enable-debug' \
+            '--libexecdir=/usr/lib/postgresql' '--with-gnu-ld' \
+            '--includedir=/usr/include/postgresql' '--enable-dtrace' \
+            '--enable-nls' '--enable-thread-safety' '--disable-rpath' \
+            '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
+            'LLVM_CONFIG=/usr/bin/llvm-config-11' 'CLANG=/usr/bin/clang-11' \
+            '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' \
+            'PROVE=/usr/bin/prove' 'TAR=/bin/tar' 'XSLTPROC=xsltproc --nonet' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' \
+            'build_alias=x86_64-linux-gnu' '--with-gssapi' \
+            'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
+            'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
+           make world
+           sudo make install-world
+
+      - name: Start postgresql cluster
+        run: |
+          export PATH="/usr/lib/postgresql/16/bin:$PATH"
+          sudo cp /usr/lib/postgresql/16/bin/pg_config /usr/bin
+          initdb -D /opt/pgsql/data
+          pg_ctl -D /opt/pgsql/data -l logfile start
+
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
+
+      - name: Build pg_stat_monitor
+        run: |
+          make USE_PGXS=1
+          sudo make USE_PGXS=1 install
+        working-directory: src/pg_stat_monitor
+
+      - name: Load pg_stat_monitor library and Restart Server
+        run: |
+          export PATH="/usr/lib/postgresql/16/bin:$PATH"
+          pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> \
+            /opt/pgsql/data/postgresql.conf
+          pg_ctl -D /opt/pgsql/data -l logfile start
+        working-directory: src/pg_stat_monitor
+
+      - name: Start pg_stat_monitor_tests
+        run: |
+          make installcheck
+        working-directory: src/pg_stat_monitor/
+
+      - name: Change dir permissions on fail
+        if: ${{ failure() }}
+        run: |
+          sudo chmod -R ugo+rwx t
+          sudo chmod -R ugo+rwx tmp_check
+          exit 2 # regenerate error so that we can upload files in next step
+        working-directory: src/pg_stat_monitor
+
+      - name: Upload logs on fail
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Regressions diff and postgresql log
+          path: |
+            src/pg_stat_monitor/regression.diffs
+            src/pg_stat_monitor/regression.out
+            src/pg_stat_monitor/logfile
+            src/pg_stat_monitor/t/results/
+            src/pg_stat_monitor/tmp_check/log/
+            !src/pg_stat_monitor/tmp_check/**/archives/*
+            !src/pg_stat_monitor/tmp_check/**/backup/*
+            !src/pg_stat_monitor/tmp_check/**/pgdata/*
+            !src/pg_stat_monitor/tmp_check/**/archives/
+            !src/pg_stat_monitor/tmp_check/**/backup/
+            !src/pg_stat_monitor/tmp_check/**/pgdata/
+          if-no-files-found: warn
+          retention-days: 3
+
+      - name: Start Server installcheck-world tests
+        run: |
+          export PATH="/usr/lib/postgresql/16/bin:$PATH"
+          pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "compute_query_id = off" >> /opt/pgsql/data/postgresql.conf
+          pg_ctl -D /opt/pgsql/data -l logfile start
+          make installcheck-world
+
+      - name: Report on installcheck-world test suites fail
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Regressions output files of failed testsuite, and pg log
+          path: |
+            **/regression.diffs
+            **/regression.out
+            src/pg_stat_monitor/logfile
+          retention-days: 3

--- a/.github/workflows/postgresql-16-pgdg-package.yml
+++ b/.github/workflows/postgresql-16-pgdg-package.yml
@@ -1,0 +1,87 @@
+name: postgresql-16-pgdg-package
+on: [pull_request]
+
+jobs:
+  build:
+    name: pg-16-pgdg-package-test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/pg_stat_monitor'
+
+      - name: Delete old postgresql files
+        run: |
+          sudo apt-get update
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev wget \
+            zlib1g-dev libssl-dev libpam0g-dev bison flex libipc-run-perl
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+            /etc/postgresql
+          sudo rm -f /usr/bin/pg_config
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
+
+      - name: Install PG Distribution Postgresql 16
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt \
+            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo wget --quiet -O - \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc |
+            sudo apt-key add -
+          sudo apt update
+          sudo apt -y install postgresql-16 postgresql-server-dev-16
+
+      - name: Change src owner to postgres
+        run: |
+          sudo chmod o+rx ~
+          sudo chown -R postgres:postgres src
+
+      - name: Build pg_stat_monitor
+        run: |
+          sudo -u postgres bash -c 'make USE_PGXS=1'
+          sudo make USE_PGXS=1 install
+        working-directory: src/pg_stat_monitor
+
+      - name: Start pg_stat_monitor_tests
+        run: |
+          sudo service postgresql stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" | 
+            sudo tee -a /etc/postgresql/16/main/postgresql.conf
+          sudo service postgresql start
+          sudo psql -V
+          export PG_TEST_PORT_DIR=${GITHUB_WORKSPACE}/src/pg_stat_monitor
+          echo $PG_TEST_PORT_DIR
+          sudo -E -u postgres bash -c 'make installcheck USE_PGXS=1'
+        working-directory: src/pg_stat_monitor
+
+      - name: Change dir permissions on fail
+        if: ${{ failure() }}
+        run: |
+          sudo chmod -R ugo+rwx t
+          sudo chmod -R ugo+rwx tmp_check
+          exit 2 # regenerate error so that we can upload files in next step
+        working-directory: src/pg_stat_monitor
+
+      - name: Upload logs on fail
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Regressions diff and postgresql log
+          path: |
+            src/pg_stat_monitor/regression.diffs
+            src/pg_stat_monitor/regression.out
+            src/pg_stat_monitor/logfile
+            src/pg_stat_monitor/t/results/
+            src/pg_stat_monitor/tmp_check/log/
+            !src/pg_stat_monitor/tmp_check/**/archives/*
+            !src/pg_stat_monitor/tmp_check/**/backup/*
+            !src/pg_stat_monitor/tmp_check/**/pgdata/*
+            !src/pg_stat_monitor/tmp_check/**/archives/
+            !src/pg_stat_monitor/tmp_check/**/backup/
+            !src/pg_stat_monitor/tmp_check/**/pgdata/
+          if-no-files-found: warn
+          retention-days: 3


### PR DESCRIPTION
PGDG workflow will fail until packages are available for PG-16 on PGDG repo. But PG-16-Build will work. 