### PR TITLE
PG-2485 Fix off-by-one bug in comment extraction

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -3075,10 +3075,13 @@ get_histogram_timings(PG_FUNCTION_ARGS)
 }
 
 static bool
-append_comment_char(char *comments, size_t max_len, size_t *idx, char c)
+append_comment_char(char *comments, size_t buf_len, size_t *idx, char c)
 {
-	if (*idx >= max_len)
+	if (*idx >= buf_len - 1)
+	{
+		comments[buf_len - 1] = '\0';
 		return false;
+	}
 
 	comments[*idx] = c;
 	(*idx)++;
@@ -3087,14 +3090,14 @@ append_comment_char(char *comments, size_t max_len, size_t *idx, char c)
 }
 
 static void
-extract_query_comments(const char *query, char *comments, size_t max_len)
+extract_query_comments(const char *query, char *comments, size_t buf_len)
 {
 	size_t		curr_len = 0;
 	const char *q_iter = query;
 
 	if (!pgsm_extract_comments)
 	{
-		comments[0] = 0;
+		comments[0] = '\0';
 		return;
 	}
 
@@ -3107,27 +3110,27 @@ extract_query_comments(const char *query, char *comments, size_t max_len)
 		{
 			if (curr_len != 0)
 			{
-				if (!append_comment_char(comments, max_len, &curr_len, ','))
+				if (!append_comment_char(comments, buf_len, &curr_len, ','))
 					return;
-				if (!append_comment_char(comments, max_len, &curr_len, ' '))
+				if (!append_comment_char(comments, buf_len, &curr_len, ' '))
 					return;
 			}
 			while (*q_iter && *(q_iter + 1) && (*q_iter != '*' || *(q_iter + 1) != '/'))
 			{
-				if (!append_comment_char(comments, max_len, &curr_len, *q_iter))
+				if (!append_comment_char(comments, buf_len, &curr_len, *q_iter))
 					return;
 				q_iter++;
 			}
 
 			if (*q_iter)
 			{
-				if (!append_comment_char(comments, max_len, &curr_len, *q_iter))
+				if (!append_comment_char(comments, buf_len, &curr_len, *q_iter))
 					return;
 				q_iter++;
 			}
 			if (*q_iter)
 			{
-				if (!append_comment_char(comments, max_len, &curr_len, *q_iter))
+				if (!append_comment_char(comments, buf_len, &curr_len, *q_iter))
 					return;
 				q_iter++;
 			}
@@ -3136,7 +3139,7 @@ extract_query_comments(const char *query, char *comments, size_t max_len)
 		q_iter++;
 	}
 
-	comments[curr_len] = 0;
+	comments[curr_len] = '\0';
 }
 
 static void

--- a/t/003_settings_pgms_extract_comments.pl
+++ b/t/003_settings_pgms_extract_comments.pl
@@ -57,6 +57,12 @@ PGSM::append_to_file($stdout);
 
 ($cmdret, $stdout, $stderr) = $node->psql(
 	'postgres',
+	'SELECT 1 /* ' . 'x' x 256 . ' */, 2;',
+	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
+PGSM::append_to_file($stdout);
+
+($cmdret, $stdout, $stderr) = $node->psql(
+	'postgres',
 	'SELECT query, comments FROM pg_stat_monitor ORDER BY query COLLATE "C";',
 	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
 PGSM::append_to_file($stdout);

--- a/t/expected/003_settings_pgms_extract_comments.out
+++ b/t/expected/003_settings_pgms_extract_comments.out
@@ -17,13 +17,20 @@ SELECT 1 AS num /* First comment */, 'John' AS name /* Second comment*/;
    1 | John
 (1 row)
 
+SELECT 1 /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */, 2;
+ ?column? | ?column? 
+----------+----------
+        1 |        2
+(1 row)
+
 SELECT query, comments FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                                                                                            query                                                                                             |                 comments                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------
- SELECT 1 AS num /* First comment */, 'John' AS name /* Second comment*/                                                                                                                      | /* First comment */, /* Second comment*/
- SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name = 'pg_stat_monitor.pgsm_extract_comments' | 
- SELECT pg_stat_monitor_reset()                                                                                                                                                               | 
-(3 rows)
+                                                                                                                                       query                                                                                                                                        |                                                                                                                            comments                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT 1 /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */, 2 | /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ SELECT 1 AS num /* First comment */, 'John' AS name /* Second comment*/                                                                                                                                                                                                            | /* First comment */, /* Second comment*/
+ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name = 'pg_stat_monitor.pgsm_extract_comments'                                                                                       | 
+ SELECT pg_stat_monitor_reset()                                                                                                                                                                                                                                                     | 
+(4 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 


### PR DESCRIPTION
We could overflow the buffer by one byte due to and off-by-one bug. While fixing this bug we also rename the length variable to make the intent more obvious.

The code still does not handle multi-byte characters correctly but just not overflowing the buffer is a nice improvement.

PG-0

