### PR TITLE
PG-1907 PG-18 Support

### DIFF
--- a/.github/workflows/postgresql-18-build.yml
+++ b/.github/workflows/postgresql-18-build.yml
@@ -1,0 +1,151 @@
+name: postgresql-18-build
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: pg-18-build-test
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - name: Clone postgres repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: 'postgres/postgres'
+          ref: 'REL_18_STABLE'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev bison flex \
+            libipc-run-perl -y docbook-xsl docbook-xsl libxml2 libxml2-utils \
+            libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev \
+            libsystemd-dev gettext tcl-dev libperl-dev pkg-config clang-14 \
+            llvm-14 llvm-14-dev libselinux1-dev python3-dev \
+            uuid-dev liblz4-dev
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+           /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+           /etc/postgresql
+          sudo rm -f /usr/bin/pg_config
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
+
+      - name: Create pgsql dir
+        run: mkdir -p /opt/pgsql
+
+      - name: Build postgres
+        run: |
+          export PATH="/opt/pgsql/bin:$PATH"
+          ./configure '--build=x86_64-linux-gnu' '--prefix=/usr' \
+            '--includedir=${prefix}/include' '--mandir=${prefix}/share/man' \
+            '--infodir=${prefix}/share/info' '--sysconfdir=/etc' \
+            '--localstatedir=/var' '--libdir=${prefix}/lib/x86_64-linux-gnu' \
+            '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--with-icu' \
+            '--with-tcl' '--with-perl' '--with-python' '--with-pam' \
+            '--with-openssl' '--with-libxml' '--with-libxslt' '--with-ldap' \
+            'PYTHON=/usr/bin/python3' '--mandir=/usr/share/postgresql/18/man' \
+            '--docdir=/usr/share/doc/postgresql-doc-18' '--with-pgport=5432' \
+            '--sysconfdir=/etc/postgresql-common' '--datarootdir=/usr/share' \
+            '--datadir=/usr/share/postgresql/18' '--with-uuid=e2fs' \
+            '--bindir=/usr/lib/postgresql/18/bin' '--enable-tap-tests' \
+            '--libdir=/usr/lib/x86_64-linux-gnu' '--enable-debug' \
+            '--libexecdir=/usr/lib/postgresql' '--with-gnu-ld' \
+            '--includedir=/usr/include/postgresql' '--enable-dtrace' \
+            '--enable-nls' '--enable-thread-safety' '--disable-rpath' \
+            '--with-system-tzdata=/usr/share/zoneinfo' '--with-llvm' \
+            'LLVM_CONFIG=/usr/bin/llvm-config-14' 'CLANG=/usr/bin/clang-14' \
+            '--with-systemd' '--with-selinux' 'MKDIR_P=/bin/mkdir -p' \
+            'PROVE=/usr/bin/prove' 'TAR=/bin/tar' 'XSLTPROC=xsltproc --nonet' \
+            'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' \
+            'build_alias=x86_64-linux-gnu' '--with-gssapi' \
+            'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' \
+            'CFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer' \
+            'CXXFLAGS=-g -O2 -fstack-protector-strong -Wformat -Werror=format-security'
+           make world
+           sudo make install-world
+
+      - name: Start postgresql cluster
+        run: |
+          export PATH="/usr/lib/postgresql/18/bin:$PATH"
+          sudo cp /usr/lib/postgresql/18/bin/pg_config /usr/bin
+          initdb -D /opt/pgsql/data
+          pg_ctl -D /opt/pgsql/data -l logfile start
+
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: 'src/pg_stat_monitor'
+
+      - name: Build pg_stat_monitor
+        run: |
+          make USE_PGXS=1
+          sudo make USE_PGXS=1 install
+        working-directory: src/pg_stat_monitor
+
+      - name: Configure and Restart Server
+        run: |
+          export PATH="/usr/lib/postgresql/18/bin:$PATH"
+          pg_ctl -D /opt/pgsql/data -l logfile stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" >> \
+            /opt/pgsql/data/postgresql.conf
+          echo "compute_query_id = regress" >> /opt/pgsql/data/postgresql.conf
+          pg_ctl -D /opt/pgsql/data -l logfile start
+        working-directory: src/pg_stat_monitor
+
+      - name: Start pg_stat_monitor_tests
+        run: |
+          make installcheck
+        working-directory: src/pg_stat_monitor/
+
+      - name: Change dir permissions on fail
+        if: ${{ failure() }}
+        run: |
+          sudo chmod -R ugo+rwx t
+          sudo chmod -R ugo+rwx tmp_check
+          exit 2 # regenerate error so that we can upload files in next step
+        working-directory: src/pg_stat_monitor
+
+      - name: Upload logs on fail
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: Regressions diff and postgresql log
+          path: |
+            src/pg_stat_monitor/regression.diffs
+            src/pg_stat_monitor/regression.out
+            src/pg_stat_monitor/logfile
+            src/pg_stat_monitor/t/results/
+            src/pg_stat_monitor/tmp_check/log/
+            !src/pg_stat_monitor/tmp_check/**/archives/*
+            !src/pg_stat_monitor/tmp_check/**/backup/*
+            !src/pg_stat_monitor/tmp_check/**/pgdata/*
+            !src/pg_stat_monitor/tmp_check/**/archives/
+            !src/pg_stat_monitor/tmp_check/**/backup/
+            !src/pg_stat_monitor/tmp_check/**/pgdata/
+          if-no-files-found: warn
+          retention-days: 3
+
+      - name: Start Server installcheck-world tests
+        run: make installcheck-world
+
+      - name: Report on installcheck-world test suites fail
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ failure() }}
+        with:
+          name: Regressions output files of failed testsuite, and pg log
+          path: |
+            **/regression.diffs
+            **/regression.out
+            src/pg_stat_monitor/logfile
+          retention-days: 3

--- a/.github/workflows/postgresql-18-pgdg-package.yml
+++ b/.github/workflows/postgresql-18-pgdg-package.yml
@@ -1,0 +1,97 @@
+name: postgresql-18-pgdg-package
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: pg-18-pgdg-package-test
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - name: Clone pg_stat_monitor repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: 'src/pg_stat_monitor'
+
+      - name: Delete old postgresql files
+        run: |
+          sudo apt-get update
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev wget \
+            zlib1g-dev libssl-dev libpam0g-dev bison flex libipc-run-perl
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+            /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+            /etc/postgresql
+          sudo rm -f /usr/bin/pg_config
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
+
+      - name: Install PG Distribution Postgresql 18
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt \
+            $(lsb_release -cs)-pgdg main 18" > /etc/apt/sources.list.d/pgdg.list'
+          sudo wget --quiet -O - \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc |
+            sudo apt-key add -
+          sudo apt update
+          sudo apt -y install postgresql-18 postgresql-server-dev-18
+
+      - name: Change src owner to postgres
+        run: |
+          sudo chmod o+rx ~
+          sudo chown -R postgres:postgres src
+
+      - name: Build pg_stat_monitor
+        run: |
+          sudo -u postgres bash -c 'make USE_PGXS=1'
+          sudo make USE_PGXS=1 install
+        working-directory: src/pg_stat_monitor
+
+      - name: Start pg_stat_monitor_tests
+        run: |
+          sudo service postgresql stop
+          echo "shared_preload_libraries = 'pg_stat_monitor'" | 
+            sudo tee -a /etc/postgresql/18/main/postgresql.conf
+          sudo service postgresql start
+          sudo psql -V
+          export PG_TEST_PORT_DIR=${GITHUB_WORKSPACE}/src/pg_stat_monitor
+          echo $PG_TEST_PORT_DIR
+          sudo -E -u postgres bash -c 'make installcheck USE_PGXS=1'
+        working-directory: src/pg_stat_monitor
+
+      - name: Change dir permissions on fail
+        if: ${{ failure() }}
+        run: |
+          sudo chmod -R ugo+rwx t
+          sudo chmod -R ugo+rwx tmp_check
+          exit 2 # regenerate error so that we can upload files in next step
+        working-directory: src/pg_stat_monitor
+
+      - name: Upload logs on fail
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: Regressions diff and postgresql log
+          path: |
+            src/pg_stat_monitor/regression.diffs
+            src/pg_stat_monitor/regression.out
+            src/pg_stat_monitor/logfile
+            src/pg_stat_monitor/t/results/
+            src/pg_stat_monitor/tmp_check/log/
+            !src/pg_stat_monitor/tmp_check/**/archives/*
+            !src/pg_stat_monitor/tmp_check/**/backup/*
+            !src/pg_stat_monitor/tmp_check/**/pgdata/*
+            !src/pg_stat_monitor/tmp_check/**/archives/
+            !src/pg_stat_monitor/tmp_check/**/backup/
+            !src/pg_stat_monitor/tmp_check/**/pgdata/
+          if-no-files-found: warn
+          retention-days: 3

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ REGRESS = basic \
 	cmd_type \
 	error \
 	rows \
+	squashing \
 	tags \
 	user \
 	level_tracking \

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ REGRESS = basic \
 	tags \
 	user \
 	level_tracking \
