### PR TITLE
Do not check string length before NULL check

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1559,9 +1559,9 @@ pgsm_store_error(const char *query, ErrorData *edata)
 {
 	pgsmEntry  *entry;
 	int64		queryid = 0;
-	int			len = strlen(query);
+	int			len;
 
-	if (!query || len == 0)
+	if (!query || query[0] == '\0')
 		return;
 
 	len = strlen(query);


### PR DESCRIPTION
The optimizer is likely to usually make this harmless but it is undefined behvior.

PG-0

### Description
<!--- Describe your changes in detail -->


### Links
<!--- Please provide links to any related PRs in this or other repositories --->

