### PR TITLE
Add PostgreSQL 19 compatibility

### DIFF
--- a/hash_query.c
+++ b/hash_query.c
@@ -122,7 +122,11 @@ pgsm_startup(void)
 		pgsm->raw_dsa_area = p;
 		dsa = dsa_create_in_place(pgsm->raw_dsa_area,
 								  pgsm_query_area_size(),
+#if PG_VERSION_NUM >= 190000
+								  LWLockNewTrancheId("pg_stat_monitor_dsa"), 0);
+#else
 								  LWLockNewTrancheId(), 0);
+#endif
 		dsa_pin(dsa);
 		dsa_set_size_limit(dsa, pgsm_query_area_size());
 
@@ -180,7 +184,11 @@ pgsm_create_bucket_hash(pgsmSharedState *pgsm, dsa_area *dsa)
 #if USE_DYNAMIC_HASH
 	dshash_table *dsh;
 
+#if PG_VERSION_NUM >= 190000
+	pgsm->hash_tranche_id = LWLockNewTrancheId("pg_stat_monitor_hash");
+#else
 	pgsm->hash_tranche_id = LWLockNewTrancheId();
+#endif
 	dsh_params.tranche_id = pgsm->hash_tranche_id;
 	dsh = dshash_create(dsa, &dsh_params, 0);
 	bucket_hash = dshash_get_hash_table_handle(dsh);
@@ -191,7 +199,11 @@ pgsm_create_bucket_hash(pgsmSharedState *pgsm, dsa_area *dsa)
 	memset(&info, 0, sizeof(info));
 	info.keysize = sizeof(pgsmHashKey);
 	info.entrysize = sizeof(pgsmEntry);
+#if PG_VERSION_NUM >= 190000
+	bucket_hash = ShmemInitHash("pg_stat_monitor: bucket hashtable", MAX_BUCKET_ENTRIES, &info, HASH_ELEM | HASH_BLOBS);
+#else
 	bucket_hash = ShmemInitHash("pg_stat_monitor: bucket hashtable", MAX_BUCKET_ENTRIES, MAX_BUCKET_ENTRIES, &info, HASH_ELEM | HASH_BLOBS);
+#endif
 #endif
 	return bucket_hash;
 }

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -171,7 +171,11 @@ static int	pg_get_application_name(char *name, int buff_size);
 static PgBackendStatus *pg_get_backend_status(void);
 static Datum intarray_get_datum(int32 arr[], int len);
 
+#if PG_VERSION_NUM >= 190000
+DECLARE_HOOK(void pgsm_post_parse_analyze, ParseState *pstate, Query *query, const JumbleState *jstate);
+#else
 DECLARE_HOOK(void pgsm_post_parse_analyze, ParseState *pstate, Query *query, JumbleState *jstate);
+#endif
 DECLARE_HOOK(void pgsm_ExecutorStart, QueryDesc *queryDesc, int eflags);
 #if PG_VERSION_NUM < 180000
 DECLARE_HOOK(void pgsm_ExecutorRun, QueryDesc *queryDesc, ScanDirection direction, uint64 count, bool execute_once);
@@ -186,7 +190,11 @@ DECLARE_HOOK(bool pgsm_ExecutorCheckPerms, List *rt, bool abort);
 DECLARE_HOOK(bool pgsm_ExecutorCheckPerms, List *rt, List *rp, bool abort);
 #endif
 
+#if PG_VERSION_NUM >= 190000
+DECLARE_HOOK(PlannedStmt *pgsm_planner_hook, Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams, ExplainState *es);
+#else
 DECLARE_HOOK(PlannedStmt *pgsm_planner_hook, Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams);
+#endif
 DECLARE_HOOK(void pgsm_ProcessUtility, PlannedStmt *pstmt, const char *queryString,
 			 bool readOnlyTree,
 			 ProcessUtilityContext context,
@@ -376,7 +384,11 @@ pgsm_shmem_request(void)
 #endif
 
 static void
+#if PG_VERSION_NUM >= 190000
+pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, const JumbleState *jstate)
+#else
 pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, JumbleState *jstate)
