### PR TITLE
Try to standardize formatting for CREATE FUNCTION

### DIFF
--- a/pg_stat_monitor--1.0--2.0.sql
+++ b/pg_stat_monitor--1.0--2.0.sql
@@ -86,11 +86,15 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT bucket_done         BOOLEAN
 )
 RETURNS SETOF record
-AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_0'
-LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+STRICT
+PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_0';
 
 CREATE FUNCTION histogram(_bucket int, _quryid int8)
-RETURNS SETOF RECORD AS $$
+RETURNS SETOF record
+LANGUAGE plpgsql
+AS $$
 DECLARE
  rec record;
 BEGIN
@@ -103,11 +107,13 @@ BEGIN
         RETURN next rec;
     END loop;
 END
-$$ language plpgsql;
+$$;
 
 -- Register a view on the function for ease of use.
-CREATE FUNCTION pgsm_create_11_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_11_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -159,11 +165,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-
-CREATE FUNCTION pgsm_create_13_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_13_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -226,10 +233,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-CREATE FUNCTION pgsm_create_14_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_14_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -292,10 +301,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-CREATE FUNCTION pgsm_create_15_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_15_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -371,10 +382,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-CREATE FUNCTION pgsm_create_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
     DECLARE ver integer;
     BEGIN
         SELECT current_setting('server_version_num') INTO ver;
@@ -392,7 +405,7 @@ $$
     END IF;
     RETURN 0;
     END;
-$$ LANGUAGE plpgsql;
+$$;
 
 SELECT pgsm_create_view();
 REVOKE ALL ON FUNCTION pgsm_create_view FROM PUBLIC;

--- a/pg_stat_monitor--2.0--2.1.sql
+++ b/pg_stat_monitor--2.0--2.1.sql
@@ -94,12 +94,16 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT bucket_done         BOOLEAN
 )
 RETURNS SETOF record
-AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_1'
-LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+STRICT
+PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_1';
 
 -- Register a view on the function for ease of use.
-CREATE FUNCTION pgsm_create_11_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_11_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -151,11 +155,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-
-CREATE FUNCTION pgsm_create_13_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_13_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -218,10 +223,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-CREATE FUNCTION pgsm_create_14_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_14_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -284,7 +291,7 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE FUNCTION pgsm_create_15_view() RETURNS INT AS
 $$
@@ -365,8 +372,10 @@ RETURN 0;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE FUNCTION pgsm_create_17_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_17_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -449,10 +458,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-CREATE FUNCTION pgsm_create_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
     DECLARE ver integer;
     BEGIN
         SELECT current_setting('server_version_num') INTO ver;
@@ -473,7 +484,7 @@ $$
     END IF;
     RETURN 0;
     END;
-$$ LANGUAGE plpgsql;
+$$;
 
 SELECT pgsm_create_view();
 REVOKE ALL ON FUNCTION pgsm_create_view FROM PUBLIC;

--- a/pg_stat_monitor--2.0.sql
+++ b/pg_stat_monitor--2.0.sql
@@ -4,28 +4,36 @@
 -- Register functions.
 CREATE FUNCTION pg_stat_monitor_reset()
 RETURNS void
-AS 'MODULE_PATHNAME'
-LANGUAGE C PARALLEL SAFE;
+PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_stat_monitor_version()
 RETURNS text
-AS 'MODULE_PATHNAME'
-LANGUAGE C PARALLEL SAFE;
+PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION get_histogram_timings()
 RETURNS text
-AS 'MODULE_PATHNAME'
-LANGUAGE C PARALLEL SAFE;
+PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION range()
-RETURNS text[] AS $$
+RETURNS text[]
+LANGUAGE sql
+AS $$
 SELECT string_to_array(get_histogram_timings(), ','); 
-$$ LANGUAGE SQL;
+$$;
 
 -- Some generic utility function used internally.
 
-CREATE FUNCTION get_cmd_type (cmd_type INTEGER) RETURNS TEXT AS
-$$
+CREATE FUNCTION get_cmd_type(cmd_type int)
+RETURNS text
+PARALLEL SAFE
+LANGUAGE sql
+AS $$
 SELECT
     CASE
         WHEN cmd_type = 0 THEN ''
@@ -36,13 +44,13 @@ SELECT
         WHEN cmd_type = 5 THEN 'UTILITY'
         WHEN cmd_type = 6 THEN 'NOTHING'
     END
-$$
-LANGUAGE SQL PARALLEL SAFE;
+$$;
 
 CREATE FUNCTION decode_error_level(elevel int)
-RETURNS  text
-AS
-$$
+RETURNS text
+PARALLEL SAFE
+LANGUAGE sql
+AS $$
 SELECT
         CASE
            WHEN elevel = 0 THEN  ''
@@ -58,11 +66,12 @@ SELECT
            WHEN elevel = 19 THEN 'WARNING'
            WHEN elevel = 20 THEN 'ERROR'
        END
-$$
-LANGUAGE SQL PARALLEL SAFE;
+$$;
 
 CREATE FUNCTION histogram(_bucket int, _quryid int8)
-RETURNS SETOF RECORD AS $$
+RETURNS SETOF record
+LANGUAGE plpgsql
+AS $$
 DECLARE
  rec record;
 BEGIN
@@ -75,7 +84,7 @@ BEGIN
         RETURN next rec;
     END loop;
 END
-$$ language plpgsql;
+$$;
 
 -- pg_stat_monitor internal function, must not call outside from this file.
 CREATE FUNCTION pg_stat_monitor_internal(
@@ -158,12 +167,16 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT bucket_done         BOOLEAN
 )
 RETURNS SETOF record
-AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_0'
-LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+STRICT
+PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_0';
 
 -- Register a view on the function for ease of use.
-CREATE FUNCTION pgsm_create_11_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_11_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -215,11 +228,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-
-CREATE FUNCTION pgsm_create_13_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_13_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -282,10 +296,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-CREATE FUNCTION pgsm_create_14_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_14_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -348,10 +364,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-CREATE FUNCTION pgsm_create_15_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_15_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -427,10 +445,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-CREATE FUNCTION pgsm_create_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
     DECLARE ver integer;
     BEGIN
         SELECT current_setting('server_version_num') INTO ver;
@@ -448,7 +468,7 @@ $$
     END IF;
     RETURN 0;
     END;
-$$ LANGUAGE plpgsql;
+$$;
 
 SELECT pgsm_create_view();
 REVOKE ALL ON FUNCTION pgsm_create_view FROM PUBLIC;

--- a/pg_stat_monitor--2.1--2.2.sql
+++ b/pg_stat_monitor--2.1--2.2.sql
@@ -1,8 +1,11 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "ALTER EXTENSION pg_stat_monitor" to load this file. \quit
 
-CREATE OR REPLACE FUNCTION get_cmd_type (cmd_type INTEGER) RETURNS TEXT AS
-$$
+CREATE OR REPLACE FUNCTION get_cmd_type(cmd_type int)
+RETURNS text
+PARALLEL SAFE
+LANGUAGE sql
+AS $$
 SELECT
     CASE
         WHEN cmd_type = 0 THEN ''
@@ -16,12 +19,13 @@ SELECT
         WHEN cmd_type = 6 AND current_setting('server_version_num')::int < 150000 THEN 'NOTHING'
         WHEN cmd_type = 7 THEN 'NOTHING'
     END
-$$
-LANGUAGE SQL PARALLEL SAFE;
+$$;
 
 -- Create new function that handles error levels across PostgreSQL versions 12-17
 CREATE OR REPLACE FUNCTION decode_error_level(elevel int)
 RETURNS text
+PARALLEL SAFE
+LANGUAGE sql
 AS $$
 SELECT CASE
     WHEN elevel = 0 THEN ''
@@ -43,4 +47,4 @@ SELECT CASE
     WHEN elevel = 22 AND current_setting('server_version_num')::int >= 140000 THEN 'FATAL'
     WHEN elevel = 23 AND current_setting('server_version_num')::int >= 140000 THEN 'PANIC'
 END;
-$$ LANGUAGE SQL PARALLEL SAFE;
+$$;

--- a/pg_stat_monitor--2.2--2.3.sql
+++ b/pg_stat_monitor--2.2--2.3.sql
@@ -95,11 +95,15 @@ CREATE FUNCTION pg_stat_monitor_internal(
     OUT bucket_done         BOOLEAN
 )
 RETURNS SETOF record
-AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_3'
-LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+STRICT
+PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'pg_stat_monitor_2_3';
 
-CREATE FUNCTION pgsm_create_18_view() RETURNS INT AS
-$$
+CREATE FUNCTION pgsm_create_18_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
 BEGIN
 CREATE VIEW pg_stat_monitor AS SELECT
     bucket,
@@ -186,10 +190,12 @@ FROM pg_stat_monitor_internal(TRUE)
 ORDER BY bucket_start_time;
 RETURN 0;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
-CREATE OR REPLACE FUNCTION pgsm_create_view() RETURNS INT AS
-$$
+CREATE OR REPLACE FUNCTION pgsm_create_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
     DECLARE ver integer;
     BEGIN
         SELECT current_setting('server_version_num') INTO ver;
@@ -210,7 +216,7 @@ $$
     END IF;
     RETURN 0;
     END;
-$$ LANGUAGE plpgsql;
+$$;
 
 SELECT pgsm_create_view();
 REVOKE ALL ON FUNCTION pgsm_create_view FROM PUBLIC;

--- a/pg_stat_monitor--2.3--2.4.sql
+++ b/pg_stat_monitor--2.3--2.4.sql
@@ -4,6 +4,8 @@
 -- Drop PostgreSQL 13 support from function
 CREATE OR REPLACE FUNCTION decode_error_level(elevel int)
 RETURNS text
+PARALLEL SAFE
+LANGUAGE sql
 AS $$
 SELECT CASE
     WHEN elevel = 0 THEN ''
@@ -22,13 +24,15 @@ SELECT CASE
     WHEN elevel = 22 THEN 'FATAL'
     WHEN elevel = 23 THEN 'PANIC'
 END;
-$$ LANGUAGE SQL PARALLEL SAFE;
+$$;
 
 DROP FUNCTION pgsm_create_13_view();
 DROP VIEW pg_stat_monitor;
 
-CREATE OR REPLACE FUNCTION pgsm_create_view() RETURNS INT AS
-$$
+CREATE OR REPLACE FUNCTION pgsm_create_view()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
     DECLARE ver integer;
     BEGIN
         SELECT current_setting('server_version_num') INTO ver;
@@ -46,7 +50,7 @@ $$
     END IF;
     RETURN 0;
     END;
-$$ LANGUAGE plpgsql;
+$$;
 
 SELECT pgsm_create_view();
 REVOKE ALL ON FUNCTION pgsm_create_view FROM PUBLIC;


### PR DESCRIPTION
The ways we wrote `CREATE FUNCTION` were all over the place so this is an attempt at standardizing how we write SQL functions without changing the semantic meaning of any of the upgrade scripts.

The goals of this is to make sure we always write things in the same order and that we put the function body last. We also skip declaring `VOLATILE` since that is the default.

Feel free to suggest a totally different formatting, this is just one way to do it, and I mostly care about us writing things in a uniform way.