### PR TITLE
PG -156: replace query placeholders with actual arguments for prepared statements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LDFLAGS_SL += $(filter -lm, $(LIBS))
 
 TAP_TESTS = 1
 REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/pg_stat_monitor/pg_stat_monitor.conf --inputdir=regression
-REGRESS = basic version guc pgsm_query_id functions counters relations database error_insert application_name application_name_unique top_query different_parent_queries cmd_type error rows tags user level_tracking
+REGRESS = basic version guc pgsm_query_id functions counters relations database error_insert application_name application_name_unique top_query different_parent_queries cmd_type error rows tags user level_tracking denorm_prepared_statements
 
 # Disabled because these tests require "shared_preload_libraries=pg_stat_statements",
 # which typical installcheck users do not have (e.g. buildfarm clients).

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -208,13 +208,8 @@ static void pgsm_add_to_list(pgsmEntry *entry, char *query_text, int query_len);
 static pgsmEntry *pgsm_get_entry_for_query(uint64 queryid, PlanInfo *plan_info, const char *query_text, int query_len, bool create);
 static uint64 get_pgsm_query_id_hash(const char *norm_query, int len);
 
-/*
- * extract parameter value (Datum) from plist->params[idx], cast it to string then
- * append the resulting string to the buffer.
- */
 static void get_param_value(const ParamListInfo plist, int idx, StringInfoData *buffer);
 
-/* denormalize the query, replace placeholders with actual values */
 static StringInfoData get_denormalized_query(const ParamListInfo paramlist, const char *query_text);
 
 static void pgsm_cleanup_callback(void *arg);
@@ -243,7 +238,13 @@ static void pgsm_update_entry(pgsmEntry *entry,
 							  const struct JitInstrumentation *jitusage,
 							  bool reset,
 							  pgsmStoreKind kind);
-static void pgsm_store(pgsmEntry *entry);
+static void pgsm_store_ex(pgsmEntry * entry, ParamListInfo params);
+
+/* Stores query entry in normalized form */
+static inline void pgsm_store(pgsmEntry * entry)
+{
+	pgsm_store_ex(entry, NULL);
+}
 
 static void pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 									 pgsmVersion api_version,
@@ -703,7 +704,6 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 	PlanInfo	plan_info;
 	PlanInfo   *plan_ptr = NULL;
 	pgsmEntry  *entry = NULL;
-	StringInfoData query_info;
 	MemoryContext oldctx;
 
 	/* Extract the plan information in case of SELECT statement */
@@ -763,13 +763,6 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 			sys_info.stime = time_diff(rusage_end.ru_stime, rusage_start.ru_stime);
 		}
 
-        if (!pgsm_normalized_query && queryDesc->params) {
-            query_info = get_denormalized_query(queryDesc->params, queryDesc->sourceText);
-            oldctx = MemoryContextSwitchTo(GetPgsmMemoryContext());
-            entry->query_text.query_pointer = pnstrdup(query_info.data, query_info.len);
-            MemoryContextSwitchTo(oldctx);
-        }
-
 		pgsm_update_entry(entry,	/* entry */
 						  NULL, /* query */
 						  NULL, /* comments */
@@ -794,7 +787,7 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 						  false,	/* reset */
 						  PGSM_EXEC);	/* kind */
 
-		pgsm_store(entry);
+		pgsm_store_ex(entry, queryDesc->params);
 	}
 
 	if (prev_ExecutorEnd)
@@ -1880,7 +1873,6 @@ pgsm_create_hash_entry(uint64 bucket_id, uint64 queryid, PlanInfo *plan_info)
 	return entry;
 }
 
-
 /*
  * Store some statistics for a statement.
  *
@@ -1890,9 +1882,14 @@ pgsm_create_hash_entry(uint64 bucket_id, uint64 queryid, PlanInfo *plan_info)
  * If jstate is not NULL then we're trying to create an entry for which
  * we have no statistics as yet; we just want to record the normalized
  * query string.  total_time, rows, bufusage are ignored in this case.
+ *
+ * If params argument is not null and pgsm_normalized_query is off then we
+ * denormalize the query using it's actual arguments found in params.
+ * The denormalization is done during the first time the query is
+ * inserted or if the time to execute the query exceeds the average
+ * time computed for the same query.
  */
