### PR TITLE
Only fail tests if coverage drops by more than one percent

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
It is quite silly now how random fluctuations in coverage can result in red tests in the CI.