### PR TITLE
PG-2122 Fix broken client IP code

### DIFF
--- a/.github/scripts/ubuntu-deps.sh
+++ b/.github/scripts/ubuntu-deps.sh
@@ -8,6 +8,7 @@ DEPS=(
 
     # Build
     perl
+    libkrb5-dev
 
     # Test
     libipc-run-perl
@@ -29,7 +30,6 @@ case "$1" in
             gettext
             lcov
             libicu-dev
-            libkrb5-dev
             libldap2-dev
             liblz4-dev
             libpam0g-dev

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -208,7 +208,7 @@ PG_FUNCTION_INFO_V1(pg_stat_monitor);
 PG_FUNCTION_INFO_V1(get_histogram_timings);
 PG_FUNCTION_INFO_V1(pg_stat_monitor_hook_stats);
 
-static uint pg_get_client_addr(bool *ok);
+static uint pg_get_client_addr(void);
 static int	pg_get_application_name(char *name, int buff_size);
 static PgBackendStatus *pg_get_backend_status(void);
 static Datum intarray_get_datum(const int32 *arr, int len);
@@ -1261,18 +1261,14 @@ pg_get_application_name(char *name, int buff_size)
 }
 
 static uint
-pg_get_client_addr(bool *ok)
+pg_get_client_addr(void)
 {
 	PgBackendStatus *beentry = pg_get_backend_status();
 	char		remote_host[NI_MAXHOST];
 	int			ret;
 
-	remote_host[0] = '\0';
-
 	if (!beentry)
 		return ntohl(inet_addr("127.0.0.1"));
-
-	*ok = true;
 
 	ret = pg_getnameinfo_all(&beentry->st_clientaddr.addr,
 							 beentry->st_clientaddr.salen,
@@ -1687,7 +1683,6 @@ pgsm_create_hash_entry(int64 queryid, const PlanInfo *plan_info)
 {
 	pgsmEntry  *entry;
 	int			sec_ctx;
-	bool		found_client_addr = false;
 	MemoryContext oldctx;
 
 	/* Create an entry in the pgsm memory context */
@@ -1709,7 +1704,7 @@ pgsm_create_hash_entry(int64 queryid, const PlanInfo *plan_info)
 
 	/* Fetch client address only once */
 	if (pgsm_client_ip == PGSM_INVALID_IP)
-		pgsm_client_ip = pg_get_client_addr(&found_client_addr);
+		pgsm_client_ip = pg_get_client_addr();
 
 	entry->key.ip = pgsm_client_ip;
 

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -29,6 +29,7 @@
 #include <common/ip.h>
 #include <funcapi.h>
 #include <jit/jit.h>
+#include <libpq/libpq-be.h>
 #include <mb/pg_wchar.h>
 #include <miscadmin.h>
 #include <nodes/pg_list.h>
@@ -37,7 +38,6 @@
 #include <parser/parsetree.h>
 #include <parser/scanner.h>
 #include <parser/scansup.h>
-#include <pgstat.h>
 #include <storage/ipc.h>
 #include <storage/proc.h>
 #include <storage/shmem.h>
@@ -210,7 +210,6 @@ PG_FUNCTION_INFO_V1(pg_stat_monitor_hook_stats);
 
 static uint pg_get_client_addr(void);
 static int	pg_get_application_name(char *name, int buff_size);
-static PgBackendStatus *pg_get_backend_status(void);
 static Datum intarray_get_datum(const int32 *arr, int len);
 
 static int64 pgsm_hash_string(const char *str, int len);
@@ -1206,34 +1205,6 @@ pgsm_hash_string(const char *str, int len)
 	return DatumGetInt64(hash_any_extended((const unsigned char *) str, len, 0));
 }
 
-static PgBackendStatus *
-pg_get_backend_status(void)
-{
-#if PG_VERSION_NUM >= 170000
-	return pgstat_get_beentry_by_proc_number(MyProcPid);
-#elif PG_VERSION_NUM >= 160000
-	return &(pgstat_get_local_beentry_by_backend_id(MyBackendId)->backendStatus);
-#else
-	int			num_backends = pgstat_fetch_stat_numbackends();
-
-	for (int i = 1; i <= num_backends; i++)
-	{
-		LocalPgBackendStatus *local_beentry;
-		PgBackendStatus *beentry;
-
-		local_beentry = pgstat_fetch_stat_local_beentry(i);
-		if (!local_beentry)
-			continue;
-
-		beentry = &local_beentry->backendStatus;
-
-		if (beentry->st_procpid == MyProcPid)
-			return beentry;
-	}
-	return NULL;
-#endif
-}
-
 /*
  * The caller should allocate max_len memory to name including terminating null.
  * The function returns the length of the string.
@@ -1241,20 +1212,10 @@ pg_get_backend_status(void)
 static int
 pg_get_application_name(char *name, int buff_size)
 {
-	/* Try to read application name from GUC directly */
 	if (application_name && *application_name)
 		strlcpy(name, application_name, buff_size);
 	else
-	{
-		PgBackendStatus *beentry;
-
-		beentry = pg_get_backend_status();
-
-		if (!beentry)
-			strlcpy(name, "unknown", buff_size);
-		else
-			strlcpy(name, beentry->st_appname, buff_size);
-	}
+		strlcpy(name, "unknown", buff_size);
 
 	/* Return length so that others don't have to calculate */
 	return strlen(name);
@@ -1263,15 +1224,14 @@ pg_get_application_name(char *name, int buff_size)
 static uint
 pg_get_client_addr(void)
 {
-	PgBackendStatus *beentry = pg_get_backend_status();
 	char		remote_host[NI_MAXHOST];
 	int			ret;
 
-	if (!beentry)
+	if (!MyProcPort)
 		return ntohl(inet_addr("127.0.0.1"));
 
-	ret = pg_getnameinfo_all(&beentry->st_clientaddr.addr,
-							 beentry->st_clientaddr.salen,
+	ret = pg_getnameinfo_all(&MyProcPort->raddr.addr,
+							 MyProcPort->raddr.salen,
 							 remote_host, sizeof(remote_host),
 							 NULL, 0,
 							 NI_NUMERICHOST | NI_NUMERICSERV);


### PR DESCRIPTION
 Since `pg_get_backend_status()` contained a typo where we incorrectly tried to look up the BackendStatus by PID instead of by ProcNumber we almost never could see the right IP address.

But instead of fixing this we just make our lives easier by not looking at the BackendStatus at all for things related to our own backend. That seems quite wasteful and overly complex when we can access the fields directly.

The IP address code is still dodgy with its defaulting to 127.0.0.1 on UNIX sockets and its failure to support IPv6.

This might fix #519