### PR TITLE
Set collation in tests

### DIFF
--- a/t/pgsm.pm
+++ b/t/pgsm.pm
@@ -58,7 +58,7 @@ sub pgsm_init_pg
 	}
 
 	$pg_node->dump_info;
-	$pg_node->init;
+	$pg_node->init(extra => ['--lc-collate=C']);
 	return $pg_node;
 }
 


### PR DESCRIPTION
t/007_settings_pgsm_query_shared_buffer.pl was failing on my machine because my locale settings does not match what was used to generate the expected output.

Since our assertions assume C collation sorting we should set it explicitly.