-static void
-pgsm_store(pgsmEntry *entry)
+void pgsm_store_ex(pgsmEntry *entry, ParamListInfo params)
 {
 	pgsmEntry  *shared_hash_entry;
 	pgsmSharedState *pgsm;
@@ -1907,6 +1904,7 @@ pgsm_store(pgsmEntry *entry)
 	JitInstrumentation jitusage;
 	char		comments[COMMENTS_LEN] = {0};
 	int			comments_len;
+	StringInfoData query_info;
 
 	/* Safety check... */
 	if (!IsSystemInitialized())
@@ -1995,6 +1993,13 @@ pgsm_store(pgsmEntry *entry)
 		dsa_area   *query_dsa_area;
 		char	   *query_buff;
 
+		/* Denormalize the query if normalization is off */
+		if (!pgsm_normalized_query && params != NULL) {
+			query_info = get_denormalized_query(params, query);
+			query = query_info.data;
+			query_len = query_info.len;
+		}
+
 		/* New query, truncate length if necessary. */
 		if (query_len > pgsm_query_max_len)
 			query_len = pgsm_query_max_len;
@@ -2082,6 +2087,43 @@ pgsm_store(pgsmEntry *entry)
 
 		snprintf(shared_hash_entry->datname, sizeof(shared_hash_entry->datname), "%s", entry->datname);
 		snprintf(shared_hash_entry->username, sizeof(shared_hash_entry->username), "%s", entry->username);
+	}
+	/* Entry already exists, if query normalization is disabled and
+	 * the query execution time exceeds the mean time for this query,
+	 * then we denormalize the query so users can inspect which arguments
+	 * caused the query to take more time to execute */
+	else if (
+		!pgsm_normalized_query &&
+		params != NULL &&
+		entry->counters.time.total_time > shared_hash_entry->counters.time.mean_time
+	){
+		dsa_pointer dsa_query_pointer;
+		dsa_area   *query_dsa_area;
+		char	   *query_buff;
+
+		query_info = get_denormalized_query(params, query);
+		query = query_info.data;
+		query_len = query_info.len;
+
+		/* truncate length if necessary. */
+		if (query_len > pgsm_query_max_len)
+			query_len = pgsm_query_max_len;
+
+		/* Save the query text in raw dsa area */
+		query_dsa_area = get_dsa_area_for_query_text();
+		dsa_query_pointer = dsa_allocate_extended(query_dsa_area, query_len + 1, DSA_ALLOC_NO_OOM | DSA_ALLOC_ZERO);
+		if (DsaPointerIsValid(dsa_query_pointer))
+		{
+			/* Get the memory address from DSA pointer and copy the query text to it. */
+			query_buff = dsa_get_address(query_dsa_area, dsa_query_pointer);
+			memcpy(query_buff, query, query_len);
+
+			/* release previous query from shared memory */
+			if (DsaPointerIsValid(shared_hash_entry->query_text.query_pos))
+				dsa_free(query_dsa_area, shared_hash_entry->query_text.query_pos);
+
+			shared_hash_entry->query_text.query_pos = dsa_query_pointer;
+		}
 	}
 
 	pgsm_update_entry(shared_hash_entry,	/* entry */
@@ -4038,6 +4080,10 @@ get_query_id(JumbleState *jstate, Query *query)
 }
 #endif
 
+/*
+ * extract parameter value (Datum) from plist->params[idx], cast it to string then
+ * append the resulting string to the buffer.
+ */
 void
 get_param_value(const ParamListInfo plist, int idx, StringInfoData *buffer)
 {
@@ -4061,6 +4107,7 @@ get_param_value(const ParamListInfo plist, int idx, StringInfoData *buffer)
 	appendStringInfo(buffer, "%s", pstring);
 }
 
