### PR TITLE
Fix buffer overflow issue

### DIFF
--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -325,8 +325,9 @@ typedef struct Counters
 	JitInfo		jitinfo;
 	ErrorInfo	error;
 	Wal_Usage	walusage;
-	int			resp_calls[MAX_RESPONSE_BUCKET];	/* execution time's in
-													 * msec */
+	int			resp_calls[MAX_RESPONSE_BUCKET + 2];	/* execution time's in
+														 * msec; including 2
+														 * outlier buckets */
 	int64		parallel_workers_to_launch; /* # of parallel workers planned
 											 * to be launched */
 	int64		parallel_workers_launched;	/* # of parallel workers actually


### PR DESCRIPTION
## Correct the size of tmp array

The snprintf using it should work with any int, which means this string
has to fit ",-2147483648\0", which is 12 characters + a null terminator.

Otherwise it could lead to a buffer overflow, corrupting other variables
on the stack, and maybe causing a crash too?

## Fix resp_calls array size

This got broken during a refactoring in https://github.com/percona/pg_stat_monitor/commit/de712829223e0aefed62a1bbfe206694fa15993e. We need the plus 2
items because of the overflow/underflow bucket, without that we can
possibly overindex this array and corrupt other counters.

In earlier versions we even had the encoding variable stored directly
after this array, which possibly caused crashes or incorrectly working
string functions.