### PR TITLE
Add output files from failed pg_regress tests to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ dkms.conf
 typedefs*.list
 
 # test files
+/regression.diffs
+/regression.out
 /results/
 /t/results/
 /tmp_check/


### PR DESCRIPTION
Seems like we had just forgot to add these files to `.gitignore`.

PG-0
