### PR TITLE
PG-2014 Initalize nested query stack to fix crash on DDL

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -343,7 +343,7 @@ _PG_init(void)
 	ExecutorCheckPerms_hook = HOOK(pgsm_ExecutorCheckPerms);
 
 	nested_queryids = (int64 *) malloc(sizeof(int64) * max_stack_depth);
-	nested_query_txts = (char **) malloc(sizeof(char *) * max_stack_depth);
+	nested_query_txts = (char **) calloc(max_stack_depth, sizeof(char *));
 
 	system_init = true;
 }


### PR DESCRIPTION
The `pgsm_ProcessUtility()` which handles DDL increments nesting_level but does not put a query text on the next_queries stack while `pgsm_ExecutorRun()` does both. It is unclear to me if this is a mistake or by design but since readers of the query check for is the query text pointer is `NULL` and `pgsm_ExecutorRun()` reset the pointer to `NULL` before returning it is safe as long as we initialize the stack to all `NULL` pointers, which we did not.
    
This bug was found by our test suite in Jenkins on some RHEL based distro version and seems to mostly happen when the first query of a backend is `CREATE EXTENSION` and we have enabled query normalization but it is entirely possible that it could happen under other circumstances too.

The use of `calloc()` over `palloc0()` is to keep the patch small since the previous code used `malloc()`.