-	decode_error_level
+	decode_error_level \
+	parallel
 
 # Disabled because these tests require "shared_preload_libraries=pg_stat_statements",
 # which typical installcheck users do not have (e.g. buildfarm clients).

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,7 @@ tests += {
       'guc',
       'histogram',
       'level_tracking'
+      'parallel',
       'pgsqm_query_id',
       'relations',
       'rows',

--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,7 @@ tests += {
       'pgsqm_query_id',
       'relations',
       'rows',
+      'squashing',
       'state',
       'tags',
       'top_query',

--- a/pg_stat_monitor--2.2--2.3.sql
+++ b/pg_stat_monitor--2.2--2.3.sql
@@ -87,10 +87,13 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT jit_deform_count        int8,
     OUT jit_deform_time         float8,
 
-    OUT stats_since          timestamp with time zone, -- 67
+    OUT parallel_workers_to_launch  int, -- 67
+    OUT parallel_workers_launched   int,
+
+    OUT stats_since          timestamp with time zone, -- 69
     OUT minmax_stats_since   timestamp with time zone,
 
-    OUT toplevel            BOOLEAN, -- 69
+    OUT toplevel            BOOLEAN, -- 71
     OUT bucket_done         BOOLEAN
 )
 RETURNS SETOF record
@@ -174,6 +177,9 @@ CREATE VIEW pg_stat_monitor AS SELECT
     jit_emission_time,
     jit_deform_count,
     jit_deform_time,
+
+    parallel_workers_to_launch,
+    parallel_workers_launched,
 
     stats_since,
     minmax_stats_since

--- a/pg_stat_monitor--2.2--2.3.sql
+++ b/pg_stat_monitor--2.2--2.3.sql
@@ -5,12 +5,193 @@
 
 DROP FUNCTION pgsm_create_11_view();
 DROP VIEW pg_stat_monitor;
+DROP FUNCTION pg_stat_monitor_internal;
+
+CREATE FUNCTION pg_stat_monitor_internal(
+    IN showtext             boolean,
+    OUT bucket              int8,   -- 0
+    OUT userid              oid,
+    OUT username            text,
+    OUT dbid                oid,
+    OUT datname             text,
+    OUT client_ip           int8,
+
+    OUT queryid             int8,  -- 6
+    OUT planid              int8,
+    OUT query               text,
+    OUT query_plan          text,
+    OUT pgsm_query_id       int8,
+    OUT top_queryid         int8,
+    OUT top_query           text,
+    OUT application_name    text,
+
+    OUT relations           text, -- 14
+    OUT cmd_type            int,
+    OUT elevel              int,
+    OUT sqlcode             TEXT,
+    OUT message             text,
+    OUT bucket_start_time   timestamptz,
+
+    OUT calls               int8,  -- 20
+
+    OUT total_exec_time     float8, -- 21
+    OUT min_exec_time       float8,
+    OUT max_exec_time       float8,
+    OUT mean_exec_time      float8,
+    OUT stddev_exec_time    float8,
+
+    OUT rows                int8, -- 26
+
+    OUT plans               int8,  -- 27
+
+    OUT total_plan_time     float8, -- 28
+    OUT min_plan_time       float8,
+    OUT max_plan_time       float8,
+    OUT mean_plan_time      float8,
+    OUT stddev_plan_time    float8,
+
+    OUT shared_blks_hit            int8, -- 33
+    OUT shared_blks_read           int8,
+    OUT shared_blks_dirtied        int8,
+    OUT shared_blks_written        int8,
+    OUT local_blks_hit             int8,
+    OUT local_blks_read            int8,
+    OUT local_blks_dirtied         int8,
+    OUT local_blks_written         int8,
+    OUT temp_blks_read             int8,
+    OUT temp_blks_written          int8,
+    OUT shared_blk_read_time       float8,
+    OUT shared_blk_write_time      float8,
+    OUT local_blk_read_time        float8,
+    OUT local_blk_write_time       float8,
+    OUT temp_blk_read_time         float8,
+    OUT temp_blk_write_time        float8,
+
+    OUT resp_calls          text, -- 49
+    OUT cpu_user_time       float8,
+    OUT cpu_sys_time        float8,
+    OUT wal_records         int8,
+    OUT wal_fpi             int8,
+    OUT wal_bytes           numeric,
+    OUT wal_buffers_full    int8,
+    OUT comments            TEXT,
+
+    OUT jit_functions           int8, -- 57
+    OUT jit_generation_time     float8,
+    OUT jit_inlining_count      int8,
+    OUT jit_inlining_time       float8,
+    OUT jit_optimization_count  int8,
+    OUT jit_optimization_time   float8,
+    OUT jit_emission_count      int8,
+    OUT jit_emission_time       float8,
+    OUT jit_deform_count        int8,
+    OUT jit_deform_time         float8,
+
+    OUT stats_since          timestamp with time zone, -- 67
+    OUT minmax_stats_since   timestamp with time zone,
+
+    OUT toplevel            BOOLEAN, -- 69
+    OUT bucket_done         BOOLEAN
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_3'
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+
+CREATE FUNCTION pgsm_create_18_view() RETURNS INT AS
+$$
+BEGIN
+CREATE VIEW pg_stat_monitor AS SELECT
+    bucket,
+    bucket_start_time,
+    userid,
+    username,
+    dbid,
+    datname,
+    '0.0.0.0'::inet + client_ip AS client_ip,
+    pgsm_query_id,
+    queryid,
+    toplevel,
+    top_queryid,
+    query,
+    comments,
+    planid,
+    query_plan,
+    top_query,
+    application_name,
+    string_to_array(relations, ',') AS relations,
+    cmd_type,
+    get_cmd_type(cmd_type) AS cmd_type_text,
+    elevel,
+    sqlcode,
+    message,
+    calls,
+    total_exec_time,
+    min_exec_time,
+    max_exec_time,
+    mean_exec_time,
+    stddev_exec_time,
+    rows,
+    shared_blks_hit,
+    shared_blks_read,
+    shared_blks_dirtied,
+    shared_blks_written,
+    local_blks_hit,
+    local_blks_read,
+    local_blks_dirtied,
+    local_blks_written,
+    temp_blks_read,
+    temp_blks_written,
+    shared_blk_read_time,
+    shared_blk_write_time,
+    local_blk_read_time,
+    local_blk_write_time,
+    temp_blk_read_time,
+    temp_blk_write_time,
+
+    (string_to_array(resp_calls, ',')) resp_calls,
+    cpu_user_time,
+    cpu_sys_time,
+    wal_records,
+    wal_fpi,
+    wal_bytes,
+    wal_buffers_full,
+    bucket_done,
+
+    plans,
+    total_plan_time,
+    min_plan_time,
+    max_plan_time,
+    mean_plan_time,
+    stddev_plan_time,
+
+    jit_functions,
+    jit_generation_time,
+    jit_inlining_count,
+    jit_inlining_time,
+    jit_optimization_count,
+    jit_optimization_time,
+    jit_emission_count,
+    jit_emission_time,
+    jit_deform_count,
+    jit_deform_time,
+
+    stats_since,
+    minmax_stats_since
+
+FROM pg_stat_monitor_internal(TRUE)
+ORDER BY bucket_start_time;
+RETURN 0;
+END;
+$$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION pgsm_create_view() RETURNS INT AS
 $$
     DECLARE ver integer;
     BEGIN
         SELECT current_setting('server_version_num') INTO ver;
+    IF (ver >= 180000) THEN
+        return pgsm_create_18_view();
+    END IF;
     IF (ver >= 170000) THEN
         return pgsm_create_17_view();
     END IF;
@@ -29,5 +210,6 @@ $$ LANGUAGE plpgsql;
 
 SELECT pgsm_create_view();
 REVOKE ALL ON FUNCTION pgsm_create_view FROM PUBLIC;
+REVOKE ALL ON FUNCTION pgsm_create_18_view FROM PUBLIC;
 
 GRANT SELECT ON pg_stat_monitor TO PUBLIC;

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -21,6 +21,12 @@
 #include "utils/guc.h"
 #include "pgstat.h"
 #include "commands/dbcommands.h"
+
+#if PG_VERSION_NUM >= 180000
+#include "commands/explain_state.h"
+#include "commands/explain_format.h"
+#endif
+
 #include "commands/explain.h"
 #include "pg_stat_monitor.h"
 

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -152,9 +152,9 @@ typedef enum pgsmStoreKind
 	PGSM_EXEC,
 	PGSM_STORE,
 	PGSM_ERROR,
-
-	PGSM_NUMKIND				/* Must be last value of this enum */
 } pgsmStoreKind;
+
+#define PGSM_NUMKIND	(PGSM_ERROR + 1)
 
 /* the assumption of query max nested level */
 #define DEFAULT_MAX_NESTED_LEVEL	10

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -328,6 +328,10 @@ typedef struct Counters
 	Wal_Usage	walusage;
 	int			resp_calls[MAX_RESPONSE_BUCKET];	/* execution time's in
 													 * msec */
+	int64		parallel_workers_to_launch; /* # of parallel workers planned
+											 * to be launched */
+	int64		parallel_workers_launched;	/* # of parallel workers actually
+											 * launched */
 } Counters;
 
 /* Some global structure to get the cpu usage, really don't like the idea of global variable */

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -184,7 +184,7 @@ typedef struct CallTime
 
 typedef struct PlanInfo
 {
-	uint64		planid;			/* plan identifier */
+	int64		planid;			/* plan identifier */
 	char		plan_text[PLAN_TEXT_LEN];	/* plan text */
 	size_t		plan_len;		/* strlen(plan_text) */
 } PlanInfo;
