### PR TITLE
Use PostgreSQL::Version to parse PostgreSQL version in TAP tests

### DIFF
--- a/t/pgsm.pm
+++ b/t/pgsm.pm
@@ -2,6 +2,7 @@ package PGSM;
 
 use File::Basename;
 use File::Compare;
+use PostgreSQL::Version;
 use Test::More;
 
 our @ISA = qw( Exporter );
@@ -27,10 +28,7 @@ our $debug_out_filename_with_path;
 
 BEGIN
 {
-	# Get PG Server Major version from pg_config
-	$PG_MAJOR_VERSION =
-	  `pg_config --version | awk {'print \$2'} | cut -f1 -d"." | sed -e 's/[^0-9].*\$//g'`;
-	$PG_MAJOR_VERSION =~ s/^\s+|\s+$//g;
+	$PG_MAJOR_VERSION = PostgreSQL::Version->new(`pg_config --version`)->major;
 
 	# Depending upon PG server version load the required module at runtime when pgsm.pm is loaded.
 	my $node_module =


### PR DESCRIPTION
`PostgreSQL::Version` was introduced in PostgreSQL 14 but even before that we should probably have used Perl to parse the version string rather than using `sed` and `awk`.

PG-0