### PR TITLE
Remove leftover function declaration

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -213,7 +213,6 @@ static int	pg_get_application_name(char *name, int buff_size);
 static Datum intarray_get_datum(const int32 *arr, int len);
 
 static int64 pgsm_hash_string(const char *str, int len);
-char	   *unpack_sql_state(int sql_state);
 
 static pgsmEntry *pgsm_create_hash_entry(int64 queryid, const PlanInfo *plan_info);
 static void pgsm_add_to_list(pgsmEntry *entry, const char *query_text, int query_len);


### PR DESCRIPTION
I forgot to remove this declaration when removing `unpack_sql_state()` in commit 9da007a83e0b507865e44749ad5b7fd6999db431.

PG-0