@@ -192,14 +192,14 @@ typedef struct PlanInfo
 typedef struct pgsmHashKey
 {
 	uint64		bucket_id;		/* bucket number */
-	uint64		queryid;		/* query identifier */
-	uint64		planid;			/* plan identifier */
-	uint64		appid;			/* hash of application name */
+	int64		queryid;		/* query identifier */
+	int64		planid;			/* plan identifier */
+	int64		appid;			/* hash of application name */
 	Oid			userid;			/* user OID */
 	Oid			dbid;			/* database OID */
 	uint32		ip;				/* client ip address */
 	bool		toplevel;		/* query executed at top level */
-	uint64		parentid;		/* parent queryid of current query */
+	int64		parentid;		/* parent queryId of current query */
 } pgsmHashKey;
 
 typedef struct QueryInfo
@@ -337,7 +337,7 @@ typedef struct Counters
 typedef struct pgsmEntry
 {
 	pgsmHashKey key;			/* hash key of entry - MUST BE FIRST */
-	uint64		pgsm_query_id;	/* pgsm generate normalized query hash */
+	int64		pgsm_query_id;	/* pgsm generate normalized query hash */
 	char		datname[NAMEDATALEN];	/* database name */
 	char		username[NAMEDATALEN];	/* user name */
 	Counters	counters;		/* the statistics for this query */

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -308,6 +308,7 @@ typedef struct Wal_Usage
 	int64		wal_records;	/* # of WAL records generated */
 	int64		wal_fpi;		/* # of WAL full page images generated */
 	uint64		wal_bytes;		/* total amount of WAL bytes generated */
+	int64		wal_buffers_full;	/* # of times the WAL buffers became full */
 } Wal_Usage;
 
 typedef struct Counters

--- a/regression/expected/functions.out
+++ b/regression/expected/functions.out
@@ -24,9 +24,10 @@ SELECT routine_schema, routine_name, routine_type, data_type FROM information_sc
  public         | pgsm_create_14_view      | FUNCTION     | integer
  public         | pgsm_create_15_view      | FUNCTION     | integer
  public         | pgsm_create_17_view      | FUNCTION     | integer
+ public         | pgsm_create_18_view      | FUNCTION     | integer
  public         | pgsm_create_view         | FUNCTION     | integer
  public         | range                    | FUNCTION     | ARRAY
-(13 rows)
+(14 rows)
 
 SET ROLE u1;
 SELECT routine_schema, routine_name, routine_type, data_type FROM information_schema.routines WHERE routine_schema = 'public' ORDER BY routine_name COLLATE "C";

--- a/regression/expected/functions_1.out
+++ b/regression/expected/functions_1.out
@@ -24,9 +24,10 @@ SELECT routine_schema, routine_name, routine_type, data_type FROM information_sc
  public         | pgsm_create_14_view      | FUNCTION     | integer
  public         | pgsm_create_15_view      | FUNCTION     | integer
  public         | pgsm_create_17_view      | FUNCTION     | integer
+ public         | pgsm_create_18_view      | FUNCTION     | integer
  public         | pgsm_create_view         | FUNCTION     | integer
  public         | range                    | FUNCTION     | ARRAY
-(13 rows)
+(14 rows)
 
 SET ROLE u1;
 SELECT routine_schema, routine_name, routine_type, data_type FROM information_schema.routines WHERE routine_schema = 'public' ORDER BY routine_name COLLATE "C";

--- a/regression/expected/parallel.out
+++ b/regression/expected/parallel.out
@@ -1,0 +1,6 @@
+--
+-- Tests for parallel statistics
+--
+SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+\if :skip_test
+\quit

--- a/regression/expected/parallel_1.out
+++ b/regression/expected/parallel_1.out
@@ -1,0 +1,39 @@
+--
+-- Tests for parallel statistics
+--
+SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+\if :skip_test
+\quit
+\endif
+CREATE EXTENSION pg_stat_monitor;
+SET pgsm.track_utility = FALSE;
+-- encourage use of parallel plans
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET max_parallel_workers_per_gather = 2;
+CREATE TABLE pgsm_parallel_tab (a int);
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT count(*) FROM pgsm_parallel_tab;
+ count 
+-------
+     0
+(1 row)
+
+SELECT query,
+  parallel_workers_to_launch > 0 AS has_workers_to_launch,
+  parallel_workers_launched > 0 AS has_workers_launched
+  FROM pg_stat_monitor
+  WHERE query ~ 'SELECT count'
+  ORDER BY query COLLATE "C";
+                 query                  | has_workers_to_launch | has_workers_launched 
+----------------------------------------+-----------------------+----------------------
+ SELECT count(*) FROM pgsm_parallel_tab | t                     | t
+(1 row)
+
+DROP TABLE pgsm_parallel_tab;

