### PR TITLE
PG-2395 Fetch datname and username from syscache in pgsm_store()

### DIFF
--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -1695,8 +1695,6 @@ pgsm_create_hash_entry(uint64 bucket_id, int64 queryid, PlanInfo *plan_info)
 	int			sec_ctx;
 	bool		found_client_addr = false;
 	MemoryContext oldctx;
-	char	   *datname = NULL;
-	char	   *username = NULL;
 
 	/* Create an entry in the pgsm memory context */
 	oldctx = MemoryContextSwitchTo(GetPgsmMemoryContext());
@@ -1735,21 +1733,6 @@ pgsm_create_hash_entry(uint64 bucket_id, int64 queryid, PlanInfo *plan_info)
 #else
 	entry->key.toplevel = ((nesting_level + plan_nested_level) == 0);
 #endif
-
-	if (IsTransactionState())
-	{
-		datname = get_database_name(entry->key.dbid);
-		username = GetUserNameFromId(entry->key.userid, true);
-
-		snprintf(entry->datname, sizeof(entry->datname), "%s", datname);
-		snprintf(entry->username, sizeof(entry->username), "%s", username);
-
-		if (datname)
-			pfree(datname);
-
-		if (username)
-			pfree(username);
-	}
 
 	MemoryContextSwitchTo(oldctx);
 
@@ -1803,6 +1786,23 @@ pgsm_store(pgsmEntry *entry)
 	/* Let's do all the leg work here before we acquire any locks */
 	extract_query_comments(query, comments, sizeof(comments));
 	comments_len = strlen(comments);
+
+	if (IsTransactionState() && strlen(entry->datname) == 0)
+	{
+		char	   *datname = get_database_name(entry->key.dbid);
+
+		snprintf(entry->datname, sizeof(entry->datname), "%s", datname);
+		if (datname)
+			pfree(datname);
+	}
+	if (IsTransactionState() && strlen(entry->username) == 0)
+	{
+		char	   *username = GetUserNameFromId(entry->key.userid, true);
+
+		snprintf(entry->username, sizeof(entry->username), "%s", username);
+		if (username)
+			pfree(username);
+	}
 
 	/* bufusage */
 	bufusage.shared_blks_hit = entry->counters.blocks.shared_blks_hit;


### PR DESCRIPTION
Resolve them from the catalog in pgsm_store() rather than in pgsm_create_hash_entry(). We have a bug report we have not been able to reproduce where queryDesc->totaltime is freed mid-call in pgsm_ExecutorEnd(), most likely by cache invalidation processing during these syscache lookups when they ran inside pgsm_create_hash_entry(). The misbehaving callback is most likely from another extension or the RDS fork of PostgreSQL, since standard invalidation callbacks does not seem to touch the relevant memory context.

I didn't change the undefined behavior of passing NULL to snprintf() in this PR, but we should fix it in the future (i believe glibc inserts a placeholder like `(null)` for us which is the existing behavior before this PR.)
