### PR TITLE
Clean up getrusage() calls

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -525,8 +525,7 @@ pgsm_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 static void
 pgsm_ExecutorStart(QueryDesc *queryDesc, int eflags)
 {
-	if (getrusage(RUSAGE_SELF, &rusage_start) != 0)
-		elog(DEBUG1, "[pg_stat_monitor] pgsm_ExecutorStart: failed to execute getrusage.");
+	getrusage(RUSAGE_SELF, &rusage_start);
 
 	if (prev_ExecutorStart)
 		prev_ExecutorStart(queryDesc, eflags);
@@ -719,16 +718,9 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 		 */
 		InstrEndLoop(queryDesc->totaltime);
 
-		sys_info.utime = 0;
-		sys_info.stime = 0;
-
-		if (getrusage(RUSAGE_SELF, &rusage_end) != 0)
-			elog(DEBUG1, "[pg_stat_monitor] pgsm_ExecutorEnd: Failed to execute getrusage.");
-		else
-		{
-			sys_info.utime = time_diff(rusage_end.ru_utime, rusage_start.ru_utime);
-			sys_info.stime = time_diff(rusage_end.ru_stime, rusage_start.ru_stime);
-		}
+		getrusage(RUSAGE_SELF, &rusage_end);
+		sys_info.utime = time_diff(rusage_end.ru_utime, rusage_start.ru_utime);
+		sys_info.stime = time_diff(rusage_end.ru_stime, rusage_start.ru_stime);
 
 		entry->counters.info.cmd_type = queryDesc->operation;
 
@@ -1045,8 +1037,7 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		WalUsage	walusage_start = pgWalUsage;
 		pgsmEntry  *entry = pgsm_create_hash_entry(queryId, NULL);
 
-		if (getrusage(RUSAGE_SELF, &rusage_start) != 0)
-			elog(DEBUG1, "[pg_stat_monitor] pgsm_ProcessUtility: Failed to execute getrusage.");
+		getrusage(RUSAGE_SELF, &rusage_start);
 
 		INSTR_TIME_SET_CURRENT(start);
 		nesting_level++;
@@ -1072,19 +1063,11 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 			nesting_level--;
 			PG_RE_THROW();
 		}
-
-		sys_info.utime = 0;
-		sys_info.stime = 0;
-
 		PG_END_TRY();
 
-		if (getrusage(RUSAGE_SELF, &rusage_end) != 0)
-			elog(DEBUG1, "[pg_stat_monitor] pgsm_ProcessUtility: Failed to execute getrusage.");
-		else
-		{
-			sys_info.utime = time_diff(rusage_end.ru_utime, rusage_start.ru_utime);
-			sys_info.stime = time_diff(rusage_end.ru_stime, rusage_start.ru_stime);
-		}
+		getrusage(RUSAGE_SELF, &rusage_end);
+		sys_info.utime = time_diff(rusage_end.ru_utime, rusage_start.ru_utime);
+		sys_info.stime = time_diff(rusage_end.ru_stime, rusage_start.ru_stime);
 
 		INSTR_TIME_SET_CURRENT(duration);
 		INSTR_TIME_SUBTRACT(duration, start);

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -138,7 +138,6 @@ static char relations[REL_LST][REL_LEN];
 static int	num_relations;		/* Number of relation in the query */
 static bool system_init = false;
 static struct rusage rusage_start;
-static struct rusage rusage_end;
 
 /* Application name and length; set each time when an entry is created locally */
 static char app_name[APPLICATIONNAME_LEN];
@@ -700,6 +699,7 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 	if (queryId != INT64CONST(0) && queryDesc->totaltime && pgsm_enabled(nesting_level))
 	{
 		pgsmEntry  *entry;
+		struct rusage rusage_end;
 		SysInfo		sys_info;
 
 		entry = pgsm_get_entry_for_query(queryId, plan_ptr, queryDesc->sourceText, queryDesc->operation);
@@ -1030,6 +1030,7 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		instr_time	start;
 		instr_time	duration;
 		uint64		rows;
+		struct rusage rusage_end;
 		SysInfo		sys_info;
 		BufferUsage bufusage;
 		BufferUsage bufusage_start = pgBufferUsage;

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -524,7 +524,8 @@ pgsm_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 static void
 pgsm_ExecutorStart(QueryDesc *queryDesc, int eflags)
 {
-	getrusage(RUSAGE_SELF, &rusage_start);
+	if (pgsm_enabled(nesting_level))
+		getrusage(RUSAGE_SELF, &rusage_start);
 
 	if (prev_ExecutorStart)
 		prev_ExecutorStart(queryDesc, eflags);


### PR DESCRIPTION
This does not fix the bug with `getrusage()` calls overwriting `rusage_start` but still improves our code a bit. Fixes:

- Stop calling `getruage()` when tracking is not enabled.
- Stop trying to handle errors from a function which cannot fail expect for on invalid input. PostgreSQL also ignores errors from `getrusage()`.
- Make `rusage_end` a local variable.

PG-0