--- a/regression/expected/pgsm_query_id_2.out
+++ b/regression/expected/pgsm_query_id_2.out
@@ -1,0 +1,114 @@
+CREATE EXTENSION pg_stat_monitor;
+CREATE DATABASE db1;
+CREATE DATABASE db2;
+\c db1
+CREATE TABLE t1 (a int);
+CREATE TABLE t2 (b int);
+CREATE FUNCTION add(integer, integer) RETURNS integer
+    AS 'select $1 + $2;'
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+\c db2
+CREATE TABLE t1 (a int);
+CREATE TABLE t3 (c int);
+CREATE FUNCTION add(integer, integer) RETURNS integer
+    AS 'select $1 + $2;'
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+\c contrib_regression
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+\c db1
+SELECT * FROM t1;
+ a 
+---
+(0 rows)
+
+SELECT *, ADD(1, 2) FROM t1;
+ a | add 
+---+-----
+(0 rows)
+
+SELECT * FROM t2;
+ b 
+---
+(0 rows)
+
+-- Check that spaces and comments do not generate a different pgsm_query_id
+SELECT     *     FROM t2 --WHATEVER;
+;
+ b 
+---
+(0 rows)
+
+SELECT     *     FROM t2 /* ...
+...
+More comments to check for spaces.
+*/
+     ;
+ b 
+---
+(0 rows)
+
+\c db2
+SELECT * FROM t1;
+ a 
+---
+(0 rows)
+
+SELECT *, ADD(1, 2) FROM t1;
+ a | add 
+---+-----
+(0 rows)
+
+set pg_stat_monitor.pgsm_enable_pgsm_query_id = off;
+SELECT * FROM t3;
+ c 
+---
+(0 rows)
+
+set pg_stat_monitor.pgsm_enable_pgsm_query_id = on;
+SELECT * FROM t3 where c = 20;
+ c 
+---
+(0 rows)
+
+\c contrib_regression
+SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_query_id, query, datname;
+      datname       |    pgsm_query_id    |                        query                        | calls 
+--------------------+---------------------+-----------------------------------------------------+-------
+ contrib_regression |  689150021118383254 | SELECT pg_stat_monitor_reset()                      |     1
+ db1                | 1897482803466821995 | SELECT * FROM t2                                    |     3
+ db1                | 1988437669671417938 | SELECT * FROM t1                                    |     1
+ db2                | 1988437669671417938 | SELECT * FROM t1                                    |     1
+ db2                | 6633979598391393345 | SELECT * FROM t3 where c = 20                       |     1
+ db1                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
+ db2                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
+ db2                |                     | SELECT * FROM t3                                    |     1
+ db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     2
+(9 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+\c db1
+DROP TABLE t1;
+DROP TABLE t2;
+DROP FUNCTION ADD;
+\c db2
+DROP TABLE t1;
+DROP TABLE t3;
+DROP FUNCTION ADD;
+\c contrib_regression
+DROP DATABASE db1;
+DROP DATABASE db2;
+DROP EXTENSION pg_stat_monitor;

--- a/regression/expected/squashing.out
+++ b/regression/expected/squashing.out
@@ -1,0 +1,6 @@
+--
+-- Const squashing functionality
+--
+SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+\if :skip_test
+\quit

--- a/regression/expected/squashing_1.out
+++ b/regression/expected/squashing_1.out
@@ -1,0 +1,792 @@
+--
+-- Const squashing functionality
+--
+SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+\if :skip_test
+\quit
+\endif
+CREATE EXTENSION pg_stat_monitor;
+SET pg_stat_monitor.pgsm_normalized_query = TRUE;
+--
+-- Simple Lists
+--
+CREATE TABLE test_squash (id int, data int);
+-- single element will not be squashed
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash WHERE id IN (1);
+ id | data 
+----+------
+(0 rows)
+
+SELECT ARRAY[1];
+ array 
+-------
+ {1}
+(1 row)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                      query                      | calls 
+-------------------------------------------------+-------
+ SELECT * FROM test_squash WHERE id IN ($1)      |     1
+ SELECT ARRAY[$1]                                |     1
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
+(3 rows)
+
+-- more than 1 element in a list will be squashed
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash WHERE id IN (1, 2, 3);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5);
+ id | data 
+----+------
+(0 rows)
+
+SELECT ARRAY[1, 2, 3];
+  array  
+---------
+ {1,2,3}
+(1 row)
+
+SELECT ARRAY[1, 2, 3, 4];
+   array   
+-----------
+ {1,2,3,4}
+(1 row)
+
+SELECT ARRAY[1, 2, 3, 4, 5];
+    array    
+-------------
+ {1,2,3,4,5}
+(1 row)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                         query                         | calls 
+-------------------------------------------------------+-------
+ SELECT * FROM test_squash WHERE id IN ($1 /*, ... */) |     3
+ SELECT ARRAY[$1 /*, ... */]                           |     3
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t       |     1
+(3 rows)
+
+-- built-in functions will be squashed
+-- the IN and ARRAY forms of this statement will have the same queryId
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT WHERE 1 IN (1, int4(1), int4(2), 2);
+--
+(1 row)
+
+SELECT WHERE 1 = ANY (ARRAY[1, int4(1), int4(2), 2]);
+--
+(1 row)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                      query                      | calls 
+-------------------------------------------------+-------
+ SELECT WHERE $1 IN ($2 /*, ... */)              |     2
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
+(2 rows)
+
+-- This tests are disabled due bug in PGSM, see: https://perconadev.atlassian.net/browse/PG-1936
+-- -- external parameters will be squashed
+-- SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+-- SELECT * FROM test_squash WHERE id IN ($1, $2, $3, $4, $5)  \bind 1 2 3 4 5
+-- ;
+-- SELECT * FROM test_squash WHERE id::text = ANY(ARRAY[$1, $2, $3, $4, $5]) \bind 1 2 3 4 5
+-- ;
+-- SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+-- -- prepared statements will also be squashed
+-- -- the IN and ARRAY forms of this statement will have the same queryId
+-- SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+-- PREPARE p1(int, int, int, int, int) AS
+-- SELECT * FROM test_squash WHERE id IN ($1, $2, $3, $4, $5);
+-- EXECUTE p1(1, 2, 3, 4, 5);
+-- DEALLOCATE p1;
+-- PREPARE p1(int, int, int, int, int) AS
+-- SELECT * FROM test_squash WHERE id = ANY(ARRAY[$1, $2, $3, $4, $5]);
+-- EXECUTE p1(1, 2, 3, 4, 5);
+-- DEALLOCATE p1;
+-- SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+-- More conditions in the query
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9) AND data = 2;
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10) AND data = 2;
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11) AND data = 2;
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]) AND data = 2;
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) AND data = 2;
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) AND data = 2;
+ id | data 
+----+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                                query                                | calls 
+---------------------------------------------------------------------+-------
+ SELECT * FROM test_squash WHERE id IN ($1 /*, ... */) AND data = $2 |     6
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t                     |     1
+(2 rows)
+
+-- Multiple squashed intervals
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9)
+    AND data IN (1, 2, 3, 4, 5, 6, 7, 8, 9);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    AND data IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+    AND data IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9])
+    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                         query                         | calls 
+-------------------------------------------------------+-------
+ SELECT * FROM test_squash WHERE id IN ($1 /*, ... */)+|     6
+     AND data IN ($2 /*, ... */)                       | 
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t       |     1
+(2 rows)
+
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+-- No constants squashing for OpExpr
+-- The IN and ARRAY forms of this statement will have the same queryId
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash WHERE id IN
+	(1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id IN
+	(@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9');
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id = ANY(ARRAY
+	[1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id = ANY(ARRAY
+	[@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9']);
+ id | data 
+----+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                                               query                                                | calls 
+----------------------------------------------------------------------------------------------------+-------
+ SELECT * FROM test_squash WHERE id IN                                                             +|     2
+         ($1 + $2, $3 + $4, $5 + $6, $7 + $8, $9 + $10, $11 + $12, $13 + $14, $15 + $16, $17 + $18) | 
+ SELECT * FROM test_squash WHERE id IN                                                             +|     2
+         (@ $1, @ $2, @ $3, @ $4, @ $5, @ $6, @ $7, @ $8, @ $9)                                     | 
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t                                                    |     1
+(3 rows)
+
+--
+-- FuncExpr
+--
+-- Verify multiple type representation end up with the same query_id
+CREATE TABLE test_float (data float);
+-- The casted ARRAY expressions will have the same queryId as the IN clause
+-- form of the query
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT data FROM test_float WHERE data IN (1, 2);
+ data 
+------
+(0 rows)
+
+SELECT data FROM test_float WHERE data IN (1, '2');
+ data 
+------
+(0 rows)
+
+SELECT data FROM test_float WHERE data IN ('1', 2);
+ data 
+------
+(0 rows)
+
+SELECT data FROM test_float WHERE data IN ('1', '2');
+ data 
+------
+(0 rows)
+
+SELECT data FROM test_float WHERE data IN (1.0, 1.0);
+ data 
+------
+(0 rows)
+
+SELECT data FROM test_float WHERE data = ANY(ARRAY['1'::double precision, '2'::double precision]);
+ data 
+------
+(0 rows)
+
+SELECT data FROM test_float WHERE data = ANY(ARRAY[1.0::double precision, 1.0::double precision]);
+ data 
+------
+(0 rows)
+
+SELECT data FROM test_float WHERE data = ANY(ARRAY[1, 2]);
+ data 
+------
+(0 rows)
+
+SELECT data FROM test_float WHERE data = ANY(ARRAY[1, '2']);
+ data 
+------
+(0 rows)
+
+SELECT data FROM test_float WHERE data = ANY(ARRAY['1', 2]);
+ data 
+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                               query                                | calls 
+--------------------------------------------------------------------+-------
+ SELECT data FROM test_float WHERE data = ANY(ARRAY[$1 /*, ... */]) |     3
+ SELECT data FROM test_float WHERE data IN ($1 /*, ... */)          |     7
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t                    |     1
+(3 rows)
+
+-- Numeric type, implicit cast is squashed
+CREATE TABLE test_squash_numeric (id int, data numeric(5, 2));
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash_numeric WHERE data IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash_numeric WHERE data = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                                  query                                   | calls 
+--------------------------------------------------------------------------+-------
+ SELECT * FROM test_squash_numeric WHERE data = ANY(ARRAY[$1 /*, ... */]) |     1
+ SELECT * FROM test_squash_numeric WHERE data IN ($1 /*, ... */)          |     1
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t                          |     1
+(3 rows)
+
+-- Bigint, implicit cast is squashed
+CREATE TABLE test_squash_bigint (id int, data bigint);
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash_bigint WHERE data IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash_bigint WHERE data = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                                  query                                  | calls 
+-------------------------------------------------------------------------+-------
+ SELECT * FROM test_squash_bigint WHERE data = ANY(ARRAY[$1 /*, ... */]) |     1
+ SELECT * FROM test_squash_bigint WHERE data IN ($1 /*, ... */)          |     1
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t                         |     1
+(3 rows)
+
+-- Bigint, explicit cast is squashed
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash_bigint WHERE data IN
+	(1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
+	 7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash_bigint WHERE data = ANY(ARRAY[
+	 1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
+	 7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                      query                      | calls 
+-------------------------------------------------+-------
+ SELECT * FROM test_squash_bigint WHERE data IN +|     2
+         ($1 /*, ... */)                         | 
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
+(2 rows)
+
+-- Bigint, long tokens with parenthesis, will not squash
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash_bigint WHERE id IN
+	(abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
+	 abs(800), abs(900), abs(1000), ((abs(1100))));
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash_bigint WHERE id = ANY(ARRAY[
+	 abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
+	 abs(800), abs(900), abs(1000), ((abs(1100)))]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                                  query                                  | calls 
+-------------------------------------------------------------------------+-------
+ SELECT * FROM test_squash_bigint WHERE id IN                           +|     2
+         (abs($1), abs($2), abs($3), abs($4), abs($5), abs($6), abs($7),+| 
+          abs($8), abs($9), abs($10), ((abs($11))))                      | 
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t                         |     1
+(2 rows)
+
+-- Multiple FuncExpr's. Will not squash
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT WHERE 1 IN (1::int::bigint::int, 2::int::bigint::int);
+--
+(1 row)
+
+SELECT WHERE 1 = ANY(ARRAY[1::int::bigint::int, 2::int::bigint::int]);
+--
+(1 row)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                      query                      | calls 
+-------------------------------------------------+-------
+ SELECT WHERE $1 IN ($2 /*, ... */)              |     2
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
+(2 rows)
+
+--
+-- CoerceViaIO
+--
+-- Create some dummy type to force CoerceViaIO
+CREATE TYPE casttesttype;
+CREATE FUNCTION casttesttype_in(cstring)
+   RETURNS casttesttype
+   AS 'textin'
+   LANGUAGE internal STRICT IMMUTABLE;
+NOTICE:  return type casttesttype is only a shell
+CREATE FUNCTION casttesttype_out(casttesttype)
+   RETURNS cstring
+   AS 'textout'
+   LANGUAGE internal STRICT IMMUTABLE;
+NOTICE:  argument type casttesttype is only a shell
+LINE 1: CREATE FUNCTION casttesttype_out(casttesttype)
+                                         ^
+CREATE TYPE casttesttype (
+   internallength = variable,
+   input = casttesttype_in,
+   output = casttesttype_out,
+   alignment = int4
+);
+CREATE CAST (int4 AS casttesttype) WITH INOUT;
+CREATE FUNCTION casttesttype_eq(casttesttype, casttesttype)
+returns boolean language sql immutable as $$
+    SELECT true
+$$;
+CREATE OPERATOR = (
+    leftarg = casttesttype,
+    rightarg = casttesttype,
+    procedure = casttesttype_eq,
+    commutator = =);
+CREATE TABLE test_squash_cast (id int, data casttesttype);
+-- Use the introduced type to construct a list of CoerceViaIO around Const
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash_cast WHERE data IN
+	(1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
+	 4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
+	 7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
+	 10::int4::casttesttype, 11::int4::casttesttype);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash_cast WHERE data = ANY (ARRAY
+	[1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
+	 4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
+	 7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
+	 10::int4::casttesttype, 11::int4::casttesttype]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                      query                      | calls 
+-------------------------------------------------+-------
+ SELECT * FROM test_squash_cast WHERE data IN   +|     2
+         ($1 /*, ... */)                         | 
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
+(2 rows)
+
+-- Some casting expression are simplified to Const
+CREATE TABLE test_squash_jsonb (id int, data jsonb);
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash_jsonb WHERE data IN
+	(('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
+	 ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
+	 ('"9"')::jsonb, ('"10"')::jsonb);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash_jsonb WHERE data = ANY (ARRAY
+	[('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
+	 ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
+	 ('"9"')::jsonb, ('"10"')::jsonb]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                      query                      | calls 
+-------------------------------------------------+-------
+ SELECT * FROM test_squash_jsonb WHERE data IN  +|     2
+         ($1 /*, ... */)                         | 
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
+(2 rows)
+
+-- CoerceViaIO, SubLink instead of a Const. Will not squash
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT * FROM test_squash_jsonb WHERE data IN
+	((SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
+	 (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
+	 (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
+	 (SELECT '"10"')::jsonb);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash_jsonb WHERE data = ANY(ARRAY
+	[(SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
+	 (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
+	 (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
+	 (SELECT '"10"')::jsonb]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                                query                                 | calls 
+----------------------------------------------------------------------+-------
+ SELECT * FROM test_squash_jsonb WHERE data IN                       +|     2
+         ((SELECT $1)::jsonb, (SELECT $2)::jsonb, (SELECT $3)::jsonb,+| 
+          (SELECT $4)::jsonb, (SELECT $5)::jsonb, (SELECT $6)::jsonb,+| 
+          (SELECT $7)::jsonb, (SELECT $8)::jsonb, (SELECT $9)::jsonb,+| 
+          (SELECT $10)::jsonb)                                        | 
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t                      |     1
+(2 rows)
+
+-- Multiple CoerceViaIO are squashed
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT WHERE 1 IN (1::text::int::text::int, 1::text::int::text::int);
+--
+(1 row)
+
+SELECT WHERE 1 = ANY(ARRAY[1::text::int::text::int, 1::text::int::text::int]);
+--
+(1 row)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                      query                      | calls 
+-------------------------------------------------+-------
+ SELECT WHERE $1 IN ($2 /*, ... */)              |     2
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
+(2 rows)
+
+--
+-- RelabelType
+--
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+-- However many layers of RelabelType there are, the list will be squashable.
+SELECT * FROM test_squash WHERE id IN
+	(1::oid, 2::oid, 3::oid, 4::oid, 5::oid, 6::oid, 7::oid, 8::oid, 9::oid);
+ id | data 
+----+------
+(0 rows)
+
+SELECT ARRAY[1::oid, 2::oid, 3::oid, 4::oid, 5::oid, 6::oid, 7::oid, 8::oid, 9::oid];
+        array        
+---------------------
+ {1,2,3,4,5,6,7,8,9}
+(1 row)
+
+SELECT * FROM test_squash WHERE id IN (1::oid, 2::oid::int::oid);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1::oid, 2::oid::int::oid]);
+ id | data 
+----+------
+(0 rows)
+
+-- RelabelType together with CoerceViaIO is also squashable
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1::oid::text::int::oid, 2::oid::int::oid]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1::text::int::oid, 2::oid::int::oid]);
+ id | data 
+----+------
+(0 rows)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                      query                      | calls 
+-------------------------------------------------+-------
+ SELECT * FROM test_squash WHERE id IN          +|     5
+         ($1 /*, ... */)                         | 
+ SELECT ARRAY[$1 /*, ... */]                     |     1
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
+(3 rows)
+
+--
+-- edge cases
+--
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+-- for nested arrays, only constants are squashed
+SELECT ARRAY[
+    ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    ];
+                                             array                                             
+-----------------------------------------------------------------------------------------------
+ {{1,2,3,4,5,6,7,8,9,10},{1,2,3,4,5,6,7,8,9,10},{1,2,3,4,5,6,7,8,9,10},{1,2,3,4,5,6,7,8,9,10}}
+(1 row)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                      query                      | calls 
+-------------------------------------------------+-------
+ SELECT ARRAY[                                  +|     1
+     ARRAY[$1 /*, ... */],                      +| 
+     ARRAY[$2 /*, ... */],                      +| 
+     ARRAY[$3 /*, ... */],                      +| 
+     ARRAY[$4 /*, ... */]                       +| 
+     ]                                           | 
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
+(2 rows)
+
+-- Test constants evaluation in a CTE, which was causing issues in the past
+WITH cte AS (
+    SELECT 'const' as const FROM test_squash
+)
+SELECT ARRAY['a', 'b', 'c', const::varchar] AS result
+FROM cte;
+ result 
+--------
+(0 rows)
+
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+-- Rewritten as an OpExpr, so it will not be squashed
+select where '1' IN ('1'::int, '2'::int::text);
+--
+(1 row)
+
+-- Rewritten as an ArrayExpr, so it will be squashed
+select where '1' IN ('1'::int, '2'::int);
+--
+(1 row)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                      query                      | calls 
+-------------------------------------------------+-------
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
+ select where $1 IN ($2 /*, ... */)              |     1
+ select where $1 IN ($2::int, $3::int::text)     |     1
+(3 rows)
+
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+-- Both of these queries will be rewritten as an ArrayExpr, so they
+-- will be squashed, and have a similar queryId
+select where '1' IN ('1'::int::text, '2'::int::text);
+--
+(1 row)
+
+select where '1' = ANY (array['1'::int::text, '2'::int::text]);
+--
+(1 row)
+
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+                      query                      | calls 
+-------------------------------------------------+-------
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
+ select where $1 IN ($2 /*, ... */)              |     2
+(2 rows)
+
+--
+-- cleanup
+--
+DROP TABLE test_squash;
+DROP TABLE test_float;
+DROP TABLE test_squash_numeric;
+DROP TABLE test_squash_bigint;
+DROP TABLE test_squash_cast CASCADE;
+DROP TABLE test_squash_jsonb;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/parallel.sql
+++ b/regression/sql/parallel.sql
@@ -1,0 +1,32 @@
+--
+-- Tests for parallel statistics
+--
+
+SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+\if :skip_test
+\quit
+\endif
+
+CREATE EXTENSION pg_stat_monitor;
+SET pgsm.track_utility = FALSE;
+
+-- encourage use of parallel plans
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET max_parallel_workers_per_gather = 2;
+
+CREATE TABLE pgsm_parallel_tab (a int);
+
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+
+SELECT count(*) FROM pgsm_parallel_tab;
+
+SELECT query,
+  parallel_workers_to_launch > 0 AS has_workers_to_launch,
+  parallel_workers_launched > 0 AS has_workers_launched
+  FROM pg_stat_monitor
+  WHERE query ~ 'SELECT count'
+  ORDER BY query COLLATE "C";
+
+DROP TABLE pgsm_parallel_tab;

--- a/regression/sql/squashing.sql
+++ b/regression/sql/squashing.sql
@@ -1,0 +1,312 @@
+--
+-- Const squashing functionality
+--
+
+SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+\if :skip_test
+\quit
+\endif
+
+CREATE EXTENSION pg_stat_monitor;
+SET pg_stat_monitor.pgsm_normalized_query = TRUE;
+
+--
+-- Simple Lists
+--
+
+CREATE TABLE test_squash (id int, data int);
+
+-- single element will not be squashed
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash WHERE id IN (1);
+SELECT ARRAY[1];
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- more than 1 element in a list will be squashed
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash WHERE id IN (1, 2, 3);
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4);
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5);
+SELECT ARRAY[1, 2, 3];
+SELECT ARRAY[1, 2, 3, 4];
+SELECT ARRAY[1, 2, 3, 4, 5];
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- built-in functions will be squashed
+-- the IN and ARRAY forms of this statement will have the same queryId
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT WHERE 1 IN (1, int4(1), int4(2), 2);
+SELECT WHERE 1 = ANY (ARRAY[1, int4(1), int4(2), 2]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- This tests are disabled due bug in PGSM, see: https://perconadev.atlassian.net/browse/PG-1936
+-- -- external parameters will be squashed
+-- SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+-- SELECT * FROM test_squash WHERE id IN ($1, $2, $3, $4, $5)  \bind 1 2 3 4 5
+-- ;
+-- SELECT * FROM test_squash WHERE id::text = ANY(ARRAY[$1, $2, $3, $4, $5]) \bind 1 2 3 4 5
+-- ;
+-- SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- -- prepared statements will also be squashed
+-- -- the IN and ARRAY forms of this statement will have the same queryId
+-- SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+-- PREPARE p1(int, int, int, int, int) AS
+-- SELECT * FROM test_squash WHERE id IN ($1, $2, $3, $4, $5);
+-- EXECUTE p1(1, 2, 3, 4, 5);
+-- DEALLOCATE p1;
+-- PREPARE p1(int, int, int, int, int) AS
+-- SELECT * FROM test_squash WHERE id = ANY(ARRAY[$1, $2, $3, $4, $5]);
+-- EXECUTE p1(1, 2, 3, 4, 5);
+-- DEALLOCATE p1;
+-- SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- More conditions in the query
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9) AND data = 2;
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10) AND data = 2;
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11) AND data = 2;
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]) AND data = 2;
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) AND data = 2;
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) AND data = 2;
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- Multiple squashed intervals
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9)
+    AND data IN (1, 2, 3, 4, 5, 6, 7, 8, 9);
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    AND data IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+    AND data IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9])
+    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+
+-- No constants squashing for OpExpr
+-- The IN and ARRAY forms of this statement will have the same queryId
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash WHERE id IN
+	(1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9);
+SELECT * FROM test_squash WHERE id IN
+	(@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9');
+SELECT * FROM test_squash WHERE id = ANY(ARRAY
+	[1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9]);
+SELECT * FROM test_squash WHERE id = ANY(ARRAY
+	[@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9']);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+--
+-- FuncExpr
+--
+
+-- Verify multiple type representation end up with the same query_id
+CREATE TABLE test_float (data float);
+-- The casted ARRAY expressions will have the same queryId as the IN clause
+-- form of the query
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT data FROM test_float WHERE data IN (1, 2);
+SELECT data FROM test_float WHERE data IN (1, '2');
+SELECT data FROM test_float WHERE data IN ('1', 2);
+SELECT data FROM test_float WHERE data IN ('1', '2');
+SELECT data FROM test_float WHERE data IN (1.0, 1.0);
+SELECT data FROM test_float WHERE data = ANY(ARRAY['1'::double precision, '2'::double precision]);
+SELECT data FROM test_float WHERE data = ANY(ARRAY[1.0::double precision, 1.0::double precision]);
+SELECT data FROM test_float WHERE data = ANY(ARRAY[1, 2]);
+SELECT data FROM test_float WHERE data = ANY(ARRAY[1, '2']);
+SELECT data FROM test_float WHERE data = ANY(ARRAY['1', 2]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- Numeric type, implicit cast is squashed
+CREATE TABLE test_squash_numeric (id int, data numeric(5, 2));
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash_numeric WHERE data IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+SELECT * FROM test_squash_numeric WHERE data = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- Bigint, implicit cast is squashed
+CREATE TABLE test_squash_bigint (id int, data bigint);
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash_bigint WHERE data IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+SELECT * FROM test_squash_bigint WHERE data = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- Bigint, explicit cast is squashed
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash_bigint WHERE data IN
+	(1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
+	 7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint);
+SELECT * FROM test_squash_bigint WHERE data = ANY(ARRAY[
+	 1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
+	 7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- Bigint, long tokens with parenthesis, will not squash
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash_bigint WHERE id IN
+	(abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
+	 abs(800), abs(900), abs(1000), ((abs(1100))));
+SELECT * FROM test_squash_bigint WHERE id = ANY(ARRAY[
+	 abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
+	 abs(800), abs(900), abs(1000), ((abs(1100)))]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- Multiple FuncExpr's. Will not squash
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT WHERE 1 IN (1::int::bigint::int, 2::int::bigint::int);
+SELECT WHERE 1 = ANY(ARRAY[1::int::bigint::int, 2::int::bigint::int]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+--
+-- CoerceViaIO
+--
+
+-- Create some dummy type to force CoerceViaIO
+CREATE TYPE casttesttype;
+
+CREATE FUNCTION casttesttype_in(cstring)
+   RETURNS casttesttype
+   AS 'textin'
+   LANGUAGE internal STRICT IMMUTABLE;
+
+CREATE FUNCTION casttesttype_out(casttesttype)
+   RETURNS cstring
+   AS 'textout'
+   LANGUAGE internal STRICT IMMUTABLE;
+
+CREATE TYPE casttesttype (
+   internallength = variable,
+   input = casttesttype_in,
+   output = casttesttype_out,
+   alignment = int4
+);
+
+CREATE CAST (int4 AS casttesttype) WITH INOUT;
+
+CREATE FUNCTION casttesttype_eq(casttesttype, casttesttype)
+returns boolean language sql immutable as $$
+    SELECT true
+$$;
+
+CREATE OPERATOR = (
+    leftarg = casttesttype,
+    rightarg = casttesttype,
+    procedure = casttesttype_eq,
+    commutator = =);
+
+CREATE TABLE test_squash_cast (id int, data casttesttype);
+
+-- Use the introduced type to construct a list of CoerceViaIO around Const
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash_cast WHERE data IN
+	(1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
+	 4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
+	 7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
+	 10::int4::casttesttype, 11::int4::casttesttype);
+SELECT * FROM test_squash_cast WHERE data = ANY (ARRAY
+	[1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
+	 4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
+	 7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
+	 10::int4::casttesttype, 11::int4::casttesttype]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- Some casting expression are simplified to Const
+CREATE TABLE test_squash_jsonb (id int, data jsonb);
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash_jsonb WHERE data IN
+	(('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
+	 ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
+	 ('"9"')::jsonb, ('"10"')::jsonb);
+SELECT * FROM test_squash_jsonb WHERE data = ANY (ARRAY
+	[('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
+	 ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
+	 ('"9"')::jsonb, ('"10"')::jsonb]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- CoerceViaIO, SubLink instead of a Const. Will not squash
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT * FROM test_squash_jsonb WHERE data IN
+	((SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
+	 (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
+	 (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
+	 (SELECT '"10"')::jsonb);
+SELECT * FROM test_squash_jsonb WHERE data = ANY(ARRAY
+	[(SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
+	 (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
+	 (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
+	 (SELECT '"10"')::jsonb]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- Multiple CoerceViaIO are squashed
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT WHERE 1 IN (1::text::int::text::int, 1::text::int::text::int);
+SELECT WHERE 1 = ANY(ARRAY[1::text::int::text::int, 1::text::int::text::int]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+--
+-- RelabelType
+--
+
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+-- However many layers of RelabelType there are, the list will be squashable.
+SELECT * FROM test_squash WHERE id IN
+	(1::oid, 2::oid, 3::oid, 4::oid, 5::oid, 6::oid, 7::oid, 8::oid, 9::oid);
+SELECT ARRAY[1::oid, 2::oid, 3::oid, 4::oid, 5::oid, 6::oid, 7::oid, 8::oid, 9::oid];
+SELECT * FROM test_squash WHERE id IN (1::oid, 2::oid::int::oid);
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1::oid, 2::oid::int::oid]);
+-- RelabelType together with CoerceViaIO is also squashable
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1::oid::text::int::oid, 2::oid::int::oid]);
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1::text::int::oid, 2::oid::int::oid]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+--
+-- edge cases
+--
+
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+-- for nested arrays, only constants are squashed
+SELECT ARRAY[
+    ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    ];
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+-- Test constants evaluation in a CTE, which was causing issues in the past
+WITH cte AS (
+    SELECT 'const' as const FROM test_squash
+)
+SELECT ARRAY['a', 'b', 'c', const::varchar] AS result
+FROM cte;
+
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+-- Rewritten as an OpExpr, so it will not be squashed
+select where '1' IN ('1'::int, '2'::int::text);
+-- Rewritten as an ArrayExpr, so it will be squashed
+select where '1' IN ('1'::int, '2'::int);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+-- Both of these queries will be rewritten as an ArrayExpr, so they
+-- will be squashed, and have a similar queryId
+select where '1' IN ('1'::int::text, '2'::int::text);
+select where '1' = ANY (array['1'::int::text, '2'::int::text]);
+SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
+
+--
+-- cleanup
+--
+DROP TABLE test_squash;
+DROP TABLE test_float;
+DROP TABLE test_squash_numeric;
+DROP TABLE test_squash_bigint;
+DROP TABLE test_squash_cast CASCADE;
+DROP TABLE test_squash_jsonb;
+SELECT pg_stat_monitor_reset();
+DROP EXTENSION pg_stat_monitor;

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -22,7 +22,22 @@ print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
 close $conf;
 
 # Dictionary for expected PGSM columns names on different PG server versions
-my %pg_versions_pgsm_columns = ( 17 => "application_name,".
+my %pg_versions_pgsm_columns = ( 18 => "application_name,".
+   "bucket,bucket_done,bucket_start_time,calls," .
+   "client_ip,cmd_type,cmd_type_text,comments,cpu_sys_time,cpu_user_time," .
+   "datname,dbid,elevel,jit_deform_count,jit_deform_time," .
+   "jit_emission_count,jit_emission_time,jit_functions,jit_generation_time," .
+   "jit_inlining_count,jit_inlining_time,jit_optimization_count,jit_optimization_time," .
+   "local_blk_read_time,local_blk_write_time,local_blks_dirtied,local_blks_hit,".
+   "local_blks_read,local_blks_written,max_exec_time,max_plan_time,mean_exec_time," .
+   "mean_plan_time,message,min_exec_time,min_plan_time,minmax_stats_since," .
+   "pgsm_query_id,planid,plans,query,query_plan,queryid,relations,resp_calls,rows," .
+   "shared_blk_read_time,shared_blk_write_time,shared_blks_dirtied," .
+   "shared_blks_hit,shared_blks_read,shared_blks_written,sqlcode,stats_since," .
+   "stddev_exec_time,stddev_plan_time,temp_blk_read_time,temp_blk_write_time," .
+   "temp_blks_read,temp_blks_written,top_query,top_queryid,toplevel," .
+   "total_exec_time,total_plan_time,userid,username,wal_bytes,wal_fpi,wal_records",
+   17 => "application_name,".
    "bucket,bucket_done,bucket_start_time,calls," .
    "client_ip,cmd_type,cmd_type_text,comments,cpu_sys_time,cpu_user_time," .
    "datname,dbid,elevel,jit_deform_count,jit_deform_time," .

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -31,6 +31,7 @@ my %pg_versions_pgsm_columns = ( 18 => "application_name,".
    "local_blk_read_time,local_blk_write_time,local_blks_dirtied,local_blks_hit,".
    "local_blks_read,local_blks_written,max_exec_time,max_plan_time,mean_exec_time," .
    "mean_plan_time,message,min_exec_time,min_plan_time,minmax_stats_since," .
+   "parallel_workers_launched,parallel_workers_to_launch," .
    "pgsm_query_id,planid,plans,query,query_plan,queryid,relations,resp_calls,rows," .
    "shared_blk_read_time,shared_blk_write_time,shared_blks_dirtied," .
    "shared_blks_hit,shared_blks_read,shared_blks_written,sqlcode,stats_since," .

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -36,7 +36,8 @@ my %pg_versions_pgsm_columns = ( 18 => "application_name,".
    "shared_blks_hit,shared_blks_read,shared_blks_written,sqlcode,stats_since," .
    "stddev_exec_time,stddev_plan_time,temp_blk_read_time,temp_blk_write_time," .
    "temp_blks_read,temp_blks_written,top_query,top_queryid,toplevel," .
-   "total_exec_time,total_plan_time,userid,username,wal_bytes,wal_fpi,wal_records",
+   "total_exec_time,total_plan_time,userid,username,wal_buffers_full,wal_bytes," .
+   "wal_fpi,wal_records",
    17 => "application_name,".
    "bucket,bucket_done,bucket_start_time,calls," .
    "client_ip,cmd_type,cmd_type_text,comments,cpu_sys_time,cpu_user_time," .

--- a/t/025_compare_pgss.pl
+++ b/t/025_compare_pgss.pl
@@ -145,6 +145,14 @@ if ($PGSM::PG_MAJOR_VERSION >= 18)
     ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.wal_buffers_full) = SUM(PGSS.wal_buffers_full) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
     trim($stdout);
     is($stdout,'t',"Compare: wal_buffers_full are equal.");
+
+    ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.parallel_workers_to_launch) = SUM(PGSS.parallel_workers_to_launch) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+    trim($stdout);
+    is($stdout,'t',"Compare: parallel_workers_to_launch are equal.");
+
+    ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.parallel_workers_launched) = SUM(PGSS.parallel_workers_launched) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+    trim($stdout);
+    is($stdout,'t',"Compare: parallel_workers_launched are equal.");
 }
 
 # Compare values for query 'INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)' 
@@ -201,6 +209,14 @@ if ($PGSM::PG_MAJOR_VERSION >= 18)
     ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.wal_buffers_full) = SUM(PGSS.wal_buffers_full) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
     trim($stdout);
     is($stdout,'t',"Compare: wal_buffers_full are equal.");
+
+    ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.parallel_workers_to_launch) = SUM(PGSS.parallel_workers_to_launch) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+    trim($stdout);
+    is($stdout,'t',"Compare: parallel_workers_to_launch are equal.");
+
+    ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.parallel_workers_launched) = SUM(PGSS.parallel_workers_launched) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+    trim($stdout);
+    is($stdout,'t',"Compare: parallel_workers_launched are equal.");
 }
 
 # Compare values for query 'SELECT abalance FROM pgbench_accounts WHERE aid = $1' 
@@ -257,6 +273,14 @@ if ($PGSM::PG_MAJOR_VERSION >= 18)
     ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.wal_buffers_full) = SUM(PGSS.wal_buffers_full) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
     trim($stdout);
     is($stdout,'t',"Compare: wal_buffers_full are equal.");
+
+    ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.parallel_workers_to_launch) = SUM(PGSS.parallel_workers_to_launch) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+    trim($stdout);
+    is($stdout,'t',"Compare: parallel_workers_to_launch are equal.");
+
+    ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.parallel_workers_launched) = SUM(PGSS.parallel_workers_launched) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+    trim($stdout);
+    is($stdout,'t',"Compare: parallel_workers_launched are equal.");
 }
 
 # Compare values for query 'UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2'
@@ -309,6 +333,14 @@ if ($PGSM::PG_MAJOR_VERSION >= 18)
     ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.wal_buffers_full) = SUM(PGSS.wal_buffers_full) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
     trim($stdout);
     is($stdout,'t',"Compare: wal_buffers_full are equal.");
+
+    ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.parallel_workers_to_launch) = SUM(PGSS.parallel_workers_to_launch) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+    trim($stdout);
+    is($stdout,'t',"Compare: parallel_workers_to_launch are equal.");
+
+    ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT SUM(PGSM.parallel_workers_launched) = SUM(PGSS.parallel_workers_launched) FROM pg_stat_monitor AS PGSM INNER JOIN pg_stat_statements AS PGSS ON PGSS.query = PGSM.query WHERE PGSM.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY PGSM.query;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+    trim($stdout);
+    is($stdout,'t',"Compare: parallel_workers_launched are equal.");
 }
 
 # DROP EXTENSION

--- a/t/expected/007_settings_pgsm_query_shared_buffer.out.18
+++ b/t/expected/007_settings_pgsm_query_shared_buffer.out.18
@@ -1,0 +1,151 @@
+CREATE EXTENSION pg_stat_monitor;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_shared_buffer';
+                   name                   | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_query_shared_buffer | 1       | MB   | postmaster | integer | configuration file | 1       | 10000   |          | 20       | 1         | f
+(1 row)
+
+CREATE database example;
+SELECT datname, substr(query,0,150) AS query, SUM(calls) AS calls FROM pg_stat_monitor GROUP BY datname, query ORDER BY datname, query, calls DESC Limit 20;
+ datname |                                                     query                                                     | calls 
+---------+---------------------------------------------------------------------------------------------------------------+-------
+ example | INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)          | 10000
+ example | SELECT abalance FROM pgbench_accounts WHERE aid = $1                                                          | 10000
+ example | SELECT relkind FROM pg_catalog.pg_class WHERE oid=$1::pg_catalog.regclass                                     |     3
+ example | UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2                                           | 10000
+ example | UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2                                           | 10000
+ example | UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2                                            | 10000
+ example | alter table pgbench_accounts add primary key (aid)                                                            |     1
+ example | alter table pgbench_branches add primary key (bid)                                                            |     1
+ example | alter table pgbench_tellers add primary key (tid)                                                             |     1
+ example | begin                                                                                                         | 10001
+ example | commit                                                                                                        | 10001
+ example | copy pgbench_accounts from stdin with (freeze on)                                                             |     1
+ example | copy pgbench_branches from stdin with (freeze on)                                                             |     1
+ example | copy pgbench_tellers from stdin with (freeze on)                                                              |     1
+ example | create table pgbench_accounts(aid    int not null,bid int,abalance int,filler char(84)) with (fillfactor=100) |     1
+ example | create table pgbench_branches(bid int not null,bbalance int,filler char(88)) with (fillfactor=100)            |     1
+ example | create table pgbench_history(tid int,bid int,aid    int,delta int,mtime timestamp,filler char(22))            |     1
+ example | create table pgbench_tellers(tid int not null,bid int,tbalance int,filler char(84)) with (fillfactor=100)     |     1
+ example | drop table if exists pgbench_accounts, pgbench_branches, pgbench_history, pgbench_tellers                     |     1
+ example | select count(*) from pgbench_branches                                                                         |     1
+(20 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_shared_buffer';
+                   name                   | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_query_shared_buffer | 2       | MB   | postmaster | integer | configuration file | 1       | 10000   |          | 20       | 2         | f
+(1 row)
+
+SELECT datname, substr(query,0,150) AS query, SUM(calls) AS calls FROM pg_stat_monitor GROUP BY datname, query ORDER BY datname, query, calls DESC Limit 20;
+ datname |                                                     query                                                     | calls 
+---------+---------------------------------------------------------------------------------------------------------------+-------
+ example | INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)          | 10000
+ example | SELECT abalance FROM pgbench_accounts WHERE aid = $1                                                          | 10000
+ example | SELECT relkind FROM pg_catalog.pg_class WHERE oid=$1::pg_catalog.regclass                                     |     3
+ example | UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2                                           | 10000
+ example | UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2                                           | 10000
+ example | UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2                                            | 10000
+ example | alter table pgbench_accounts add primary key (aid)                                                            |     1
+ example | alter table pgbench_branches add primary key (bid)                                                            |     1
+ example | alter table pgbench_tellers add primary key (tid)                                                             |     1
+ example | begin                                                                                                         | 10001
+ example | commit                                                                                                        | 10001
+ example | copy pgbench_accounts from stdin with (freeze on)                                                             |     1
+ example | copy pgbench_branches from stdin with (freeze on)                                                             |     1
+ example | copy pgbench_tellers from stdin with (freeze on)                                                              |     1
+ example | create table pgbench_accounts(aid    int not null,bid int,abalance int,filler char(84)) with (fillfactor=100) |     1
+ example | create table pgbench_branches(bid int not null,bbalance int,filler char(88)) with (fillfactor=100)            |     1
+ example | create table pgbench_history(tid int,bid int,aid    int,delta int,mtime timestamp,filler char(22))            |     1
+ example | create table pgbench_tellers(tid int not null,bid int,tbalance int,filler char(84)) with (fillfactor=100)     |     1
+ example | drop table if exists pgbench_accounts, pgbench_branches, pgbench_history, pgbench_tellers                     |     1
+ example | select count(*) from pgbench_branches                                                                         |     1
+(20 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_shared_buffer';
+                   name                   | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_query_shared_buffer | 20      | MB   | postmaster | integer | configuration file | 1       | 10000   |          | 20       | 20        | f
+(1 row)
+
+SELECT datname, substr(query,0,150) AS query, SUM(calls) AS calls FROM pg_stat_monitor GROUP BY datname, query ORDER BY datname, query, calls DESC Limit 20;
+ datname |                                                     query                                                     | calls 
+---------+---------------------------------------------------------------------------------------------------------------+-------
+ example | INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)          | 10000
+ example | SELECT abalance FROM pgbench_accounts WHERE aid = $1                                                          | 10000
+ example | SELECT relkind FROM pg_catalog.pg_class WHERE oid=$1::pg_catalog.regclass                                     |     3
+ example | UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2                                           | 10000
+ example | UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2                                           | 10000
+ example | UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2                                            | 10000
+ example | alter table pgbench_accounts add primary key (aid)                                                            |     1
+ example | alter table pgbench_branches add primary key (bid)                                                            |     1
+ example | alter table pgbench_tellers add primary key (tid)                                                             |     1
+ example | begin                                                                                                         | 10001
+ example | commit                                                                                                        | 10001
+ example | copy pgbench_accounts from stdin with (freeze on)                                                             |     1
+ example | copy pgbench_branches from stdin with (freeze on)                                                             |     1
+ example | copy pgbench_tellers from stdin with (freeze on)                                                              |     1
+ example | create table pgbench_accounts(aid    int not null,bid int,abalance int,filler char(84)) with (fillfactor=100) |     1
+ example | create table pgbench_branches(bid int not null,bbalance int,filler char(88)) with (fillfactor=100)            |     1
+ example | create table pgbench_history(tid int,bid int,aid    int,delta int,mtime timestamp,filler char(22))            |     1
+ example | create table pgbench_tellers(tid int not null,bid int,tbalance int,filler char(84)) with (fillfactor=100)     |     1
+ example | drop table if exists pgbench_accounts, pgbench_branches, pgbench_history, pgbench_tellers                     |     1
+ example | select count(*) from pgbench_branches                                                                         |     1
+(20 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_shared_buffer';
+                   name                   | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_query_shared_buffer | 2048    | MB   | postmaster | integer | configuration file | 1       | 10000   |          | 20       | 2048      | f
+(1 row)
+
+SELECT datname, substr(query,0,150) AS query, SUM(calls) AS calls FROM pg_stat_monitor GROUP BY datname, query ORDER BY datname, query, calls DESC Limit 20;
+ datname |                                                     query                                                     | calls 
+---------+---------------------------------------------------------------------------------------------------------------+-------
+ example | INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)          | 10000
+ example | SELECT abalance FROM pgbench_accounts WHERE aid = $1                                                          | 10000
+ example | SELECT relkind FROM pg_catalog.pg_class WHERE oid=$1::pg_catalog.regclass                                     |     3
+ example | UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2                                           | 10000
+ example | UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2                                           | 10000
+ example | UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2                                            | 10000
+ example | alter table pgbench_accounts add primary key (aid)                                                            |     1
+ example | alter table pgbench_branches add primary key (bid)                                                            |     1
+ example | alter table pgbench_tellers add primary key (tid)                                                             |     1
+ example | begin                                                                                                         | 10001
+ example | commit                                                                                                        | 10001
+ example | copy pgbench_accounts from stdin with (freeze on)                                                             |     1
+ example | copy pgbench_branches from stdin with (freeze on)                                                             |     1
+ example | copy pgbench_tellers from stdin with (freeze on)                                                              |     1
+ example | create table pgbench_accounts(aid    int not null,bid int,abalance int,filler char(84)) with (fillfactor=100) |     1
+ example | create table pgbench_branches(bid int not null,bbalance int,filler char(88)) with (fillfactor=100)            |     1
+ example | create table pgbench_history(tid int,bid int,aid    int,delta int,mtime timestamp,filler char(22))            |     1
+ example | create table pgbench_tellers(tid int not null,bid int,tbalance int,filler char(84)) with (fillfactor=100)     |     1
+ example | drop table if exists pgbench_accounts, pgbench_branches, pgbench_history, pgbench_tellers                     |     1
+ example | select count(*) from pgbench_branches                                                                         |     1
+(20 rows)
+
+DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
PG-1907

### Description
<!--- Describe your changes in detail -->
Full PG18 diff: https://github.com/postgres/postgres/compare/REL_17_STABLE...REL_18_STABLE

### Notable changes:
1. ExecutorRun signature change: https://github.com/postgres/postgres/commit/3eea7a0c97e94f9570af87317ce3f6a41eb62768

2. Use macro to define the number of enum values: https://github.com/postgres/postgres/commit/10b721821d6d6e27e594549cf105476dc28514c8

3. Use int64 instead of uint64 for queryIDs: https://github.com/postgres/postgres/commit/c3eda50b0648005281c2a3cf95375708f8ef97fc
In SQL we always show them as signed + it's just hashes, so we can do that change for all version of PG.

4. Add const list squashing during query normalization: 
https://github.com/postgres/postgres/commit/62d712ecfd940f60e68bde5b6972b6859937c412 
https://github.com/postgres/postgres/commit/0f65f3eec478db8ac4f217a608b4478fed023bac
https://github.com/postgres/postgres/commit/c2da1a5d6325a92d834c9cb036f65d362e4bfc3e

5. Removed volatile qualifiers, they are not needed for spinlocks since PG 9.5:
https://github.com/postgres/postgres/commit/8928817769de0d81758bc760333d3056c67b63c1
https://github.com/postgres/postgres/commit/0709b7ee72e4bc71ad07b7120acd117265ab51d0

6. Add columns to track parallel worker activity :https://github.com/postgres/postgres/commit/cf54a2c002544a4b7934deb44c895750aadb0a3c

7. Add wal_buffers_full: https://github.com/postgres/postgres/commit/ce5bcc4a9f26484746f82d23584c8e342cba9b10


### Links
<!--- Please provide links to any related PRs in this or other repositories --->

