### PR TITLE
Remove code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-# Order is important; the last matching pattern takes the most precedence.
-
-*       @artemgavrilov @dutow


### PR DESCRIPTION
Since we have stopped using auto-assignment as part of our process we should probably remove the code owners file.
