### PR TITLE
Trust semver in github actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: src/pg_stat_monitor
 
       - name: Checkout cppcheck sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           repository: "danmar/cppcheck"
           ref: "2.13.4"
@@ -43,13 +43,13 @@ jobs:
 
     steps:
       - name: Clone postgres repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           repository: 'postgres/postgres'
           ref: 'REL_17_STABLE'
 
       - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'contrib/pg_stat_monitor'
 
@@ -87,9 +87,9 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
 
       - name: Check license headers
-        uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+        uses: apache/skywalking-eyes/header@v0.8.0
         with:
           token: "" # Prevent comments

--- a/.github/workflows/code-coverage-test.yml
+++ b/.github/workflows/code-coverage-test.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Clone postgres repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           repository: 'postgres/postgres'
           ref: 'REL_15_STABLE'
@@ -83,7 +83,7 @@ jobs:
           pg_ctl -D /opt/pgsql/data -l logfile start
 
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -113,7 +113,7 @@ jobs:
         working-directory: src/pg_stat_monitor
 
       - name: Upload
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@v5
         with:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |

--- a/.github/workflows/pgxn-release.yml
+++ b/.github/workflows/pgxn-release.yml
@@ -22,7 +22,7 @@ jobs:
       shell: bash
 
     - name: Check out
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@v6
       with:
         ref: '${{ inputs.version }}'
 

--- a/.github/workflows/pmm-integration.yaml
+++ b/.github/workflows/pmm-integration.yaml
@@ -22,14 +22,14 @@ jobs:
 
     steps:
       - name: Clone QA Integration
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           repository: Percona-Lab/qa-integration
           ref: main
           path: qa-integration
 
       - name: Clone PMM UI tests
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           repository: percona/pmm-ui-tests
           ref: main
@@ -67,7 +67,7 @@ jobs:
         run: docker exec pdpgsql_pmm_${{ matrix.postgresql }}_1 cat /var/log/pmm-agent.log > ./pmm-ui-tests/tests/output/pmm-agent.log
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: tests-artifact

--- a/.github/workflows/postgresql-14-build.yml
+++ b/.github/workflows/postgresql-14-build.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone postgres repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           repository: 'postgres/postgres'
           ref: 'REL_14_STABLE'
@@ -83,7 +83,7 @@ jobs:
           pg_ctl -D /opt/pgsql/data -l logfile start
 
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |
@@ -140,7 +140,7 @@ jobs:
         run: make installcheck-world
 
       - name: Report on installcheck-world test suites fail
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
           name: Regressions output files of failed testsuite, and pg log

--- a/.github/workflows/postgresql-14-pgdg-package.yml
+++ b/.github/workflows/postgresql-14-pgdg-package.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |

--- a/.github/workflows/postgresql-14-ppg-package.yml
+++ b/.github/workflows/postgresql-14-ppg-package.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |

--- a/.github/workflows/postgresql-15-build.yml
+++ b/.github/workflows/postgresql-15-build.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone postgres repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           repository: 'postgres/postgres'
           ref: 'REL_15_STABLE'
@@ -83,7 +83,7 @@ jobs:
           pg_ctl -D /opt/pgsql/data -l logfile start
 
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |
@@ -140,7 +140,7 @@ jobs:
         run: make installcheck-world
 
       - name: Report on installcheck-world test suites fail
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
           name: Regressions output files of failed testsuite, and pg log

--- a/.github/workflows/postgresql-15-pgdg-package.yml
+++ b/.github/workflows/postgresql-15-pgdg-package.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |

--- a/.github/workflows/postgresql-15-ppg-package.yml
+++ b/.github/workflows/postgresql-15-ppg-package.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |

--- a/.github/workflows/postgresql-16-build.yml
+++ b/.github/workflows/postgresql-16-build.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone postgres repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           repository: 'postgres/postgres'
           ref: 'REL_16_STABLE'
@@ -83,7 +83,7 @@ jobs:
           pg_ctl -D /opt/pgsql/data -l logfile start
 
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |
@@ -140,7 +140,7 @@ jobs:
         run: make installcheck-world
 
       - name: Report on installcheck-world test suites fail
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
           name: Regressions output files of failed testsuite, and pg log

--- a/.github/workflows/postgresql-16-pgdg-package.yml
+++ b/.github/workflows/postgresql-16-pgdg-package.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |

--- a/.github/workflows/postgresql-16-ppg-package.yml
+++ b/.github/workflows/postgresql-16-ppg-package.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |

--- a/.github/workflows/postgresql-17-build.yml
+++ b/.github/workflows/postgresql-17-build.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone postgres repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           repository: 'postgres/postgres'
           ref: 'REL_17_STABLE'
@@ -83,7 +83,7 @@ jobs:
           pg_ctl -D /opt/pgsql/data -l logfile start
 
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |
@@ -140,7 +140,7 @@ jobs:
         run: make installcheck-world
 
       - name: Report on installcheck-world test suites fail
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
           name: Regressions output files of failed testsuite, and pg log

--- a/.github/workflows/postgresql-17-pgdg-package.yml
+++ b/.github/workflows/postgresql-17-pgdg-package.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |

--- a/.github/workflows/postgresql-17-ppg-package.yml
+++ b/.github/workflows/postgresql-17-ppg-package.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |

--- a/.github/workflows/postgresql-18-build.yml
+++ b/.github/workflows/postgresql-18-build.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone postgres repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           repository: 'postgres/postgres'
           ref: 'REL_18_STABLE'
@@ -83,7 +83,7 @@ jobs:
           pg_ctl -D /opt/pgsql/data -l logfile start
 
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |
@@ -140,7 +140,7 @@ jobs:
         run: make installcheck-world
 
       - name: Report on installcheck-world test suites fail
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
           name: Regressions output files of failed testsuite, and pg log

--- a/.github/workflows/postgresql-18-pgdg-package.yml
+++ b/.github/workflows/postgresql-18-pgdg-package.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |

--- a/.github/workflows/postgresql-18-ppg-package.yml
+++ b/.github/workflows/postgresql-18-ppg-package.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone pg_stat_monitor repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           path: 'src/pg_stat_monitor'
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload logs on fail
         if: ${{ failure() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: Regressions diff and postgresql log
           path: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,19 +23,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@v2
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: SARIF file
           path: results.sarif
@@ -43,6 +43,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard (optional).
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314 # v4.32.1
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
We don't use github actions for anything production critical, so it seems fine to trust that the promises of semver is kept for these actions rather than having dependabot spam us with patch updates.
