### PR TITLE
Use hash_bytes_extended() to skip casts to and from Datum

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1191,7 +1191,7 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 static int64
 pgsm_hash_string(const char *str, int len)
 {
-	return DatumGetInt64(hash_any_extended((const unsigned char *) str, len, 0));
+	return (int64) hash_bytes_extended((const unsigned char *) str, len, 0);
 }
 
 /*


### PR DESCRIPTION
The casts via Datum should not add any overhead but they made the code less clear.

PG-0
