### PR TITLE
Simplify logic for initialization check and OOM

### DIFF
--- a/src/hash_query.c
+++ b/src/hash_query.c
@@ -295,13 +295,7 @@ hash_entry_dealloc(int new_bucket_id, int old_bucket_id)
 }
 
 bool
-IsHashInitialize(void)
-{
-	return (pgsmStateLocal.shared_pgsmState != NULL);
-}
-
-bool
 IsSystemOOM(void)
 {
-	return (IsHashInitialize() && pgsmStateLocal.shared_pgsmState->pgsm_oom);
+	return pgsmStateLocal.shared_pgsmState && pgsmStateLocal.shared_pgsmState->pgsm_oom;
 }

--- a/src/hash_query.h
+++ b/src/hash_query.h
@@ -247,7 +247,6 @@ void		pgsm_startup(void);
 MemoryContext GetPgsmMemoryContext(void);
 dsa_area   *get_dsa_area_for_query_text(void);
 HTAB	   *get_pgsmHash(void);
-bool		IsHashInitialize(void);
 bool		IsSystemOOM(void);
 Size		pgsm_ShmemSize(void);
 pgsmSharedState *pgsm_get_ss(void);

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -344,8 +344,6 @@ _PG_init(void)
 
 	nested_queryids = (int64 *) malloc(sizeof(int64) * max_stack_depth);
 	nested_query_txts = (char **) calloc(max_stack_depth, sizeof(char *));
-
-	system_init = true;
 }
 
 /*
@@ -361,6 +359,8 @@ pgsm_shmem_startup(void)
 		prev_shmem_startup_hook();
 
 	pgsm_startup();
+
+	system_init = true;
 }
 
 static void
@@ -1927,7 +1927,7 @@ pgsm_store(pgsmEntry *entry)
 			 * Out of memory; report only if the state has changed now.
 			 * Otherwise we risk filling up the log file with these message.
 			 */
-			if (!IsSystemOOM())
+			if (!pgsm->pgsm_oom)
 			{
 				pgsm->pgsm_oom = true;
 
@@ -2993,7 +2993,7 @@ pgsm_emit_log_hook(ErrorData *edata)
 	if (MyProc == NULL)
 		goto exit;
 
-	if (edata->elevel >= WARNING && !disable_error_capture && IsSystemOOM() == false)
+	if (edata->elevel >= WARNING && !disable_error_capture && !IsSystemOOM())
 		pgsm_store_error(debug_query_string ? debug_query_string : "", edata);
 
 	/* We need to make sure we re-enable error capture if query was aborted */
@@ -3007,7 +3007,7 @@ exit:
 static bool
 IsSystemInitialized(void)
 {
-	return (system_init && IsHashInitialize());
+	return system_init;
 }
 
 /*


### PR DESCRIPTION
By setting the flag for successful initialization in our shared memory startup hook we can simplify the logic for the initialization check. And while working in this area we also simplify the OOM code a bit.

PG-0