### PR TITLE
Remove more leftovers from when hooks benchmarks

### DIFF
--- a/src/hash_query.c
+++ b/src/hash_query.c
@@ -163,10 +163,6 @@ pgsm_startup(void)
 															ALLOCSET_DEFAULT_SIZES);
 	}
 
-#ifdef BENCHMARK
-	init_hook_stats();
-#endif
-
 	LWLockRelease(AddinShmemInitLock);
 
 	/*


### PR DESCRIPTION
Commit 0af6295513dc6f010605f133dd27659742dcffbe missed removing this piece of code.

PG-0