### PR TITLE
Remove unused argument to hash_entry_dealloc()

### DIFF
--- a/src/hash_query.c
+++ b/src/hash_query.c
@@ -334,14 +334,12 @@ hash_entry_alloc(pgsmSharedState *pgsm, pgsmHashKey *key)
  *      state is PGSM_EXEC or PGSM_ERROR).
  *    - Clear query buffer for new_bucket_id.
  *    - If old_bucket_id != -1, move all pending hash table entries in
- *      old_bucket_id to the new bucket id, also move pending queries from the
- *      previous query buffer (query_buffer[old_bucket_id]) to the new one
- *      (query_buffer[new_bucket_id]).
+ *      old_bucket_id to the new bucket id.
  *
  * Caller must hold an exclusive lock on pgsm->lock.
  */
 void
-hash_entry_dealloc(int new_bucket_id, int old_bucket_id, unsigned char *query_buffer)
+hash_entry_dealloc(int new_bucket_id, int old_bucket_id)
 {
 	PGSM_HASH_SEQ_STATUS hstat;
 	pgsmEntry  *entry = NULL;

--- a/src/hash_query.h
+++ b/src/hash_query.h
@@ -289,7 +289,7 @@ bool		IsHashInitialize(void);
 bool		IsSystemOOM(void);
 Size		pgsm_ShmemSize(void);
 pgsmSharedState *pgsm_get_ss(void);
-void		hash_entry_dealloc(int new_bucket_id, int old_bucket_id, unsigned char *query_buffer);
+void		hash_entry_dealloc(int new_bucket_id, int old_bucket_id);
 pgsmEntry  *hash_entry_alloc(pgsmSharedState *pgsm, pgsmHashKey *key);
 
 void	   *pgsm_hash_find(PGSM_HASH_TABLE * shared_hash, pgsmHashKey *key, bool *found);

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1999,8 +1999,7 @@ pg_stat_monitor_reset(PG_FUNCTION_ARGS)
 
 	pgsm = pgsm_get_ss();
 	pgsm_lock_aquire(pgsm, LW_EXCLUSIVE);
-	hash_entry_dealloc(INVALID_BUCKET_ID, INVALID_BUCKET_ID, NULL);
-
+	hash_entry_dealloc(INVALID_BUCKET_ID, INVALID_BUCKET_ID);
 	pgsm_lock_release(pgsm);
 	PG_RETURN_VOID();
 }
@@ -2563,7 +2562,7 @@ get_next_wbucket(pgsmSharedState *pgsm)
 		prev_bucket_id = pg_atomic_exchange_u64(&pgsm->current_wbucket, new_bucket_id);
 
 		pgsm_lock_aquire(pgsm, LW_EXCLUSIVE);
-		hash_entry_dealloc(new_bucket_id, prev_bucket_id, NULL);
+		hash_entry_dealloc(new_bucket_id, prev_bucket_id);
 
 		pgsm_lock_release(pgsm);
 


### PR DESCRIPTION
Commit c21a3de00def9c34b0738630e0ba4a83432d46fd remove the use of this argument but forgot to remove the argument itself.

PG-0

