### PR TITLE
Hopefully fix the flaky histogram test

### DIFF
--- a/regression/expected/histogram.out
+++ b/regression/expected/histogram.out
@@ -27,19 +27,19 @@ END;
 $$ LANGUAGE 'plpgsql' STRICT;
 CREATE OR REPLACE FUNCTION wait_for_new_bucket() RETURNS VOID AS $$
 DECLARE
-    bucket_left_time int;
+    bucket_left_time numeric;
 BEGIN
     -- This test works correctly only if the bucket duration is default (60 seconds).
     SELECT 60 - EXTRACT(
         SECOND FROM(
             SELECT CURRENT_TIMESTAMP(0) bucket_start_time FROM pg_stat_monitor ORDER BY bucket_start_time DESC LIMIT 1
         )
-    )::int INTO bucket_left_time; 
+    ) INTO bucket_left_time;
 
-    -- If the bucket lifetime is less than 10 seconds, we would not fit.
-    IF bucket_left_time <= 4 THEN
+    -- If the bucket lifetime is less than 8 seconds, we would not fit.
+    IF bucket_left_time < 8 THEN
         -- RAISE NOTICE 'Bucket lifetime comes to an end → sleeping 4 seconds...';
-        PERFORM pg_sleep(4);
+        PERFORM pg_sleep(8);
     END IF;
 END;
 $$ LANGUAGE plpgsql;

--- a/regression/sql/histogram.sql
+++ b/regression/sql/histogram.sql
@@ -29,19 +29,19 @@ $$ LANGUAGE 'plpgsql' STRICT;
 
 CREATE OR REPLACE FUNCTION wait_for_new_bucket() RETURNS VOID AS $$
 DECLARE
-    bucket_left_time int;
+    bucket_left_time numeric;
 BEGIN
     -- This test works correctly only if the bucket duration is default (60 seconds).
     SELECT 60 - EXTRACT(
         SECOND FROM(
             SELECT CURRENT_TIMESTAMP(0) bucket_start_time FROM pg_stat_monitor ORDER BY bucket_start_time DESC LIMIT 1
         )
-    )::int INTO bucket_left_time; 
+    ) INTO bucket_left_time;
 
-    -- If the bucket lifetime is less than 10 seconds, we would not fit.
-    IF bucket_left_time <= 4 THEN
+    -- If the bucket lifetime is less than 8 seconds, we would not fit.
+    IF bucket_left_time < 8 THEN
         -- RAISE NOTICE 'Bucket lifetime comes to an end → sleeping 4 seconds...';
-        PERFORM pg_sleep(4);
+        PERFORM pg_sleep(8);
     END IF;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
The flaky histogram test seems to have been caused by that the sleep to make sure all calls end up in the same bucket was too short. The calls take 6 seconds to make and we slept for only 4 to sync with the start of the next minute. Let's increase the sleep to 8 seconds.

PG-0

