### PR TITLE
Make sure to hold the entry lock while resetting

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -238,7 +238,6 @@ static void pgsm_update_entry(pgsmEntry *entry,
 							  const struct JitInstrumentation *jitusage,
 							  int parallel_workers_to_launch,
 							  int parallel_workers_launched,
-							  bool reset,
 							  pgsmStoreKind kind);
 static void pgsm_store(pgsmEntry *entry);
 
@@ -741,7 +740,6 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 						  0,	/* parallel_workers_to_launch */
 						  0,	/* parallel_workers_launched */
 #endif
-						  false,	/* reset */
 						  PGSM_EXEC);	/* kind */
 
 		pgsm_store(entry);
@@ -927,7 +925,6 @@ pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, Par
 							  NULL, /* jitusage */
 							  0,	/* parallel_workers_to_launch */
 							  0,	/* parallel_workers_launched */
-							  false,	/* reset */
 							  PGSM_PLAN);	/* kind */
 	}
 	else
@@ -1117,7 +1114,6 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 						  NULL, /* jitusage */
 						  0,	/* parallel_workers_to_launch */
 						  0,	/* parallel_workers_launched */
-						  false,	/* reset */
 						  PGSM_EXEC);	/* kind */
 
 		pgsm_store(entry);
@@ -1248,24 +1244,9 @@ pgsm_update_entry(pgsmEntry *entry,
 				  const struct JitInstrumentation *jitusage,
 				  int parallel_workers_to_launch,
 				  int parallel_workers_launched,
-				  bool reset,
 				  pgsmStoreKind kind)
 {
 	int			plan_text_len = plan_info ? plan_info->plan_len : 0;
-
-	/*
-	 * Start collecting data for next bucket and reset all counters and
-	 * timestamps
-	 */
-	if (reset)
-	{
-		memset(&entry->counters, 0, sizeof(Counters));
-		entry->stats_since = GetCurrentTimestamp();
-		entry->minmax_stats_since = entry->stats_since;
-	}
-
-	if (kind == PGSM_STORE)
-		SpinLockAcquire(&entry->mutex);
 
 	if (kind == PGSM_PLAN || kind == PGSM_STORE)
 	{
@@ -1492,9 +1473,6 @@ pgsm_update_entry(pgsmEntry *entry,
 	/* parallel worker counters */
 	entry->counters.parallel_workers_to_launch += parallel_workers_to_launch;
 	entry->counters.parallel_workers_launched += parallel_workers_launched;
-
-	if (kind == PGSM_STORE)
-		SpinLockRelease(&entry->mutex);
 }
 
 static void
@@ -1707,12 +1685,12 @@ pgsm_store(pgsmEntry *entry)
 	bool		found;
 	uint64		bucketid;
 	uint64		prev_bucket_id;
-	bool		reset = false;	/* Only used in update function - HAMID */
 	char	   *query;
 	BufferUsage bufusage;
 	WalUsage	walusage;
 	JitInstrumentation jitusage;
 	char		comments[COMMENTS_LEN];
+	TimestampTz reset_timestamp;
 
 	/* Safety check... */
 	if (!IsSystemInitialized())
@@ -1722,9 +1700,6 @@ pgsm_store(pgsmEntry *entry)
 
 	prev_bucket_id = pg_atomic_read_u64(&pgsm->current_wbucket);
 	bucketid = get_next_wbucket(pgsm);
-
-	if (bucketid != prev_bucket_id)
-		reset = true;
 
 	entry->key.bucket_id = bucketid;
 	query = entry->query_text.query_pointer;
@@ -1876,6 +1851,24 @@ pgsm_store(pgsmEntry *entry)
 		strlcpy(shared_hash_entry->username, entry->username, sizeof(shared_hash_entry->username));
 	}
 
+	/* Do work outside spinlock */
+	if (bucketid != prev_bucket_id)
+		reset_timestamp = GetCurrentTimestamp();
+
+	SpinLockAcquire(&shared_hash_entry->mutex);
+
+	/*
+	 * Start collecting data for next bucket and reset all counters and
+	 * timestamps.
+	 */
+	if (bucketid != prev_bucket_id)
+	{
+		memset(&shared_hash_entry->counters, 0, sizeof(Counters));
+		shared_hash_entry->counters.info.cmd_type = entry->counters.info.cmd_type;
+		shared_hash_entry->stats_since = reset_timestamp;
+		shared_hash_entry->minmax_stats_since = reset_timestamp;
+	}
+
 	pgsm_update_entry(shared_hash_entry,	/* entry */
 					  query,	/* query */
 					  pgsm_extract_comments ? comments : NULL,	/* comments */
@@ -1890,16 +1883,13 @@ pgsm_store(pgsmEntry *entry)
 					  &jitusage,	/* jitusage */
 					  entry->counters.parallel_workers_to_launch,	/* parallel_workers_to_launch */
 					  entry->counters.parallel_workers_launched,	/* parallel_workers_launched */
-					  reset,	/* reset */
 					  PGSM_STORE);
 
-	if (reset)
-	{
-		shared_hash_entry->counters.info.cmd_type = entry->counters.info.cmd_type;
-	}
+	SpinLockRelease(&shared_hash_entry->mutex);
+
+	pgsm_lock_release(pgsm);
 
 	memset(&entry->counters, 0, sizeof(entry->counters));
-	pgsm_lock_release(pgsm);
 }
 
 /*


### PR DESCRIPTION
When we switch buckets we believe we may have to reset hash table entries. if that is actually the case is a bit unclear since we also have code which tries to delete all old entries when switching bucket, but we may at least clean up the code so we do not modify entries in shared memory without holding a lock.

While at it we also move the taking and releasing of spin locks to a more sensible location.

PG-0