+/* denormalize the query, replace placeholders with actual values */
 StringInfoData
 get_denormalized_query(const ParamListInfo paramlist, const char *query_text)
 {

--- a/regression/expected/denorm_prepared_statements.out
+++ b/regression/expected/denorm_prepared_statements.out
@@ -1,0 +1,35 @@
+CREATE EXTENSION pg_stat_monitor;
+Set pg_stat_monitor.pgsm_normalized_query='off';
+CREATE TABLE t1 (a TEXT, b TEXT, c TEXT);
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+PREPARE prepstmt(TEXT, TEXT, TEXT) AS INSERT INTO t1(a, b, c) VALUES($1, $2, $3);
+EXECUTE prepstmt('A', 'B', 'C');
+SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                                   substring                                    | calls 
+--------------------------------------------------------------------------------+-------
+ PREPARE prepstmt(TEXT, TEXT, TEXT) AS INSERT INTO t1(a, b, c) VALUES(A, B, C); |     1
+ SELECT pg_stat_monitor_reset()                                                 |     1
+(2 rows)
+
+EXECUTE prepstmt(REPEAT('XYZ', 8192), md5(random()::text), REPEAT('RANDOM', 4096));
+SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                                                            substring                                                            | calls 
+---------------------------------------------------------------------------------------------------------------------------------+-------
+ PREPARE prepstmt(TEXT, TEXT, TEXT) AS INSERT INTO t1(a, b, c) VALUES(XYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZX |     2
+ SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C"                                          |     1
+ SELECT pg_stat_monitor_reset()                                                                                                  |     1
+(3 rows)
+
+DROP TABLE t1;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+DROP EXTENSION pg_stat_monitor;

--- a/regression/expected/denorm_prepared_statements.out
+++ b/regression/expected/denorm_prepared_statements.out
@@ -7,6 +7,8 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
+-- First test, execute cheap query then heavy query.
+-- Ensure denormalized heavy query replaces the cheaper one.
 PREPARE prepstmt(TEXT, TEXT, TEXT) AS INSERT INTO t1(a, b, c) VALUES($1, $2, $3);
 EXECUTE prepstmt('A', 'B', 'C');
 SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
@@ -17,6 +19,32 @@ SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLA
 (2 rows)
 
 EXECUTE prepstmt(REPEAT('XYZ', 8192), md5(random()::text), REPEAT('RANDOM', 4096));
+SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                                                            substring                                                            | calls 
+---------------------------------------------------------------------------------------------------------------------------------+-------
+ PREPARE prepstmt(TEXT, TEXT, TEXT) AS INSERT INTO t1(a, b, c) VALUES(XYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZX |     2
+ SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C"                                          |     1
+ SELECT pg_stat_monitor_reset()                                                                                                  |     1
+(3 rows)
+
+TRUNCATE TABLE t1;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+-- Second test, execute heavy query then cheap query.
+-- Ensure denormalized heavy query is not replaced by the cheaper one.
+EXECUTE prepstmt(REPEAT('XYZ', 8192), md5(random()::text), REPEAT('RANDOM', 4096));
+SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                                                            substring                                                            | calls 
+---------------------------------------------------------------------------------------------------------------------------------+-------
+ PREPARE prepstmt(TEXT, TEXT, TEXT) AS INSERT INTO t1(a, b, c) VALUES(XYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZX |     1
+ SELECT pg_stat_monitor_reset()                                                                                                  |     1
+(2 rows)
+
+EXECUTE prepstmt('A', 'B', 'C');
 SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
                                                             substring                                                            | calls 
 ---------------------------------------------------------------------------------------------------------------------------------+-------

--- a/regression/expected/pgsm_query_id.out
+++ b/regression/expected/pgsm_query_id.out
@@ -30,7 +30,7 @@ SELECT * FROM t1;
 ---
 (0 rows)
 
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, ADD(1234, 1000) FROM t1;
  a | add 
 ---+-----
 (0 rows)
@@ -62,7 +62,7 @@ SELECT * FROM t1;
 ---
 (0 rows)
 
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, ADD(1234, 1000) FROM t1;
  a | add 
 ---+-----
 (0 rows)
@@ -87,12 +87,12 @@ SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_q
  db1                | 1897482803466821995 | SELECT * FROM t2                                    |     3
  db1                | 1988437669671417938 | SELECT * FROM t1                                    |     1
  db2                | 1988437669671417938 | SELECT * FROM t1                                    |     1
- db1                | 2864453209316739369 | select 1 + 2                                        |     1
- db2                | 2864453209316739369 | select 1 + 2                                        |     1
+ db1                | 2864453209316739369 | select 1234 + 1000                                  |     1
+ db2                | 2864453209316739369 | select 1234 + 1000                                  |     1
  db2                | 6220142855706866455 | set pg_stat_monitor.pgsm_enable_pgsm_query_id = on  |     1
  db2                | 6633979598391393345 | SELECT * FROM t3 where c = 20                       |     1
- db1                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
- db2                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
+ db1                | 8140395000078788481 | SELECT *, ADD(1234, 1000) FROM t1                   |     1
+ db2                | 8140395000078788481 | SELECT *, ADD(1234, 1000) FROM t1                   |     1
  db2                |                     | SELECT * FROM t3                                    |     1
  db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     1
 (12 rows)

--- a/regression/expected/pgsm_query_id.out
+++ b/regression/expected/pgsm_query_id.out
@@ -87,8 +87,8 @@ SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_q
  db1                | 1897482803466821995 | SELECT * FROM t2                                    |     3
  db1                | 1988437669671417938 | SELECT * FROM t1                                    |     1
  db2                | 1988437669671417938 | SELECT * FROM t1                                    |     1
- db1                | 2864453209316739369 | select $1 + $2                                      |     1
- db2                | 2864453209316739369 | select $1 + $2                                      |     1
+ db1                | 2864453209316739369 | select 1 + 2                                        |     1
+ db2                | 2864453209316739369 | select 1 + 2                                        |     1
  db2                | 6220142855706866455 | set pg_stat_monitor.pgsm_enable_pgsm_query_id = on  |     1
  db2                | 6633979598391393345 | SELECT * FROM t3 where c = 20                       |     1
  db1                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1

--- a/regression/expected/pgsm_query_id_1.out
+++ b/regression/expected/pgsm_query_id_1.out
@@ -30,7 +30,7 @@ SELECT * FROM t1;
 ---
 (0 rows)
 
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, ADD(1234, 1000) FROM t1;
  a | add 
 ---+-----
 (0 rows)
@@ -62,7 +62,7 @@ SELECT * FROM t1;
 ---
 (0 rows)
 
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, ADD(1234, 1000) FROM t1;
  a | add 
 ---+-----
 (0 rows)
@@ -89,8 +89,8 @@ SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_q
  db2                | 1988437669671417938 | SELECT * FROM t1                                    |     1
  db2                | 6220142855706866455 | set pg_stat_monitor.pgsm_enable_pgsm_query_id = on  |     1
  db2                | 6633979598391393345 | SELECT * FROM t3 where c = 20                       |     1
- db1                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
- db2                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
+ db1                | 8140395000078788481 | SELECT *, ADD(1234, 1000) FROM t1                   |     1
+ db2                | 8140395000078788481 | SELECT *, ADD(1234, 1000) FROM t1                   |     1
  db2                |                     | SELECT * FROM t3                                    |     1
  db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     1
 (10 rows)

--- a/regression/expected/top_query.out
+++ b/regression/expected/top_query.out
@@ -26,7 +26,7 @@ SELECT add2(1,2);
 SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
                             query                             |     top_query     
 --------------------------------------------------------------+-------------------
- (select $1 + $2)                                             | SELECT add2(1,2);
+ (select NULL + NULL)                                         | SELECT add2(1,2);
  CREATE OR REPLACE FUNCTION add(int, int) RETURNS INTEGER AS +| 
  $$                                                          +| 
  BEGIN                                                       +| 

--- a/regression/expected/top_query_1.out
+++ b/regression/expected/top_query_1.out
@@ -37,7 +37,7 @@ SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
          return add($1,$2);                                  +| 
  END;                                                        +| 
  $$ language plpgsql                                          | 
- SELECT (select $1 + $2)                                      | SELECT add2(1,2);
+ SELECT (select NULL + NULL)                                  | SELECT add2(1,2);
  SELECT add2(1,2)                                             | 
  SELECT pg_stat_monitor_reset()                               | 
 (5 rows)

--- a/regression/sql/denorm_prepared_statements.sql
+++ b/regression/sql/denorm_prepared_statements.sql
@@ -1,0 +1,19 @@
+CREATE EXTENSION pg_stat_monitor;
+Set pg_stat_monitor.pgsm_normalized_query='off';
+
+CREATE TABLE t1 (a TEXT, b TEXT, c TEXT);
+
+SELECT pg_stat_monitor_reset();
+
+PREPARE prepstmt(TEXT, TEXT, TEXT) AS INSERT INTO t1(a, b, c) VALUES($1, $2, $3);
+
+EXECUTE prepstmt('A', 'B', 'C');
+SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+EXECUTE prepstmt(REPEAT('XYZ', 8192), md5(random()::text), REPEAT('RANDOM', 4096));
+SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+DROP TABLE t1;
+
+SELECT pg_stat_monitor_reset();
+DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/denorm_prepared_statements.sql
+++ b/regression/sql/denorm_prepared_statements.sql
@@ -5,12 +5,26 @@ CREATE TABLE t1 (a TEXT, b TEXT, c TEXT);
 
 SELECT pg_stat_monitor_reset();
 
+-- First test, execute cheap query then heavy query.
+-- Ensure denormalized heavy query replaces the cheaper one.
 PREPARE prepstmt(TEXT, TEXT, TEXT) AS INSERT INTO t1(a, b, c) VALUES($1, $2, $3);
 
 EXECUTE prepstmt('A', 'B', 'C');
 SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 EXECUTE prepstmt(REPEAT('XYZ', 8192), md5(random()::text), REPEAT('RANDOM', 4096));
+SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+TRUNCATE TABLE t1;
+SELECT pg_stat_monitor_reset();
+
+-- Second test, execute heavy query then cheap query.
+-- Ensure denormalized heavy query is not replaced by the cheaper one.
+
+EXECUTE prepstmt(REPEAT('XYZ', 8192), md5(random()::text), REPEAT('RANDOM', 4096));
+SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+EXECUTE prepstmt('A', 'B', 'C');
 SELECT SUBSTRING(query, 0, 128), calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 DROP TABLE t1;

--- a/regression/sql/pgsm_query_id.sql
+++ b/regression/sql/pgsm_query_id.sql
@@ -27,7 +27,7 @@ CREATE FUNCTION add(integer, integer) RETURNS integer
 SELECT pg_stat_monitor_reset();
 \c db1
 SELECT * FROM t1;
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, ADD(1234, 1000) FROM t1;
 SELECT * FROM t2;
 -- Check that spaces and comments do not generate a different pgsm_query_id
 SELECT     *     FROM t2 --WHATEVER;
@@ -40,7 +40,7 @@ More comments to check for spaces.
 
 \c db2
 SELECT * FROM t1;
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, ADD(1234, 1000) FROM t1;
 
 set pg_stat_monitor.pgsm_enable_pgsm_query_id = off;
 SELECT * FROM t3;


### PR DESCRIPTION
[PG-156](https://perconadev.atlassian.net/browse/PG-156)

Before this PR, `pg_stat_monitor` was unable to replace query placeholders when tracking prepared statements if `pg_stat_monitor.pgsm_normalized_query` is `off`.

With this update `pg_stat_monitor` now correctly store query argument values for prepared statements.

[PG-156]: https://perconadev.atlassian.net/browse/PG-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