+#endif
 {
 	pgsmEntry  *entry;
 	const char *query_text;
@@ -495,7 +507,11 @@ pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, JumbleState *
  * Post-parse-analysis hook: mark query with a queryId
  */
 static void
+#if PG_VERSION_NUM >= 190000
+pgsm_post_parse_analyze(ParseState *pstate, Query *query, const JumbleState *jstate)
+#else
 pgsm_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
+#endif
 {
 	if (prev_post_parse_analyze_hook)
 		prev_post_parse_analyze_hook(pstate, query, jstate);
@@ -512,6 +528,14 @@ pgsm_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	if (getrusage(RUSAGE_SELF, &rusage_start) != 0)
 		elog(DEBUG1, "[pg_stat_monitor] pgsm_ExecutorStart: failed to execute getrusage.");
 
+#if PG_VERSION_NUM >= 190000
+	if (pgsm_enabled(nesting_level) &&
+		queryDesc->plannedstmt->queryId != INT64CONST(0))
+	{
+		queryDesc->query_instr_options |= INSTRUMENT_TIMER | INSTRUMENT_BUFFERS | INSTRUMENT_WAL;
+	}
+#endif
+
 	if (prev_ExecutorStart)
 		prev_ExecutorStart(queryDesc, eflags);
 	else
@@ -525,6 +549,7 @@ pgsm_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	if (pgsm_enabled(nesting_level) &&
 		queryDesc->plannedstmt->queryId != INT64CONST(0))
 	{
+#if PG_VERSION_NUM < 190000
 		/*
 		 * Set up to track total elapsed time in ExecutorRun.  Make sure the
 		 * space is allocated in the per-query context so it will go away at
@@ -538,6 +563,7 @@ pgsm_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			queryDesc->totaltime = InstrAlloc(1, INSTRUMENT_ALL, false);
 			MemoryContextSwitchTo(oldcxt);
 		}
+#endif
 	}
 }
 
@@ -688,7 +714,11 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 		MemoryContextSwitchTo(oldctx);
 	}
 
+#if PG_VERSION_NUM >= 190000
+	if (queryId != INT64CONST(0) && queryDesc->query_instr && pgsm_enabled(nesting_level))
+#else
 	if (queryId != INT64CONST(0) && queryDesc->totaltime && pgsm_enabled(nesting_level))
+#endif
 	{
 		entry = pgsm_get_entry_for_query(queryId, plan_ptr, (char *) queryDesc->sourceText, strlen(queryDesc->sourceText), true, queryDesc->operation);
 		if (!entry)
@@ -704,7 +734,9 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 		 * Make sure stats accumulation is done.  (Note: it's okay if several
 		 * levels of hook all do this.)
 		 */
+#if PG_VERSION_NUM < 190000
 		InstrEndLoop(queryDesc->totaltime);
+#endif
 
 		sys_info.utime = 0;
 		sys_info.stime = 0;
@@ -727,10 +759,17 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 						  &sys_info,	/* SysInfo */
 						  NULL, /* ErrorInfo */
 						  0,	/* plan_total_time */
+#if PG_VERSION_NUM >= 190000
+						  INSTR_TIME_GET_MILLISEC(queryDesc->query_instr->total),	/* exec_total_time */
+						  queryDesc->estate->es_processed,	/* rows */
+						  &queryDesc->query_instr->bufusage,	/* bufusage */
+						  &queryDesc->query_instr->walusage,	/* walusage */
+#else
 						  queryDesc->totaltime->total * 1000.0, /* exec_total_time */
 						  queryDesc->estate->es_processed,	/* rows */
 						  &queryDesc->totaltime->bufusage,	/* bufusage */
 						  &queryDesc->totaltime->walusage,	/* walusage */
+#endif
 #if PG_VERSION_NUM >= 150000
 						  queryDesc->estate->es_jit ? &queryDesc->estate->es_jit->instr : NULL, /* jitusage */
 #else
@@ -822,7 +861,11 @@ pgsm_ExecutorCheckPerms(List *rt, List *rp, bool abort)
 }
 
 static PlannedStmt *
+#if PG_VERSION_NUM >= 190000
+pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams, ExplainState *es)
+#else
 pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams)
