### PR TITLE
Fix IPC::Run perl module name in CI

### DIFF
--- a/.github/workflows/code-coverage-test.yml
+++ b/.github/workflows/code-coverage-test.yml
@@ -28,7 +28,7 @@ jobs:
            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Create pgsql dir

--- a/.github/workflows/postgresql-12-build.yml
+++ b/.github/workflows/postgresql-12-build.yml
@@ -27,7 +27,7 @@ jobs:
            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Create pgsql dir

--- a/.github/workflows/postgresql-12-pgdg-package.yml
+++ b/.github/workflows/postgresql-12-pgdg-package.yml
@@ -23,7 +23,7 @@ jobs:
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install PG Distribution Postgresql 12

--- a/.github/workflows/postgresql-12-ppg-package.yml
+++ b/.github/workflows/postgresql-12-ppg-package.yml
@@ -26,7 +26,7 @@ jobs:
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install percona-release script

--- a/.github/workflows/postgresql-13-build.yml
+++ b/.github/workflows/postgresql-13-build.yml
@@ -27,7 +27,7 @@ jobs:
            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Create pgsql dir

--- a/.github/workflows/postgresql-13-pgdg-package.yml
+++ b/.github/workflows/postgresql-13-pgdg-package.yml
@@ -23,7 +23,7 @@ jobs:
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install PG Distribution Postgresql 13

--- a/.github/workflows/postgresql-13-ppg-package.yml
+++ b/.github/workflows/postgresql-13-ppg-package.yml
@@ -23,7 +23,7 @@ jobs:
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install percona-release script

--- a/.github/workflows/postgresql-14-build.yml
+++ b/.github/workflows/postgresql-14-build.yml
@@ -28,7 +28,7 @@ jobs:
            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Create pgsql dir

--- a/.github/workflows/postgresql-14-pgdg-package.yml
+++ b/.github/workflows/postgresql-14-pgdg-package.yml
@@ -22,7 +22,7 @@ jobs:
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install PG Distribution Postgresql 14

--- a/.github/workflows/postgresql-14-ppg-package.yml
+++ b/.github/workflows/postgresql-14-ppg-package.yml
@@ -23,7 +23,7 @@ jobs:
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install percona-release script

--- a/.github/workflows/postgresql-15-build.yml
+++ b/.github/workflows/postgresql-15-build.yml
@@ -28,7 +28,7 @@ jobs:
            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Create pgsql dir

--- a/.github/workflows/postgresql-15-pgdg-package.yml
+++ b/.github/workflows/postgresql-15-pgdg-package.yml
@@ -22,7 +22,7 @@ jobs:
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install PG Distribution Postgresql 15

--- a/.github/workflows/postgresql-15-ppg-package.yml
+++ b/.github/workflows/postgresql-15-ppg-package.yml
@@ -23,7 +23,7 @@ jobs:
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install percona-release script

--- a/.github/workflows/postgresql-16-build.yml
+++ b/.github/workflows/postgresql-16-build.yml
@@ -28,7 +28,7 @@ jobs:
            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
            /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Create pgsql dir

--- a/.github/workflows/postgresql-16-pgdg-package.yml
+++ b/.github/workflows/postgresql-16-pgdg-package.yml
@@ -22,7 +22,7 @@ jobs:
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install PG Distribution Postgresql 16

--- a/.github/workflows/postgresql-16-ppg-package.yml
+++ b/.github/workflows/postgresql-16-ppg-package.yml
@@ -23,7 +23,7 @@ jobs:
             /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
             /etc/postgresql
           sudo rm -f /usr/bin/pg_config
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
 
       - name: Install percona-release script


### PR DESCRIPTION
```
Warning: Cannot install IPC::RUN, don't know what it is.
Try the command

    i /IPC::RUN/

to find objects with matching identifiers.
```

https://metacpan.org/pod/IPC::Run

Same for pg_tde: https://github.com/Percona-Lab/pg_tde/pull/156