### PR TITLE
Only include the security policy relevant to pg_stat_monitor

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,14 +11,6 @@ Please report any vulnerabilities to our project in [Jira](https://perconadev.at
 If the vulnerability is accepted and confirmed by our experts, you should normally expect us to deliver
 a version with a fix according to the timelines provided below:
 
-For Percona created software (our engineers wrote the code):
-
 - Low/Medium: 120 days
 - High: 90 days
 - Critical: ASAP but should not exceed 30 days
-
-For Non-Percona created software (upstream provided/packaged) from the time the vendor releases a patch:
-
-- Low/Medium: 2nd release from current version
-- High: Next release
-- Critical: Hotfix or no later than next release (our regular release cadence is once every month)


### PR DESCRIPTION
`SECURITY.md` contained the policy for all our projects and not specifically pg_stat_monitor which is hardly useful information to the target audience.