+#endif
 {
 	PlannedStmt *result;
 	int64		queryId = parse->queryId;
@@ -885,9 +928,15 @@ pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, Par
 			 * the second call would trigger an assertion failure.
 			 */
 			if (planner_hook_next)
+#if PG_VERSION_NUM >= 190000
+				result = planner_hook_next(parse, query_string, cursorOptions, boundParams, es);
+			else
+				result = standard_planner(parse, query_string, cursorOptions, boundParams, es);
+#else
 				result = planner_hook_next(parse, query_string, cursorOptions, boundParams);
 			else
 				result = standard_planner(parse, query_string, cursorOptions, boundParams);
+#endif
 		}
 		PG_FINALLY();
 		{
@@ -952,9 +1001,15 @@ pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, Par
 		PG_TRY();
 		{
 			if (planner_hook_next)
+#if PG_VERSION_NUM >= 190000
+				result = planner_hook_next(parse, query_string, cursorOptions, boundParams, es);
+			else
+				result = standard_planner(parse, query_string, cursorOptions, boundParams, es);
+#else
 				result = planner_hook_next(parse, query_string, cursorOptions, boundParams);
 			else
 				result = standard_planner(parse, query_string, cursorOptions, boundParams);
+#endif
 		}
 		PG_FINALLY();
 		{
@@ -2873,8 +2928,10 @@ fill_in_constant_lengths(JumbleState *jstate, const char *query,
 							 &ScanKeywords,
 							 ScanKeywordTokens);
 
+#if PG_VERSION_NUM < 190000
 	/* we don't want to re-emit any escape string warnings */
 	yyextra.escape_string_warning = false;
+#endif
 
 	/* Search for each constant, in sequence */
 	for (i = 0; i < jstate->clocations_count; i++)

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -20,6 +20,11 @@
 #include <lib/dshash.h>
 #include <nodes/nodes.h>
 #include <storage/lwlock.h>
+#if PG_VERSION_NUM >= 190000
+#include <storage/shmem.h>
+#include <storage/proc.h>
+#include <utils/tuplestore.h>
+#endif
 #include <storage/spin.h>
 #include <utils/dsa.h>
 #include <utils/guc.h>

--- a/regression/expected/level_tracking_3.out
+++ b/regression/expected/level_tracking_3.out
@@ -1,0 +1,333 @@
+--
+-- Statement level tracking
+--
+SELECT setting::integer < 140000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+\if :skip_test
+\quit
+\endif
+CREATE EXTENSION pg_stat_monitor;
+SET pg_stat_monitor.pgsm_track_utility = TRUE;
+SET pg_stat_monitor.pgsm_normalized_query = TRUE;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+-- DO block - top-level tracking.
+CREATE TABLE stats_track_tab (x int);
+SET pg_stat_monitor.pgsm_track = 'top';
+DELETE FROM stats_track_tab;
+DO $$
+BEGIN
+  DELETE FROM stats_track_tab;
+END;
+$$ LANGUAGE plpgsql;
+SELECT toplevel, calls, query FROM pg_stat_monitor
+  WHERE query LIKE '%DELETE%' ORDER BY query COLLATE "C", toplevel;
+ toplevel | calls |             query              
+----------+-------+--------------------------------
+ t        |     1 | DELETE FROM stats_track_tab
+ t        |     1 | DO $$                         +
+          |       | BEGIN                         +
+          |       |   DELETE FROM stats_track_tab;+
+          |       | END;                          +
+          |       | $$ LANGUAGE plpgsql
+(2 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+-- DO block - all-level tracking.
+SET pg_stat_monitor.pgsm_track = 'all';
+DELETE FROM stats_track_tab;
+DO $$
+BEGIN
+  DELETE FROM stats_track_tab;
+END; $$;
+DO LANGUAGE plpgsql $$
+BEGIN
+  -- this is a SELECT
+  PERFORM 'hello world'::TEXT;
+END; $$;
+SELECT toplevel, calls, query FROM pg_stat_monitor
+  ORDER BY query COLLATE "C", toplevel;
+ toplevel | calls |                 query                  
+----------+-------+----------------------------------------
+ f        |     1 | DELETE FROM stats_track_tab
+ t        |     1 | DELETE FROM stats_track_tab
+ t        |     1 | DO $$                                 +
+          |       | BEGIN                                 +
+          |       |   DELETE FROM stats_track_tab;        +
+          |       | END; $$
+ t        |     1 | DO LANGUAGE plpgsql $$                +
+          |       | BEGIN                                 +
+          |       |   -- this is a SELECT                 +
+          |       |   PERFORM 'hello world'::TEXT;        +
+          |       | END; $$
+ f        |     1 | SELECT $1::TEXT
+ t        |     1 | SELECT pg_stat_monitor_reset()
+ t        |     1 | SET pg_stat_monitor.pgsm_track = 'all'
+(7 rows)
+
+-- DO block - top-level tracking without utility.
+SET pg_stat_monitor.pgsm_track = 'top';
+SET pg_stat_monitor.pgsm_track_utility = FALSE;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+DELETE FROM stats_track_tab;
+DO $$
+BEGIN
+  DELETE FROM stats_track_tab;
+END; $$;
+DO LANGUAGE plpgsql $$
+BEGIN
+  -- this is a SELECT
+  PERFORM 'hello world'::TEXT;
+END; $$;
+SELECT toplevel, calls, query FROM pg_stat_monitor
+  ORDER BY query COLLATE "C", toplevel;
+ toplevel | calls |             query              
+----------+-------+--------------------------------
+ t        |     1 | DELETE FROM stats_track_tab
+ t        |     1 | SELECT pg_stat_monitor_reset()
+(2 rows)
+
+-- DO block - all-level tracking without utility.
+SET pg_stat_monitor.pgsm_track = 'all';
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+DELETE FROM stats_track_tab;
+DO $$
+BEGIN
+  DELETE FROM stats_track_tab;
+END; $$;
+DO LANGUAGE plpgsql $$
+BEGIN
+  -- this is a SELECT
+  PERFORM 'hello world'::TEXT;
+END; $$;
+SELECT toplevel, calls, query FROM pg_stat_monitor
+  ORDER BY query COLLATE "C", toplevel;
+ toplevel | calls |             query              
+----------+-------+--------------------------------
+ f        |     1 | DELETE FROM stats_track_tab
+ t        |     1 | DELETE FROM stats_track_tab
+ f        |     1 | SELECT $1::TEXT
+ t        |     1 | SELECT pg_stat_monitor_reset()
+(4 rows)
+
+-- PL/pgSQL function - top-level tracking.
+SET pg_stat_monitor.pgsm_track = 'top';
+SET pg_stat_monitor.pgsm_track_utility = FALSE;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+CREATE FUNCTION PLUS_TWO(i INTEGER) RETURNS INTEGER AS $$
+DECLARE
+  r INTEGER;
+BEGIN
+  SELECT (i + 1 + 1.0)::INTEGER INTO r;
+  RETURN r;
+END; $$ LANGUAGE plpgsql;
+SELECT PLUS_TWO(3);
+ plus_two 
+----------
+        5
+(1 row)
+
+SELECT PLUS_TWO(7);
+ plus_two 
+----------
+        9
+(1 row)
+
+-- SQL function --- use LIMIT to keep it from being inlined
+CREATE FUNCTION PLUS_ONE(i INTEGER) RETURNS INTEGER AS
+$$ SELECT (i + 1.0)::INTEGER LIMIT 1 $$ LANGUAGE SQL;
+SELECT PLUS_ONE(8);
+ plus_one 
+----------
+        9
+(1 row)
+
+SELECT PLUS_ONE(10);
+ plus_one 
+----------
+       11
+(1 row)
+
+SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
+ calls | rows |             query              
+-------+------+--------------------------------
+     2 |    2 | SELECT PLUS_ONE($1)
+     2 |    2 | SELECT PLUS_TWO($1)
+     1 |    1 | SELECT pg_stat_monitor_reset()
+(3 rows)
+
+-- immutable SQL function --- can be executed at plan time
+CREATE FUNCTION PLUS_THREE(i INTEGER) RETURNS INTEGER AS
+$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE SQL;
+SELECT PLUS_THREE(8);
+ plus_three 
+------------
+         11
+(1 row)
+
+SELECT PLUS_THREE(10);
+ plus_three 
+------------
+         13
+(1 row)
+
+SELECT toplevel, calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
+ toplevel | calls | rows |                                   query                                   
+----------+-------+------+---------------------------------------------------------------------------
+ t        |     2 |    2 | SELECT PLUS_ONE($1)
+ t        |     2 |    2 | SELECT PLUS_THREE($1)
+ t        |     2 |    2 | SELECT PLUS_TWO($1)
+ t        |     1 |    3 | SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C"
+ t        |     1 |    1 | SELECT pg_stat_monitor_reset()
+(5 rows)
+
+-- PL/pgSQL function - all-level tracking.
+SET pg_stat_monitor.pgsm_track = 'all';
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+-- we drop and recreate the functions to avoid any caching funnies
+DROP FUNCTION PLUS_ONE(INTEGER);
+DROP FUNCTION PLUS_TWO(INTEGER);
+DROP FUNCTION PLUS_THREE(INTEGER);
+-- PL/pgSQL function
+CREATE FUNCTION PLUS_TWO(i INTEGER) RETURNS INTEGER AS $$
+DECLARE
+  r INTEGER;
+BEGIN
+  SELECT (i + 1 + 1.0)::INTEGER INTO r;
+  RETURN r;
+END; $$ LANGUAGE plpgsql;
+SELECT PLUS_TWO(-1);
+ plus_two 
+----------
+        1
+(1 row)
+
+SELECT PLUS_TWO(2);
+ plus_two 
+----------
+        4
+(1 row)
+
+-- SQL function --- use LIMIT to keep it from being inlined
+CREATE FUNCTION PLUS_ONE(i INTEGER) RETURNS INTEGER AS
+$$ SELECT (i + 1.0)::INTEGER LIMIT 1 $$ LANGUAGE SQL;
+SELECT PLUS_ONE(3);
+ plus_one 
+----------
+        4
+(1 row)
+
+SELECT PLUS_ONE(1);
+ plus_one 
+----------
+        2
+(1 row)
+
+SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
+ calls | rows |               query               
+-------+------+-----------------------------------
+     2 |    2 | SELECT (i + $2)::INTEGER LIMIT $3
+     2 |    2 | SELECT PLUS_ONE($1)
+     2 |    2 | SELECT PLUS_TWO($1)
+     1 |    1 | SELECT pg_stat_monitor_reset()
+(4 rows)
+
+-- immutable SQL function --- can be executed at plan time
+CREATE FUNCTION PLUS_THREE(i INTEGER) RETURNS INTEGER AS
+$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE SQL;
+SELECT PLUS_THREE(8);
+ plus_three 
+------------
+         11
+(1 row)
+
+SELECT PLUS_THREE(10);
+ plus_three 
+------------
+         13
+(1 row)
+
+SELECT toplevel, calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
+ toplevel | calls | rows |                                             query                                              
+----------+-------+------+------------------------------------------------------------------------------------------------
+ f        |     4 |    4 |                                                                                               +
+          |       |      |     SELECT pg_has_role(current_user, 'pg_read_all_stats', 'MEMBER')                           +
+          |       |      |                OR usesuper                                                                    +
+          |       |      |     FROM pg_user                                                                              +
+          |       |      |     WHERE usename = current_user;                                                             +
+          |       |      | 
+ f        |     4 |    4 |                                                                                               +
+          |       |      |     SELECT pg_stat_monitor_has_full_access()                                                  +
+          |       |      |                 OR query_userid = (SELECT usesysid FROM pg_user WHERE usename = current_user);+
+          |       |      | 
+ f        |     2 |    2 | SELECT (i + $2)::INTEGER LIMIT $3
+ t        |     2 |    2 | SELECT PLUS_ONE($1)
+ t        |     2 |    2 | SELECT PLUS_THREE($1)
+ t        |     2 |    2 | SELECT PLUS_TWO($1)
+ t        |     1 |    4 | SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C"
+ f        |     2 |    2 | SELECT i + $2 LIMIT $3
+ t        |     1 |    1 | SELECT pg_stat_monitor_reset()
+(9 rows)
+
+--
+-- pg_stat_monitor.pgsm_track = none
+--
+SET pg_stat_monitor.pgsm_track = 'none';
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SELECT 1 AS "one";
+ one 
+-----
+   1
+(1 row)
+
+SELECT 1 + 1 AS "two";
+ two 
+-----
+   2
+(1 row)
+
+SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
+ calls | rows | query 
+-------+------+-------
+(0 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+DROP EXTENSION pg_stat_monitor;

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -23,6 +23,23 @@ close $conf;
 
 # Dictionary for expected PGSM columns names on different PG server versions
 my %pg_versions_pgsm_columns = (
+	19 => "application_name,"
+	  . "bucket,bucket_done,bucket_start_time,calls,"
+	  . "client_ip,cmd_type,cmd_type_text,comments,cpu_sys_time,cpu_user_time,"
+	  . "datname,dbid,elevel,jit_deform_count,jit_deform_time,"
+	  . "jit_emission_count,jit_emission_time,jit_functions,jit_generation_time,"
+	  . "jit_inlining_count,jit_inlining_time,jit_optimization_count,jit_optimization_time,"
+	  . "local_blk_read_time,local_blk_write_time,local_blks_dirtied,local_blks_hit,"
+	  . "local_blks_read,local_blks_written,max_exec_time,max_plan_time,mean_exec_time,"
+	  . "mean_plan_time,message,min_exec_time,min_plan_time,minmax_stats_since,"
+	  . "parallel_workers_launched,parallel_workers_to_launch,"
+	  . "pgsm_query_id,planid,plans,query,query_plan,queryid,relations,resp_calls,rows,"
+	  . "shared_blk_read_time,shared_blk_write_time,shared_blks_dirtied,"
+	  . "shared_blks_hit,shared_blks_read,shared_blks_written,sqlcode,stats_since,"
+	  . "stddev_exec_time,stddev_plan_time,temp_blk_read_time,temp_blk_write_time,"
+	  . "temp_blks_read,temp_blks_written,top_query,top_queryid,toplevel,"
+	  . "total_exec_time,total_plan_time,userid,username,wal_buffers_full,wal_bytes,"
+	  . "wal_fpi,wal_records",
 	18 => "application_name,"
 	  . "bucket,bucket_done,bucket_start_time,calls,"
 	  . "client_ip,cmd_type,cmd_type_text,comments,cpu_sys_time,cpu_user_time,"

--- a/t/expected/007_settings_pgsm_query_shared_buffer.out.19
+++ b/t/expected/007_settings_pgsm_query_shared_buffer.out.19
@@ -1,0 +1,111 @@
+CREATE EXTENSION pg_stat_monitor;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_shared_buffer';
+                   name                   | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_query_shared_buffer | 1       | MB   | postmaster | integer | configuration file | 1       | 10000   |          | 20       | 1         | f
+(1 row)
+
+CREATE database example;
+SELECT datname, substr(query,0,150) AS query, SUM(calls) AS calls FROM pg_stat_monitor GROUP BY datname, query ORDER BY datname, query, calls DESC Limit 20;
+ datname  |                                                                         query                                                                         | calls 
+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------
+ example  | INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)                                                  | 10000
+ example  | SELECT abalance FROM pgbench_accounts WHERE aid = $1                                                                                                  | 10000
+ example  | SELECT relkind FROM pg_catalog.pg_class WHERE oid=$1::pg_catalog.regclass                                                                             |     3
+ example  | UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2                                                                                   | 10000
+ example  | UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2                                                                                   | 10000
+ example  | UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2                                                                                    | 10000
+ example  | select count(*) from pgbench_branches                                                                                                                 |     1
+ example  | select o.n, p.partstrat, pg_catalog.count(i.inhparent) from pg_catalog.pg_class as c join pg_catalog.pg_namespace as n on (n.oid = c.relnamespace) cr |     1
+ postgres | SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name=$1 |     1
+ postgres | SELECT pg_stat_monitor_reset()                                                                                                                        |     1
+(10 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_shared_buffer';
+                   name                   | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_query_shared_buffer | 2       | MB   | postmaster | integer | configuration file | 1       | 10000   |          | 20       | 2         | f
+(1 row)
+
+SELECT datname, substr(query,0,150) AS query, SUM(calls) AS calls FROM pg_stat_monitor GROUP BY datname, query ORDER BY datname, query, calls DESC Limit 20;
+ datname  |                                                                         query                                                                         | calls 
+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------
+ example  | INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)                                                  | 10000
+ example  | SELECT abalance FROM pgbench_accounts WHERE aid = $1                                                                                                  | 10000
+ example  | SELECT relkind FROM pg_catalog.pg_class WHERE oid=$1::pg_catalog.regclass                                                                             |     3
+ example  | UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2                                                                                   | 10000
+ example  | UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2                                                                                   | 10000
+ example  | UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2                                                                                    | 10000
+ example  | select count(*) from pgbench_branches                                                                                                                 |     1
+ example  | select o.n, p.partstrat, pg_catalog.count(i.inhparent) from pg_catalog.pg_class as c join pg_catalog.pg_namespace as n on (n.oid = c.relnamespace) cr |     1
+ postgres | SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name=$1 |     1
+ postgres | SELECT pg_stat_monitor_reset()                                                                                                                        |     1
+(10 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_shared_buffer';
+                   name                   | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_query_shared_buffer | 20      | MB   | postmaster | integer | configuration file | 1       | 10000   |          | 20       | 20        | f
+(1 row)
+
+SELECT datname, substr(query,0,150) AS query, SUM(calls) AS calls FROM pg_stat_monitor GROUP BY datname, query ORDER BY datname, query, calls DESC Limit 20;
+ datname  |                                                                         query                                                                         | calls 
+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------
+ example  | INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)                                                  | 10000
+ example  | SELECT abalance FROM pgbench_accounts WHERE aid = $1                                                                                                  | 10000
+ example  | SELECT relkind FROM pg_catalog.pg_class WHERE oid=$1::pg_catalog.regclass                                                                             |     3
+ example  | UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2                                                                                   | 10000
+ example  | UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2                                                                                   | 10000
+ example  | UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2                                                                                    | 10000
+ example  | select count(*) from pgbench_branches                                                                                                                 |     1
+ example  | select o.n, p.partstrat, pg_catalog.count(i.inhparent) from pg_catalog.pg_class as c join pg_catalog.pg_namespace as n on (n.oid = c.relnamespace) cr |     1
+ postgres | SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name=$1 |     1
+ postgres | SELECT pg_stat_monitor_reset()                                                                                                                        |     1
+(10 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_shared_buffer';
+                   name                   | setting | unit |  context   | vartype |       source       | min_val | max_val | enumvals | boot_val | reset_val | pending_restart 
+------------------------------------------+---------+------+------------+---------+--------------------+---------+---------+----------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_query_shared_buffer | 2048    | MB   | postmaster | integer | configuration file | 1       | 10000   |          | 20       | 2048      | f
+(1 row)
+
+SELECT datname, substr(query,0,150) AS query, SUM(calls) AS calls FROM pg_stat_monitor GROUP BY datname, query ORDER BY datname, query, calls DESC Limit 20;
+ datname  |                                                                         query                                                                         | calls 
+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------
+ example  | INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)                                                  | 10000
+ example  | SELECT abalance FROM pgbench_accounts WHERE aid = $1                                                                                                  | 10000
+ example  | SELECT relkind FROM pg_catalog.pg_class WHERE oid=$1::pg_catalog.regclass                                                                             |     3
+ example  | UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2                                                                                   | 10000
+ example  | UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2                                                                                   | 10000
+ example  | UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2                                                                                    | 10000
+ example  | select count(*) from pgbench_branches                                                                                                                 |     1
+ example  | select o.n, p.partstrat, pg_catalog.count(i.inhparent) from pg_catalog.pg_class as c join pg_catalog.pg_namespace as n on (n.oid = c.relnamespace) cr |     1
+ postgres | SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name=$1 |     1
+ postgres | SELECT pg_stat_monitor_reset()                                                                                                                        |     1
+(10 rows)
+
+DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
Description:

  PG19 introduces several API changes that break the build. This PR adds

  C code changes (pg_stat_monitor.c, hash_query.c, pg_stat_monitor.h):
  - Adapt to planner_hook gaining ExplainState *es parameter
  - Handle QueryDesc->totaltime rename to QueryDesc->query_instr with
    executor-managed instrumentation lifecycle (query_instr_options)
  - Fix LWLockNewTrancheId() now requiring a name argument
  - Fix ShmemInitHash() dropping max_size parameter (5->4 args)
  - Handle const JumbleState* in post_parse_analyze_hook
  - Remove escape_string_warning (dropped from core_yy_extra_type)
  - Add missing #include headers guarded by PG_VERSION_NUM >= 190000

  Test changes:
  - Add regression/expected/level_tracking_3.out for PG19
  - Add t/expected/007_settings_pgsm_query_shared_buffer.out.19
  - Add PG19 entry to t/018_column_names.pl

  All changes use #if PG_VERSION_NUM >= 190000 / #else / #endif guards.
  Tested against PG 19devel — all 22 regression tests and 34 TAP tests pass.

  Links:
  Related PostgreSQL 19 commits:
  - https://github.com/postgres/postgres/commit/b9e34283 (planner_hook ExplainState)
  - https://github.com/postgres/postgres/commit/5765fbd5 (QueryDesc->query_instr)

  Upstream CI only tests PG 14-18:
  - https://github.com/percona/pg_stat_monitor/blob/main/.github/workflows/matrix.yml