### PR TITLE
Use palloc0_object() instead of palloc0()

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1716,7 +1716,7 @@ pgsm_create_hash_entry(int64 queryid, const PlanInfo *plan_info)
 
 	/* Create an entry in the pgsm memory context */
 	oldctx = MemoryContextSwitchTo(GetPgsmMemoryContext());
-	entry = palloc0(sizeof(pgsmEntry));
+	entry = palloc0_object(pgsmEntry);
 
 	/*
 	 * Get the user ID. Let's use this instead of GetUserID as this won't


### PR DESCRIPTION
We should always try to use `palloc*_object()` and `palloc*_array()` when possible.

PG-0