### PR TITLE
Remove pointless volatile keyword

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -216,7 +216,7 @@ static MemoryContextCallback mem_cxt_reset_callback =
 	.func = pgsm_cleanup_callback,
 	.arg = NULL
 };
-static volatile bool callback_setup = false;
+static bool callback_setup = false;
 
 static void pgsm_update_entry(pgsmEntry *entry,
 							  const char *query,


### PR DESCRIPTION
Since this variable is local the the backend and we do not have any threads this volatile keyword does nothing.

PG-0