### PR TITLE
Set unit for pg_stat_monitor.pgsm_query_max_len to bytes

### DIFF
--- a/guc.c
+++ b/guc.c
@@ -68,7 +68,7 @@ init_guc(void)
 							1024,	/* min value */
 							INT_MAX,	/* max value */
 							PGC_POSTMASTER, /* context */
-							0,	/* flags */
+							GUC_UNIT_BYTE,	/* flags */
 							NULL,	/* check_hook */
 							NULL,	/* assign_hook */
 							NULL	/* show_hook */

--- a/regression/expected/guc.out
+++ b/regression/expected/guc.out
@@ -29,7 +29,7 @@ COLLATE "C";
  pg_stat_monitor.pgsm_max                     | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets             | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_max_len           | 2048    | B    | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
  pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
  pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
  pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f

--- a/regression/expected/guc_1.out
+++ b/regression/expected/guc_1.out
@@ -29,7 +29,7 @@ COLLATE "C";
  pg_stat_monitor.pgsm_max                     | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets             | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_max_len           | 2048    | B    | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
  pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
  pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
  pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f

--- a/regression/expected/guc_2.out
+++ b/regression/expected/guc_2.out
@@ -29,7 +29,7 @@ COLLATE "C";
  pg_stat_monitor.pgsm_max                     | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets             | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_max_len           | 2048    | B    | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
  pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
  pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
  pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f

--- a/t/expected/001_settings_default.out
+++ b/t/expected/001_settings_default.out
@@ -19,7 +19,7 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_max                     | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets             | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_max_len           | 2048    | B    | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
  pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
  pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
  pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f
@@ -48,7 +48,7 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_max                     | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
  pg_stat_monitor.pgsm_max_buckets             | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
  pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_max_len           | 2048    | B    | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
  pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
  pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
  pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f

--- a/t/expected/015_settings_pgsm_query_max_len.out
+++ b/t/expected/015_settings_pgsm_query_max_len.out
@@ -8,7 +8,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_max_len';
                 name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_query_max_len | 10240   |      | postmaster | integer | configuration file | 1024    | 2147483647 |          | 2048     | 10240     | f
+ pg_stat_monitor.pgsm_query_max_len | 10240   | B    | postmaster | integer | configuration file | 1024    | 2147483647 |          | 2048     | 10240     | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -33,7 +33,7 @@ SELECT length(query), query FROM pg_stat_monitor ORDER BY query;
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_max_len';
                 name                | setting | unit |  context   | vartype |       source       | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_query_max_len | 1024    |      | postmaster | integer | configuration file | 1024    | 2147483647 |          | 2048     | 1024      | f
+ pg_stat_monitor.pgsm_query_max_len | 1024    | B    | postmaster | integer | configuration file | 1024    | 2147483647 |          | 2048     | 1024      | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -45,7 +45,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_max_len';
                 name                | setting | unit |  context   | vartype | source  | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ------------------------------------+---------+------+------------+---------+---------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_query_max_len | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |          | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_max_len | 2048    | B    | postmaster | integer | default | 1024    | 2147483647 |          | 2048     | 2048      | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -57,7 +57,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_max_len';
                 name                | setting | unit |  context   | vartype | source  | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ------------------------------------+---------+------+------------+---------+---------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_query_max_len | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |          | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_max_len | 2048    | B    | postmaster | integer | default | 1024    | 2147483647 |          | 2048     | 2048      | f
 (1 row)
 
 SELECT pg_stat_monitor_reset();
@@ -69,7 +69,7 @@ SELECT pg_stat_monitor_reset();
 SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_max_len';
                 name                | setting | unit |  context   | vartype | source  | min_val |  max_val   | enumvals | boot_val | reset_val | pending_restart 
 ------------------------------------+---------+------+------------+---------+---------+---------+------------+----------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_query_max_len | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |          | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_max_len | 2048    | B    | postmaster | integer | default | 1024    | 2147483647 |          | 2048     | 2048      | f
 (1 row)
 
 DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
Given the previous confusion we had in our documentation about characters vs bytes I think adding a unit would make it clear that the limit is measured in bytes.