### PR TITLE
PG-1313 Fix decode_error_level SQL function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,26 @@ LDFLAGS_SL += $(filter -lm, $(LIBS))
 
 TAP_TESTS = 1
 REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/pg_stat_monitor/pg_stat_monitor.conf --inputdir=regression
-REGRESS = basic version guc pgsm_query_id functions counters relations database error_insert application_name application_name_unique top_query different_parent_queries cmd_type error rows tags user level_tracking
+REGRESS = basic \
+	version \
+	guc \
+	pgsm_query_id \
+	functions \
+	counters \
+	relations \
+	database \
+	error_insert \
+	application_name \
+	application_name_unique \
+	top_query \
+	different_parent_queries \
+	cmd_type \
+	error \
+	rows \
+	tags \
+	user \
+	level_tracking \
+	decode_error_level
 
 # Disabled because these tests require "shared_preload_libraries=pg_stat_statements",
 # which typical installcheck users do not have (e.g. buildfarm clients).

--- a/pg_stat_monitor--2.1--2.2.sql
+++ b/pg_stat_monitor--2.1--2.2.sql
@@ -19,3 +19,29 @@ SELECT
     END
 $$
 LANGUAGE SQL PARALLEL SAFE;
+
+-- Create new function that handles error levels across PostgreSQL versions 12-17
+CREATE OR REPLACE FUNCTION decode_error_level(elevel int)
+RETURNS text
+AS $$
+SELECT CASE
+    WHEN elevel = 0 THEN ''
+    WHEN elevel = 10 THEN 'DEBUG5'
+    WHEN elevel = 11 THEN 'DEBUG4'
+    WHEN elevel = 12 THEN 'DEBUG3'
+    WHEN elevel = 13 THEN 'DEBUG2'
+    WHEN elevel = 14 THEN 'DEBUG1'
+    WHEN elevel = 15 THEN 'LOG'
+    WHEN elevel = 16 THEN 'LOG_SERVER_ONLY'
+    WHEN elevel = 17 THEN 'INFO'
+    WHEN elevel = 18 THEN 'NOTICE'
+    WHEN elevel = 19 THEN 'WARNING'
+    WHEN elevel = 20 AND current_setting('server_version_num')::int < 140000 THEN 'ERROR'
+    WHEN elevel = 20 AND current_setting('server_version_num')::int >= 140000 THEN 'WARNING_CLIENT_ONLY'
+    WHEN elevel = 21 AND current_setting('server_version_num')::int < 140000 THEN 'FATAL'
+    WHEN elevel = 21 AND current_setting('server_version_num')::int >= 140000 THEN 'ERROR'
+    WHEN elevel = 22 AND current_setting('server_version_num')::int < 140000 THEN 'PANIC'
+    WHEN elevel = 22 AND current_setting('server_version_num')::int >= 140000 THEN 'FATAL'
+    WHEN elevel = 23 AND current_setting('server_version_num')::int >= 140000 THEN 'PANIC'
+END;
+$$ LANGUAGE SQL PARALLEL SAFE;

--- a/regression/expected/decode_error_level.out
+++ b/regression/expected/decode_error_level.out
@@ -1,0 +1,25 @@
+CREATE EXTENSION pg_stat_monitor;
+DO $$
+DECLARE
+    i integer;
+BEGIN
+    FOR i IN 10..24 LOOP
+         RAISE NOTICE 'error_code: %, error_level: %', i, decode_error_level(i);
+    END LOOP;
+END $$;
+NOTICE:  error_code: 10, error_level: DEBUG5
+NOTICE:  error_code: 11, error_level: DEBUG4
+NOTICE:  error_code: 12, error_level: DEBUG3
+NOTICE:  error_code: 13, error_level: DEBUG2
+NOTICE:  error_code: 14, error_level: DEBUG1
+NOTICE:  error_code: 15, error_level: LOG
+NOTICE:  error_code: 16, error_level: LOG_SERVER_ONLY
+NOTICE:  error_code: 17, error_level: INFO
+NOTICE:  error_code: 18, error_level: NOTICE
+NOTICE:  error_code: 19, error_level: WARNING
+NOTICE:  error_code: 20, error_level: WARNING_CLIENT_ONLY
+NOTICE:  error_code: 21, error_level: ERROR
+NOTICE:  error_code: 22, error_level: FATAL
+NOTICE:  error_code: 23, error_level: PANIC
+NOTICE:  error_code: 24, error_level: <NULL>
+DROP EXTENSION pg_stat_monitor;

--- a/regression/expected/decode_error_level_1.out
+++ b/regression/expected/decode_error_level_1.out
@@ -1,0 +1,25 @@
+CREATE EXTENSION pg_stat_monitor;
+DO $$
+DECLARE
+    i integer;
+BEGIN
+    FOR i IN 10..24 LOOP
+         RAISE NOTICE 'error_code: %, error_level: %', i, decode_error_level(i);
+    END LOOP;
+END $$;
+NOTICE:  error_code: 10, error_level: DEBUG5
+NOTICE:  error_code: 11, error_level: DEBUG4
+NOTICE:  error_code: 12, error_level: DEBUG3
+NOTICE:  error_code: 13, error_level: DEBUG2
+NOTICE:  error_code: 14, error_level: DEBUG1
+NOTICE:  error_code: 15, error_level: LOG
+NOTICE:  error_code: 16, error_level: LOG_SERVER_ONLY
+NOTICE:  error_code: 17, error_level: INFO
+NOTICE:  error_code: 18, error_level: NOTICE
+NOTICE:  error_code: 19, error_level: WARNING
+NOTICE:  error_code: 20, error_level: ERROR
+NOTICE:  error_code: 21, error_level: FATAL
+NOTICE:  error_code: 22, error_level: PANIC
+NOTICE:  error_code: 23, error_level: <NULL>
+NOTICE:  error_code: 24, error_level: <NULL>
+DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/decode_error_level.sql
+++ b/regression/sql/decode_error_level.sql
@@ -1,0 +1,12 @@
+CREATE EXTENSION pg_stat_monitor;
+
+DO $$
+DECLARE
+    i integer;
+BEGIN
+    FOR i IN 10..24 LOOP
+         RAISE NOTICE 'error_code: %, error_level: %', i, decode_error_level(i);
+    END LOOP;
+END $$;
+
+DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
Update decode_error_level function to support code up to PostgreSQL 17.

PG-1313
Fixes: https://github.com/percona/pg_stat_monitor/issues/506

### Description
<!--- Describe your changes in detail -->
This PR updated decode_error_level function with values up to PG17

Error code definitions can be found here: https://github.com/postgres/postgres/blob/REL_14_STABLE/src/include/utils/elog.h

### Links
<!--- Please provide links to any related PRs in this or other repositories --->

