### PR TITLE
Do not call strlen() when we already have the length

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1201,13 +1201,15 @@ pgsm_hash_string(const char *str, int len)
 static int
 pg_get_application_name(char *name, int buff_size)
 {
+	int			len;
+
 	if (application_name && *application_name)
-		strlcpy(name, application_name, buff_size);
+		len = strlcpy(name, application_name, buff_size);
 	else
-		strlcpy(name, "unknown", buff_size);
+		len = strlcpy(name, "unknown", buff_size);
 
 	/* Return length so that others don't have to calculate */
-	return strlen(name);
+	return len < buff_size ? len : buff_size - 1;
 }
 
 static uint


### PR DESCRIPTION
Either we should move the call to `strlen()` to the callers or we should actually use the fact that `strlcpy()` returns the length.

PG-0
