### PR TITLE
Remove all remaining mentions of USE_PGXS

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -40,4 +40,4 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     NCPU=$(sysctl -n hw.ncpu)
 fi
 
-sudo env "PATH=$PATH" PG_CFLAGS="$PG_CFLAGS" make USE_PGXS=1 install -j $NCPU
+sudo env "PATH=$PATH" PG_CFLAGS="$PG_CFLAGS" make install -j $NCPU

--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -19,6 +19,6 @@ $PG_BIN_DIR/pg_ctl -D regression_install -l regression_install.log init
 
 $PG_BIN_DIR/pg_ctl -D regression_install -l regression_install.log start -o "$OPTS"
 
-make USE_PGXS=1 installcheck
+make installcheck
 
 $PG_BIN_DIR/pg_ctl -D regression_install stop

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ You can find the tests in the `regression` directory.
     2. If you installed PostgreSQL server  from Percona Distribution for PostgreSQL, use the following command:
 
         ```sh
-        sudo su postgres bash -c 'make installcheck USE_PGXS=1'
+        sudo su postgres bash -c 'make installcheck'
         ```
 #### Run automatically
 

--- a/README.md
+++ b/README.md
@@ -246,8 +246,8 @@ Compile and install the extension
 
 ```
 cd pg_stat_monitor
-make USE_PGXS=1
-make USE_PGXS=1 install
+make
+make install
 ```
 
 ### Uninstall `pg_stat_monitor`

--- a/debian/rules
+++ b/debian/rules
@@ -6,8 +6,6 @@
 # Using pg_buildext
 include /usr/share/postgresql-common/pgxs_debian_control.mk
 
-export USE_PGXS=1
-
 %:
 	dh $@
 

--- a/rpm/pg-stat-monitor.spec
+++ b/rpm/pg-stat-monitor.spec
@@ -43,12 +43,12 @@ It provides all the features of pg_stat_statment plus its own feature set.
 	source /opt/rh/gcc-toolset-14/enable
 %endif
 sed -i 's:PG_CONFIG ?= pg_config:PG_CONFIG = /usr/pgsql-%{pgrel}/bin/pg_config:' Makefile
-%{__make} USE_PGXS=1 %{?_smp_mflags}
+%{__make} %{?_smp_mflags}
 
 
 %install
 %{__rm} -rf %{buildroot}
-%{__make} USE_PGXS=1 %{?_smp_mflags} install DESTDIR=%{buildroot}
+%{__make} %{?_smp_mflags} install DESTDIR=%{buildroot}
 %{__install} -d %{buildroot}%{pginstdir}/share/extension
 %{__install} -m 755 README.md %{buildroot}%{pginstdir}/share/extension/README-pg_stat_monitor
 


### PR DESCRIPTION
As commit 9d8b038fd679041d301600d773a98bf9b5da5dd9 removed our support for non-PGXS builds we should also remove all places with mention or set `USE_PGXS`.