### PR TITLE
Cleanup includes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,7 +34,7 @@ jobs:
         working-directory: src/pg_stat_monitor
         run: |
           set -x
-          cppcheck --enable=all --inline-suppr --template='{file}:{line},{severity},{id},{message}' --error-exitcode=1 --suppress=missingIncludeSystem --suppress=missingInclude --suppress=unmatchedSuppression:pg_stat_monitor.c --check-config .
+          cppcheck --enable=all --inline-suppr --template='{file}:{line},{severity},{id},{message}' --error-exitcode=1 --suppress=missingIncludeSystem --suppress=unmatchedSuppression:pg_stat_monitor.c --check-config .
 
   format:
     name: Format

--- a/guc.c
+++ b/guc.c
@@ -14,7 +14,7 @@
  *
  *-------------------------------------------------------------------------
  */
-#include "postgres.h"
+#include <postgres.h>
 
 #include "pg_stat_monitor.h"
 

--- a/hash_query.c
+++ b/hash_query.c
@@ -14,11 +14,11 @@
  *
  *-------------------------------------------------------------------------
  */
-#include "postgres.h"
+#include <postgres.h>
 
-#include "storage/ipc.h"
-#include "storage/shmem.h"
-#include "utils/memutils.h"
+#include <storage/ipc.h>
+#include <storage/shmem.h>
+#include <utils/memutils.h>
 
 #include "pg_stat_monitor.h"
 

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -15,43 +15,43 @@
  *-------------------------------------------------------------------------
  */
 
-#include "postgres.h"
+#include <postgres.h>
 
 #include <arpa/inet.h>
 #include <math.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 
-#include "access/hash.h"
-#include "access/parallel.h"
-#include "access/xact.h"
-#include "catalog/pg_authid.h"
-#include "commands/dbcommands.h"
-#include "commands/explain.h"
-#include "common/ip.h"
-#include "funcapi.h"
-#include "jit/jit.h"
-#include "mb/pg_wchar.h"
-#include "miscadmin.h"
-#include "nodes/pg_list.h"
-#include "optimizer/planner.h"
-#include "parser/analyze.h"
-#include "parser/parsetree.h"
-#include "parser/scanner.h"
-#include "parser/scansup.h"
-#include "pgstat.h"
-#include "storage/ipc.h"
-#include "storage/proc.h"
-#include "storage/shmem.h"
-#include "tcop/utility.h"
-#include "utils/acl.h"
-#include "utils/builtins.h"
-#include "utils/lsyscache.h"
-#include "utils/memutils.h"
+#include <access/hash.h>
+#include <access/parallel.h>
+#include <access/xact.h>
+#include <catalog/pg_authid.h>
+#include <commands/dbcommands.h>
+#include <commands/explain.h>
+#include <common/ip.h>
+#include <funcapi.h>
+#include <jit/jit.h>
+#include <mb/pg_wchar.h>
+#include <miscadmin.h>
+#include <nodes/pg_list.h>
+#include <optimizer/planner.h>
+#include <parser/analyze.h>
+#include <parser/parsetree.h>
+#include <parser/scanner.h>
+#include <parser/scansup.h>
+#include <pgstat.h>
+#include <storage/ipc.h>
+#include <storage/proc.h>
+#include <storage/shmem.h>
+#include <tcop/utility.h>
+#include <utils/acl.h>
+#include <utils/builtins.h>
+#include <utils/lsyscache.h>
+#include <utils/memutils.h>
 
 #if PG_VERSION_NUM >= 180000
-#include "commands/explain_state.h"
-#include "commands/explain_format.h"
+#include <commands/explain_state.h>
+#include <commands/explain_format.h>
 #endif
 
 #include "pg_stat_monitor.h"

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -17,17 +17,17 @@
 #ifndef __PG_STAT_MONITOR_H__
 #define __PG_STAT_MONITOR_H__
 
-#include "postgres.h"
+#include <postgres.h>
 
-#include "executor/instrument.h"
-#include "lib/dshash.h"
-#include "nodes/nodes.h"
-#include "storage/lwlock.h"
-#include "storage/spin.h"
-#include "utils/dsa.h"
-#include "utils/guc.h"
-#include "utils/hsearch.h"
-#include "utils/timestamp.h"
+#include <executor/instrument.h>
+#include <lib/dshash.h>
+#include <nodes/nodes.h>
+#include <storage/lwlock.h>
+#include <storage/spin.h>
+#include <utils/dsa.h>
+#include <utils/guc.h>
+#include <utils/hsearch.h>
+#include <utils/timestamp.h>
 
 
 /* XXX: Should USAGE_EXEC reflect execution time and/or buffer usage? */


### PR DESCRIPTION
This moves includes to where they're actually needed, removes some unused includes and uses <> rather than "" for PostgreSQL headers.