### PR TITLE
Clean up SQL formatting in the pg_regress tests

### DIFF
--- a/regression/expected/application_name.out
+++ b/regression/expected/application_name.out
@@ -11,7 +11,7 @@ SELECT 1 AS num;
    1
 (1 row)
 
-SELECT query,application_name FROM pg_stat_monitor ORDER BY query COLLATE "C";
+SELECT query, application_name FROM pg_stat_monitor ORDER BY query COLLATE "C";
              query              |      application_name       
 --------------------------------+-----------------------------
  SELECT 1 AS num                | pg_regress/application_name
@@ -30,20 +30,20 @@ SELECT 1 AS num;
    1
 (1 row)
 
-SET pg_stat_monitor.pgsm_track_application_names='no';
+SET pg_stat_monitor.pgsm_track_application_names = off;
 SELECT 1 AS num;
  num 
 -----
    1
 (1 row)
 
-SELECT query,application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
-                         query                         |      application_name       
--------------------------------------------------------+-----------------------------
- SELECT 1 AS num                                       | pg_regress/application_name
- SELECT 1 AS num                                       | 
- SELECT pg_stat_monitor_reset()                        | pg_regress/application_name
- SET pg_stat_monitor.pgsm_track_application_names='no' | 
+SELECT query, application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
+                         query                          |      application_name       
+--------------------------------------------------------+-----------------------------
+ SELECT 1 AS num                                        | pg_regress/application_name
+ SELECT 1 AS num                                        | 
+ SELECT pg_stat_monitor_reset()                         | pg_regress/application_name
+ SET pg_stat_monitor.pgsm_track_application_names = off | 
 (4 rows)
 
 SELECT pg_stat_monitor_reset();

--- a/regression/expected/application_name_unique.out
+++ b/regression/expected/application_name_unique.out
@@ -5,21 +5,21 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-SET application_name = 'naeem' ; 
+SET application_name = 'naeem';
 SELECT 1 AS num;
  num 
 -----
    1
 (1 row)
 
-SET application_name = 'psql' ; 
+SET application_name = 'psql';
 SELECT 1 AS num;
  num 
 -----
    1
 (1 row)
 
-SELECT query,application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
+SELECT query, application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
              query              |          application_name          
 --------------------------------+------------------------------------
  SELECT 1 AS num                | naeem

--- a/regression/expected/cmd_type.out
+++ b/regression/expected/cmd_type.out
@@ -5,9 +5,9 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-CREATE TABLE t1 (a INTEGER);
-CREATE TABLE t2 (b INTEGER);
-INSERT INTO t1 VALUES(1);
+CREATE TABLE t1 (a int);
+CREATE TABLE t2 (b int);
+INSERT INTO t1 VALUES (1);
 SELECT a FROM t1;
  a 
 ---
@@ -24,15 +24,15 @@ SELECT b FROM t2 FOR UPDATE;
 TRUNCATE t1;
 DROP TABLE t1;
 DROP TABLE t2;
-SELECT query, cmd_type,  cmd_type_text FROM pg_stat_monitor ORDER BY query COLLATE "C";
+SELECT query, cmd_type, cmd_type_text FROM pg_stat_monitor ORDER BY query COLLATE "C";
              query              | cmd_type | cmd_type_text 
 --------------------------------+----------+---------------
- CREATE TABLE t1 (a INTEGER)    |        5 | UTILITY
- CREATE TABLE t2 (b INTEGER)    |        5 | UTILITY
+ CREATE TABLE t1 (a int)        |        5 | UTILITY
+ CREATE TABLE t2 (b int)        |        5 | UTILITY
  DELETE FROM t1                 |        4 | DELETE
  DROP TABLE t1                  |        5 | UTILITY
  DROP TABLE t2                  |        5 | UTILITY
- INSERT INTO t1 VALUES(1)       |        3 | INSERT
+ INSERT INTO t1 VALUES (1)      |        3 | INSERT
  SELECT a FROM t1               |        1 | SELECT
  SELECT b FROM t2 FOR UPDATE    |        1 | SELECT
  SELECT pg_stat_monitor_reset() |        1 | SELECT

--- a/regression/expected/cmd_type_1.out
+++ b/regression/expected/cmd_type_1.out
@@ -5,9 +5,9 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-CREATE TABLE t1 (a INTEGER);
-CREATE TABLE t2 (b INTEGER);
-INSERT INTO t1 VALUES(1);
+CREATE TABLE t1 (a int);
+CREATE TABLE t2 (b int);
+INSERT INTO t1 VALUES (1);
 SELECT a FROM t1;
  a 
 ---
@@ -24,15 +24,15 @@ SELECT b FROM t2 FOR UPDATE;
 TRUNCATE t1;
 DROP TABLE t1;
 DROP TABLE t2;
-SELECT query, cmd_type,  cmd_type_text FROM pg_stat_monitor ORDER BY query COLLATE "C";
+SELECT query, cmd_type, cmd_type_text FROM pg_stat_monitor ORDER BY query COLLATE "C";
              query              | cmd_type | cmd_type_text 
 --------------------------------+----------+---------------
- CREATE TABLE t1 (a INTEGER)    |        6 | UTILITY
- CREATE TABLE t2 (b INTEGER)    |        6 | UTILITY
+ CREATE TABLE t1 (a int)        |        6 | UTILITY
+ CREATE TABLE t2 (b int)        |        6 | UTILITY
  DELETE FROM t1                 |        4 | DELETE
  DROP TABLE t1                  |        6 | UTILITY
  DROP TABLE t2                  |        6 | UTILITY
- INSERT INTO t1 VALUES(1)       |        3 | INSERT
+ INSERT INTO t1 VALUES (1)      |        3 | INSERT
  SELECT a FROM t1               |        1 | SELECT
  SELECT b FROM t2 FOR UPDATE    |        1 | SELECT
  SELECT pg_stat_monitor_reset() |        1 | SELECT

--- a/regression/expected/counters.out
+++ b/regression/expected/counters.out
@@ -6,41 +6,41 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-CREATE TABLE t1 (a INTEGER);
-CREATE TABLE t2 (b INTEGER);
-CREATE TABLE t3 (c INTEGER);
-CREATE TABLE t4 (d INTEGER);
+CREATE TABLE t1 (a int);
+CREATE TABLE t2 (b int);
+CREATE TABLE t3 (c int);
+CREATE TABLE t4 (d int);
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------
  
 (1 row)
 
-SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
+SELECT a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
  a | b | c | d 
 ---+---+---+---
 (0 rows)
 
-SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
+SELECT a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
  a | b | c | d 
 ---+---+---+---
 (0 rows)
 
-SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
+SELECT a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
  a | b | c | d 
 ---+---+---+---
 (0 rows)
 
-SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
+SELECT a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
  a | b | c | d 
 ---+---+---+---
 (0 rows)
 
 SELECT query, sum(calls) as calls FROM pg_stat_monitor GROUP BY query ORDER BY query COLLATE "C";
-                                      query                                      | calls 
----------------------------------------------------------------------------------+-------
- SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a |     4
- SELECT pg_stat_monitor_reset()                                                  |     1
+                                       query                                        | calls 
+------------------------------------------------------------------------------------+-------
+ SELECT a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a |     4
+ SELECT pg_stat_monitor_reset()                                                     |     1
 (2 rows)
 
 SELECT pg_stat_monitor_reset();
@@ -49,31 +49,33 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-do $$
-declare
-   n integer:= 1;
-begin
-	loop
-		PERFORM a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
-		exit when n = 1000;
-		n := n + 1;
-	end loop;
-end $$;
+DO $$
+DECLARE
+    n int := 1;
+BEGIN
+    LOOP
+        PERFORM a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
+        EXIT WHEN n = 1000;
+        n := n + 1;
+    END LOOP;
+END
+$$;
 SELECT query, sum(calls) as calls FROM pg_stat_monitor GROUP BY query ORDER BY query COLLATE "C";
-                                               query                                               | calls 
----------------------------------------------------------------------------------------------------+-------
- SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a                   |  1000
- SELECT pg_stat_monitor_reset()                                                                    |     1
- do $$                                                                                            +|     1
- declare                                                                                          +| 
-    n integer:= 1;                                                                                +| 
- begin                                                                                            +| 
-         loop                                                                                     +| 
-                 PERFORM a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;+| 
-                 exit when n = 1000;                                                              +| 
-                 n := n + 1;                                                                      +| 
-         end loop;                                                                                +| 
- end $$                                                                                            | 
+                                            query                                             | calls 
+----------------------------------------------------------------------------------------------+-------
+ DO $$                                                                                       +|     1
+ DECLARE                                                                                     +| 
+     n int := 1;                                                                             +| 
+ BEGIN                                                                                       +| 
+     LOOP                                                                                    +| 
+         PERFORM a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;+| 
+         EXIT WHEN n = 1000;                                                                 +| 
+         n := n + 1;                                                                         +| 
+     END LOOP;                                                                               +| 
+ END                                                                                         +| 
+ $$                                                                                           | 
+ SELECT a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a           |  1000
+ SELECT pg_stat_monitor_reset()                                                               |     1
 (3 rows)
 
 DROP TABLE t1;

--- a/regression/expected/database.out
+++ b/regression/expected/database.out
@@ -15,13 +15,13 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 \c db1
-SELECT * FROM t1,t2 WHERE t1.a = t2.b;
+SELECT * FROM t1, t2 WHERE t1.a = t2.b;
  a | b 
 ---+---
 (0 rows)
 
 \c db2
-SELECT * FROM t3,t4 WHERE t3.c = t4.d;
+SELECT * FROM t3, t4 WHERE t3.c = t4.d;
  c | d 
 ---+---
 (0 rows)
@@ -29,11 +29,11 @@ SELECT * FROM t3,t4 WHERE t3.c = t4.d;
 \c contrib_regression
 DROP DATABASE db2;
 SELECT datname, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
-      datname       |                 query                 
---------------------+---------------------------------------
+      datname       |                 query                  
+--------------------+----------------------------------------
  contrib_regression | DROP DATABASE db2
- db1                | SELECT * FROM t1,t2 WHERE t1.a = t2.b
- db2                | SELECT * FROM t3,t4 WHERE t3.c = t4.d
+ db1                | SELECT * FROM t1, t2 WHERE t1.a = t2.b
+ db2                | SELECT * FROM t3, t4 WHERE t3.c = t4.d
  contrib_regression | SELECT pg_stat_monitor_reset()
 (4 rows)
 

--- a/regression/expected/decode_error_level.out
+++ b/regression/expected/decode_error_level.out
@@ -1,12 +1,13 @@
 CREATE EXTENSION pg_stat_monitor;
 DO $$
 DECLARE
-    i integer;
+    i int;
 BEGIN
     FOR i IN 10..24 LOOP
-         RAISE NOTICE 'error_code: %, error_level: %', i, decode_error_level(i);
+        RAISE NOTICE 'error_code: %, error_level: %', i, decode_error_level(i);
     END LOOP;
-END $$;
+END
+$$;
 NOTICE:  error_code: 10, error_level: DEBUG5
 NOTICE:  error_code: 11, error_level: DEBUG4
 NOTICE:  error_code: 12, error_level: DEBUG3

--- a/regression/expected/different_parent_queries.out
+++ b/regression/expected/different_parent_queries.out
@@ -6,16 +6,16 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-CREATE OR REPLACE FUNCTION test() RETURNS VOID AS
-$$
+CREATE OR REPLACE FUNCTION test() RETURNS void AS $$
 BEGIN
-	PERFORM 1 + 2;
-END; $$ language plpgsql;
-CREATE OR REPLACE FUNCTION test2() RETURNS VOID AS
-$$
+    PERFORM 1 + 2;
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION test2() RETURNS void AS $$
 BEGIN
-	PERFORM 1 + 2;
-END; $$ language plpgsql;
+    PERFORM 1 + 2;
+END
+$$ LANGUAGE plpgsql;
 SELECT pg_stat_monitor_reset(); 
  pg_stat_monitor_reset 
 -----------------------
@@ -40,7 +40,7 @@ SELECT 1 + 2;
         3
 (1 row)
 
-SELECT left(query, 15) as query, calls, top_query, pgsm_query_id FROM pg_stat_monitor ORDER BY query, top_query COLLATE "C";
+SELECT left(query, 15) AS query, calls, top_query, pgsm_query_id FROM pg_stat_monitor ORDER BY query, top_query COLLATE "C";
       query      | calls |    top_query    |    pgsm_query_id     
 -----------------+-------+-----------------+----------------------
  SELECT 1 + 2    |     1 | SELECT test();  |  5193804135051352284

--- a/regression/expected/error.out
+++ b/regression/expected/error.out
@@ -5,7 +5,7 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-SELECT 1/0;   -- divide by zero
+SELECT 1 / 0; -- divide by zero
 ERROR:  division by zero
 SELECT * FROM unknown; -- unknown table
 ERROR:  relation "unknown" does not exist
@@ -15,26 +15,29 @@ ELECET * FROM unknown; -- syntax error
 ERROR:  syntax error at or near "ELECET"
 LINE 1: ELECET * FROM unknown;
         ^
-do $$
+DO $$
 BEGIN
-RAISE WARNING 'warning message';
-END $$;
+    RAISE WARNING 'warning message';
+END
+$$;
 WARNING:  warning message
-SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C",elevel;
-              query               | elevel | sqlcode |              message              
-----------------------------------+--------+---------+-----------------------------------
- ELECET * FROM unknown;           |     21 | 42601   | syntax error at or near "ELECET"
- SELECT * FROM unknown;           |     21 | 42P01   | relation "unknown" does not exist
- SELECT 1/0;                      |     21 | 22012   | division by zero
- SELECT pg_stat_monitor_reset()   |      0 |         | 
- do $$                           +|      0 |         | 
- BEGIN                           +|        |         | 
- RAISE WARNING 'warning message';+|        |         | 
- END $$                           |        |         | 
- do $$                           +|     19 | 01000   | warning message
- BEGIN                           +|        |         | 
- RAISE WARNING 'warning message';+|        |         | 
- END $$;                          |        |         | 
+SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C", elevel;
+                query                 | elevel | sqlcode |              message              
+--------------------------------------+--------+---------+-----------------------------------
+ DO $$                               +|      0 |         | 
+ BEGIN                               +|        |         | 
+     RAISE WARNING 'warning message';+|        |         | 
+ END                                 +|        |         | 
+ $$                                   |        |         | 
+ DO $$                               +|     19 | 01000   | warning message
+ BEGIN                               +|        |         | 
+     RAISE WARNING 'warning message';+|        |         | 
+ END                                 +|        |         | 
+ $$;                                  |        |         | 
+ ELECET * FROM unknown;               |     21 | 42601   | syntax error at or near "ELECET"
+ SELECT * FROM unknown;               |     21 | 42P01   | relation "unknown" does not exist
+ SELECT 1 / 0;                        |     21 | 22012   | division by zero
+ SELECT pg_stat_monitor_reset()       |      0 |         | 
 (6 rows)
 
 SELECT pg_stat_monitor_reset();

--- a/regression/expected/error_insert.out
+++ b/regression/expected/error_insert.out
@@ -1,8 +1,8 @@
-DROP TABLE IF EXISTS Company;
+DROP TABLE IF EXISTS company;
 NOTICE:  table "company" does not exist, skipping
-CREATE TABLE Company(
-   ID INT PRIMARY KEY     NOT NULL,
-   NAME TEXT    NOT NULL
+CREATE TABLE company (
+    id int PRIMARY KEY NOT NULL,
+    name text NOT NULL
 );
 CREATE EXTENSION pg_stat_monitor;
 SELECT pg_stat_monitor_reset();
@@ -11,17 +11,17 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-INSERT  INTO Company(ID, Name) VALUES (1, 'Percona'); 
-INSERT  INTO Company(ID, Name) VALUES (1, 'Percona'); 
+INSERT INTO company (id, name) VALUES (1, 'Percona');
+INSERT INTO company (id, name) VALUES (1, 'Percona');
 ERROR:  duplicate key value violates unique constraint "company_pkey"
 DETAIL:  Key (id)=(1) already exists.
-DROP TABLE IF EXISTS Company;
-SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C",elevel;
+DROP TABLE IF EXISTS company;
+SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C", elevel;
                          query                         | elevel | sqlcode |                            message                            
 -------------------------------------------------------+--------+---------+---------------------------------------------------------------
- DROP TABLE IF EXISTS Company                          |      0 |         | 
- INSERT  INTO Company(ID, Name) VALUES (1, 'Percona')  |      0 |         | 
- INSERT  INTO Company(ID, Name) VALUES (1, 'Percona'); |     21 | 23505   | duplicate key value violates unique constraint "company_pkey"
+ DROP TABLE IF EXISTS company                          |      0 |         | 
+ INSERT INTO company (id, name) VALUES (1, 'Percona')  |      0 |         | 
+ INSERT INTO company (id, name) VALUES (1, 'Percona'); |     21 | 23505   | duplicate key value violates unique constraint "company_pkey"
  SELECT pg_stat_monitor_reset()                        |      0 |         | 
 (4 rows)
 

--- a/regression/expected/guc.out
+++ b/regression/expected/guc.out
@@ -1,20 +1,20 @@
 CREATE EXTENSION pg_stat_monitor;
-SELECT  name
-        , setting
-        , unit
-        , context
-        , vartype
-        , source
-        , min_val
-        , max_val
-        , enumvals
-        , boot_val
-        , reset_val
-        , pending_restart 
-FROM    pg_settings
-WHERE   name     LIKE     'pg_stat_monitor.%'
-ORDER
-BY      name
+SELECT
+    name,
+    setting,
+    unit,
+    context,
+    vartype,
+    source,
+    min_val,
+    max_val,
+    enumvals,
+    boot_val,
+    reset_val,
+    pending_restart
+FROM pg_settings
+WHERE name LIKE 'pg_stat_monitor.%'
+ORDER BY name
 COLLATE "C";
                      name                     | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
 ----------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------

--- a/regression/expected/level_tracking.out
+++ b/regression/expected/level_tracking.out
@@ -2,8 +2,8 @@
 -- Statement level tracking
 --
 CREATE EXTENSION pg_stat_monitor;
-SET pg_stat_monitor.pgsm_track_utility = TRUE;
-SET pg_stat_monitor.pgsm_normalized_query = TRUE;
+SET pg_stat_monitor.pgsm_track_utility = on;
+SET pg_stat_monitor.pgsm_normalized_query = on;
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------
@@ -16,19 +16,19 @@ SET pg_stat_monitor.pgsm_track = 'top';
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END;
-$$ LANGUAGE plpgsql;
+    DELETE FROM stats_track_tab;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  WHERE query LIKE '%DELETE%' ORDER BY query COLLATE "C", toplevel;
- toplevel | calls |             query              
-----------+-------+--------------------------------
+    WHERE query LIKE '%DELETE%' ORDER BY query COLLATE "C", toplevel;
+ toplevel | calls |              query               
+----------+-------+----------------------------------
  t        |     1 | DELETE FROM stats_track_tab
- t        |     1 | DO $$                         +
-          |       | BEGIN                         +
-          |       |   DELETE FROM stats_track_tab;+
-          |       | END;                          +
-          |       | $$ LANGUAGE plpgsql
+ t        |     1 | DO $$                           +
+          |       | BEGIN                           +
+          |       |     DELETE FROM stats_track_tab;+
+          |       | END                             +
+          |       | $$
 (2 rows)
 
 SELECT pg_stat_monitor_reset();
@@ -42,36 +42,40 @@ SET pg_stat_monitor.pgsm_track = 'all';
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END; $$;
-DO LANGUAGE plpgsql $$
+    DELETE FROM stats_track_tab;
+END
+$$;
+DO $$
 BEGIN
-  -- this is a SELECT
-  PERFORM 'hello world'::TEXT;
-END; $$;
+    -- this is a SELECT
+    PERFORM 'hello world'::text;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  ORDER BY query COLLATE "C", toplevel;
+    ORDER BY query COLLATE "C", toplevel;
  toplevel | calls |                 query                  
 ----------+-------+----------------------------------------
  f        |     1 | DELETE FROM stats_track_tab
  t        |     1 | DELETE FROM stats_track_tab
  t        |     1 | DO $$                                 +
           |       | BEGIN                                 +
-          |       |   DELETE FROM stats_track_tab;        +
-          |       | END; $$
- t        |     1 | DO LANGUAGE plpgsql $$                +
+          |       |     -- this is a SELECT               +
+          |       |     PERFORM 'hello world'::text;      +
+          |       | END                                   +
+          |       | $$
+ t        |     1 | DO $$                                 +
           |       | BEGIN                                 +
-          |       |   -- this is a SELECT                 +
-          |       |   PERFORM 'hello world'::TEXT;        +
-          |       | END; $$
- f        |     1 | SELECT $1::TEXT
+          |       |     DELETE FROM stats_track_tab;      +
+          |       | END                                   +
+          |       | $$
+ f        |     1 | SELECT $1::text
  t        |     1 | SELECT pg_stat_monitor_reset()
  t        |     1 | SET pg_stat_monitor.pgsm_track = 'all'
 (7 rows)
 
 -- DO block - top-level tracking without utility.
 SET pg_stat_monitor.pgsm_track = 'top';
-SET pg_stat_monitor.pgsm_track_utility = FALSE;
+SET pg_stat_monitor.pgsm_track_utility = off;
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------
@@ -81,19 +85,21 @@ SELECT pg_stat_monitor_reset();
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END; $$;
-DO LANGUAGE plpgsql $$
+    DELETE FROM stats_track_tab;
+END
+$$;
+DO $$
 BEGIN
-  -- this is a SELECT
-  PERFORM 'hello world'::TEXT;
-END; $$;
+    -- this is a SELECT
+    PERFORM 'hello world'::text;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  ORDER BY query COLLATE "C", toplevel;
+    ORDER BY query COLLATE "C", toplevel;
  toplevel | calls |             query              
 ----------+-------+--------------------------------
  t        |     2 | DELETE FROM stats_track_tab
- t        |     1 | SELECT $1::TEXT
+ t        |     1 | SELECT $1::text
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
@@ -108,60 +114,63 @@ SELECT pg_stat_monitor_reset();
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END; $$;
-DO LANGUAGE plpgsql $$
+    DELETE FROM stats_track_tab;
+END
+$$;
+DO $$
 BEGIN
-  -- this is a SELECT
-  PERFORM 'hello world'::TEXT;
-END; $$;
+    -- this is a SELECT
+    PERFORM 'hello world'::text;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  ORDER BY query COLLATE "C", toplevel;
+    ORDER BY query COLLATE "C", toplevel;
  toplevel | calls |             query              
 ----------+-------+--------------------------------
  t        |     2 | DELETE FROM stats_track_tab
- t        |     1 | SELECT $1::TEXT
+ t        |     1 | SELECT $1::text
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
 -- PL/pgSQL function - top-level tracking.
 SET pg_stat_monitor.pgsm_track = 'top';
-SET pg_stat_monitor.pgsm_track_utility = FALSE;
+SET pg_stat_monitor.pgsm_track_utility = off;
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------
  
 (1 row)
 
-CREATE FUNCTION PLUS_TWO(i INTEGER) RETURNS INTEGER AS $$
+CREATE FUNCTION plus_two(i int) RETURNS int AS $$
 DECLARE
-  r INTEGER;
+    r int;
 BEGIN
-  SELECT (i + 1 + 1.0)::INTEGER INTO r;
-  RETURN r;
-END; $$ LANGUAGE plpgsql;
-SELECT PLUS_TWO(3);
+    SELECT (i + 1 + 1.0)::int INTO r;
+    RETURN r;
+END
+$$ LANGUAGE plpgsql;
+SELECT plus_two(3);
  plus_two 
 ----------
         5
 (1 row)
 
-SELECT PLUS_TWO(7);
+SELECT plus_two(7);
  plus_two 
 ----------
         9
 (1 row)
 
 -- SQL function --- use LIMIT to keep it from being inlined
-CREATE FUNCTION PLUS_ONE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT (i + 1.0)::INTEGER LIMIT 1 $$ LANGUAGE SQL;
-SELECT PLUS_ONE(8);
+CREATE FUNCTION plus_one(i int) RETURNS int AS
+$$ SELECT (i + 1.0)::int LIMIT 1 $$ LANGUAGE sql;
+SELECT plus_one(8);
  plus_one 
 ----------
         9
 (1 row)
 
-SELECT PLUS_ONE(10);
+SELECT plus_one(10);
  plus_one 
 ----------
        11
@@ -170,21 +179,21 @@ SELECT PLUS_ONE(10);
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
  calls | rows |             query              
 -------+------+--------------------------------
-     2 |    2 | SELECT PLUS_ONE($1)
-     2 |    2 | SELECT PLUS_TWO($1)
      1 |    1 | SELECT pg_stat_monitor_reset()
+     2 |    2 | SELECT plus_one($1)
+     2 |    2 | SELECT plus_two($1)
 (3 rows)
 
 -- immutable SQL function --- can be executed at plan time
-CREATE FUNCTION PLUS_THREE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE SQL;
-SELECT PLUS_THREE(8);
+CREATE FUNCTION plus_three(i int) RETURNS int AS
+$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE sql;
+SELECT plus_three(8);
  plus_three 
 ------------
          11
 (1 row)
 
-SELECT PLUS_THREE(10);
+SELECT plus_three(10);
  plus_three 
 ------------
          13
@@ -193,12 +202,12 @@ SELECT PLUS_THREE(10);
 SELECT toplevel, calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
  toplevel | calls | rows |                                   query                                   
 ----------+-------+------+---------------------------------------------------------------------------
- t        |     2 |    2 | SELECT PLUS_ONE($1)
- t        |     2 |    2 | SELECT PLUS_THREE($1)
- t        |     2 |    2 | SELECT PLUS_TWO($1)
  t        |     1 |    3 | SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C"
  f        |     2 |    2 | SELECT i + $2 LIMIT $3
  t        |     1 |    1 | SELECT pg_stat_monitor_reset()
+ t        |     2 |    2 | SELECT plus_one($1)
+ t        |     2 |    2 | SELECT plus_three($1)
+ t        |     2 |    2 | SELECT plus_two($1)
 (6 rows)
 
 -- PL/pgSQL function - all-level tracking.
@@ -210,64 +219,65 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 -- we drop and recreate the functions to avoid any caching funnies
-DROP FUNCTION PLUS_ONE(INTEGER);
-DROP FUNCTION PLUS_TWO(INTEGER);
-DROP FUNCTION PLUS_THREE(INTEGER);
+DROP FUNCTION plus_one(int);
+DROP FUNCTION plus_two(int);
+DROP FUNCTION plus_three(int);
 -- PL/pgSQL function
-CREATE FUNCTION PLUS_TWO(i INTEGER) RETURNS INTEGER AS $$
+CREATE FUNCTION plus_two(i int) RETURNS int AS $$
 DECLARE
-  r INTEGER;
+    r int;
 BEGIN
-  SELECT (i + 1 + 1.0)::INTEGER INTO r;
-  RETURN r;
-END; $$ LANGUAGE plpgsql;
-SELECT PLUS_TWO(-1);
+    SELECT (i + 1 + 1.0)::int INTO r;
+    RETURN r;
+END
+$$ LANGUAGE plpgsql;
+SELECT plus_two(-1);
  plus_two 
 ----------
         1
 (1 row)
 
-SELECT PLUS_TWO(2);
+SELECT plus_two(2);
  plus_two 
 ----------
         4
 (1 row)
 
 -- SQL function --- use LIMIT to keep it from being inlined
-CREATE FUNCTION PLUS_ONE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT (i + 1.0)::INTEGER LIMIT 1 $$ LANGUAGE SQL;
-SELECT PLUS_ONE(3);
+CREATE FUNCTION plus_one(i int) RETURNS int AS
+$$ SELECT (i + 1.0)::int LIMIT 1 $$ LANGUAGE sql;
+SELECT plus_one(3);
  plus_one 
 ----------
         4
 (1 row)
 
-SELECT PLUS_ONE(1);
+SELECT plus_one(1);
  plus_one 
 ----------
         2
 (1 row)
 
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |               query               
--------+------+-----------------------------------
-     2 |    2 | SELECT (i + $2 + $3)::INTEGER
-     2 |    2 | SELECT (i + $2)::INTEGER LIMIT $3
-     2 |    2 | SELECT PLUS_ONE($1)
-     2 |    2 | SELECT PLUS_TWO($1)
+ calls | rows |             query              
+-------+------+--------------------------------
+     2 |    2 | SELECT (i + $2 + $3)::int
+     2 |    2 | SELECT (i + $2)::int LIMIT $3
      1 |    1 | SELECT pg_stat_monitor_reset()
+     2 |    2 | SELECT plus_one($1)
+     2 |    2 | SELECT plus_two($1)
 (5 rows)
 
 -- immutable SQL function --- can be executed at plan time
-CREATE FUNCTION PLUS_THREE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE SQL;
-SELECT PLUS_THREE(8);
+CREATE FUNCTION plus_three(i int) RETURNS int AS
+$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE sql;
+SELECT plus_three(8);
  plus_three 
 ------------
          11
 (1 row)
 
-SELECT PLUS_THREE(10);
+SELECT plus_three(10);
  plus_three 
 ------------
          13
@@ -276,14 +286,14 @@ SELECT PLUS_THREE(10);
 SELECT toplevel, calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
  toplevel | calls | rows |                                   query                                   
 ----------+-------+------+---------------------------------------------------------------------------
- f        |     2 |    2 | SELECT (i + $2 + $3)::INTEGER
- f        |     2 |    2 | SELECT (i + $2)::INTEGER LIMIT $3
- t        |     2 |    2 | SELECT PLUS_ONE($1)
- t        |     2 |    2 | SELECT PLUS_THREE($1)
- t        |     2 |    2 | SELECT PLUS_TWO($1)
+ f        |     2 |    2 | SELECT (i + $2 + $3)::int
+ f        |     2 |    2 | SELECT (i + $2)::int LIMIT $3
  t        |     1 |    5 | SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C"
  f        |     2 |    2 | SELECT i + $2 LIMIT $3
  t        |     1 |    1 | SELECT pg_stat_monitor_reset()
+ t        |     2 |    2 | SELECT plus_one($1)
+ t        |     2 |    2 | SELECT plus_three($1)
+ t        |     2 |    2 | SELECT plus_two($1)
 (8 rows)
 
 --
@@ -296,13 +306,13 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-SELECT 1 AS "one";
+SELECT 1 AS one;
  one 
 -----
    1
 (1 row)
 
-SELECT 1 + 1 AS "two";
+SELECT 1 + 1 AS two;
  two 
 -----
    2

--- a/regression/expected/level_tracking_1.out
+++ b/regression/expected/level_tracking_1.out
@@ -2,8 +2,8 @@
 -- Statement level tracking
 --
 CREATE EXTENSION pg_stat_monitor;
-SET pg_stat_monitor.pgsm_track_utility = TRUE;
-SET pg_stat_monitor.pgsm_normalized_query = TRUE;
+SET pg_stat_monitor.pgsm_track_utility = on;
+SET pg_stat_monitor.pgsm_normalized_query = on;
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------
@@ -16,19 +16,19 @@ SET pg_stat_monitor.pgsm_track = 'top';
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END;
-$$ LANGUAGE plpgsql;
+    DELETE FROM stats_track_tab;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  WHERE query LIKE '%DELETE%' ORDER BY query COLLATE "C", toplevel;
- toplevel | calls |             query              
-----------+-------+--------------------------------
+    WHERE query LIKE '%DELETE%' ORDER BY query COLLATE "C", toplevel;
+ toplevel | calls |              query               
+----------+-------+----------------------------------
  t        |     1 | DELETE FROM stats_track_tab
- t        |     1 | DO $$                         +
-          |       | BEGIN                         +
-          |       |   DELETE FROM stats_track_tab;+
-          |       | END;                          +
-          |       | $$ LANGUAGE plpgsql
+ t        |     1 | DO $$                           +
+          |       | BEGIN                           +
+          |       |     DELETE FROM stats_track_tab;+
+          |       | END                             +
+          |       | $$
 (2 rows)
 
 SELECT pg_stat_monitor_reset();
@@ -42,36 +42,40 @@ SET pg_stat_monitor.pgsm_track = 'all';
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END; $$;
-DO LANGUAGE plpgsql $$
+    DELETE FROM stats_track_tab;
+END
+$$;
+DO $$
 BEGIN
-  -- this is a SELECT
-  PERFORM 'hello world'::TEXT;
-END; $$;
+    -- this is a SELECT
+    PERFORM 'hello world'::text;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  ORDER BY query COLLATE "C", toplevel;
+    ORDER BY query COLLATE "C", toplevel;
  toplevel | calls |                 query                  
 ----------+-------+----------------------------------------
  f        |     1 | DELETE FROM stats_track_tab
  t        |     1 | DELETE FROM stats_track_tab
  t        |     1 | DO $$                                 +
           |       | BEGIN                                 +
-          |       |   DELETE FROM stats_track_tab;        +
-          |       | END; $$
- t        |     1 | DO LANGUAGE plpgsql $$                +
+          |       |     -- this is a SELECT               +
+          |       |     PERFORM 'hello world'::text;      +
+          |       | END                                   +
+          |       | $$
+ t        |     1 | DO $$                                 +
           |       | BEGIN                                 +
-          |       |   -- this is a SELECT                 +
-          |       |   PERFORM 'hello world'::TEXT;        +
-          |       | END; $$
- f        |     1 | SELECT $1::TEXT
+          |       |     DELETE FROM stats_track_tab;      +
+          |       | END                                   +
+          |       | $$
+ f        |     1 | SELECT $1::text
  t        |     1 | SELECT pg_stat_monitor_reset()
  t        |     1 | SET pg_stat_monitor.pgsm_track = 'all'
 (7 rows)
 
 -- DO block - top-level tracking without utility.
 SET pg_stat_monitor.pgsm_track = 'top';
-SET pg_stat_monitor.pgsm_track_utility = FALSE;
+SET pg_stat_monitor.pgsm_track_utility = off;
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------
@@ -81,15 +85,17 @@ SELECT pg_stat_monitor_reset();
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END; $$;
-DO LANGUAGE plpgsql $$
+    DELETE FROM stats_track_tab;
+END
+$$;
+DO $$
 BEGIN
-  -- this is a SELECT
-  PERFORM 'hello world'::TEXT;
-END; $$;
+    -- this is a SELECT
+    PERFORM 'hello world'::text;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  ORDER BY query COLLATE "C", toplevel;
+    ORDER BY query COLLATE "C", toplevel;
  toplevel | calls |             query              
 ----------+-------+--------------------------------
  t        |     1 | DELETE FROM stats_track_tab
@@ -107,61 +113,64 @@ SELECT pg_stat_monitor_reset();
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END; $$;
-DO LANGUAGE plpgsql $$
+    DELETE FROM stats_track_tab;
+END
+$$;
+DO $$
 BEGIN
-  -- this is a SELECT
-  PERFORM 'hello world'::TEXT;
-END; $$;
+    -- this is a SELECT
+    PERFORM 'hello world'::text;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  ORDER BY query COLLATE "C", toplevel;
+    ORDER BY query COLLATE "C", toplevel;
  toplevel | calls |             query              
 ----------+-------+--------------------------------
  f        |     1 | DELETE FROM stats_track_tab
  t        |     1 | DELETE FROM stats_track_tab
- f        |     1 | SELECT $1::TEXT
+ f        |     1 | SELECT $1::text
  t        |     1 | SELECT pg_stat_monitor_reset()
 (4 rows)
 
 -- PL/pgSQL function - top-level tracking.
 SET pg_stat_monitor.pgsm_track = 'top';
-SET pg_stat_monitor.pgsm_track_utility = FALSE;
+SET pg_stat_monitor.pgsm_track_utility = off;
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------
  
 (1 row)
 
-CREATE FUNCTION PLUS_TWO(i INTEGER) RETURNS INTEGER AS $$
+CREATE FUNCTION plus_two(i int) RETURNS int AS $$
 DECLARE
-  r INTEGER;
+    r int;
 BEGIN
-  SELECT (i + 1 + 1.0)::INTEGER INTO r;
-  RETURN r;
-END; $$ LANGUAGE plpgsql;
-SELECT PLUS_TWO(3);
+    SELECT (i + 1 + 1.0)::int INTO r;
+    RETURN r;
+END
+$$ LANGUAGE plpgsql;
+SELECT plus_two(3);
  plus_two 
 ----------
         5
 (1 row)
 
-SELECT PLUS_TWO(7);
+SELECT plus_two(7);
  plus_two 
 ----------
         9
 (1 row)
 
 -- SQL function --- use LIMIT to keep it from being inlined
-CREATE FUNCTION PLUS_ONE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT (i + 1.0)::INTEGER LIMIT 1 $$ LANGUAGE SQL;
-SELECT PLUS_ONE(8);
+CREATE FUNCTION plus_one(i int) RETURNS int AS
+$$ SELECT (i + 1.0)::int LIMIT 1 $$ LANGUAGE sql;
+SELECT plus_one(8);
  plus_one 
 ----------
         9
 (1 row)
 
-SELECT PLUS_ONE(10);
+SELECT plus_one(10);
  plus_one 
 ----------
        11
@@ -170,21 +179,21 @@ SELECT PLUS_ONE(10);
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
  calls | rows |             query              
 -------+------+--------------------------------
-     2 |    2 | SELECT PLUS_ONE($1)
-     2 |    2 | SELECT PLUS_TWO($1)
      1 |    1 | SELECT pg_stat_monitor_reset()
+     2 |    2 | SELECT plus_one($1)
+     2 |    2 | SELECT plus_two($1)
 (3 rows)
 
 -- immutable SQL function --- can be executed at plan time
-CREATE FUNCTION PLUS_THREE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE SQL;
-SELECT PLUS_THREE(8);
+CREATE FUNCTION plus_three(i int) RETURNS int AS
+$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE sql;
+SELECT plus_three(8);
  plus_three 
 ------------
          11
 (1 row)
 
-SELECT PLUS_THREE(10);
+SELECT plus_three(10);
  plus_three 
 ------------
          13
@@ -193,11 +202,11 @@ SELECT PLUS_THREE(10);
 SELECT toplevel, calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
  toplevel | calls | rows |                                   query                                   
 ----------+-------+------+---------------------------------------------------------------------------
- t        |     2 |    2 | SELECT PLUS_ONE($1)
- t        |     2 |    2 | SELECT PLUS_THREE($1)
- t        |     2 |    2 | SELECT PLUS_TWO($1)
  t        |     1 |    3 | SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C"
  t        |     1 |    1 | SELECT pg_stat_monitor_reset()
+ t        |     2 |    2 | SELECT plus_one($1)
+ t        |     2 |    2 | SELECT plus_three($1)
+ t        |     2 |    2 | SELECT plus_two($1)
 (5 rows)
 
 -- PL/pgSQL function - all-level tracking.
@@ -209,64 +218,65 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 -- we drop and recreate the functions to avoid any caching funnies
-DROP FUNCTION PLUS_ONE(INTEGER);
-DROP FUNCTION PLUS_TWO(INTEGER);
-DROP FUNCTION PLUS_THREE(INTEGER);
+DROP FUNCTION plus_one(int);
+DROP FUNCTION plus_two(int);
+DROP FUNCTION plus_three(int);
 -- PL/pgSQL function
-CREATE FUNCTION PLUS_TWO(i INTEGER) RETURNS INTEGER AS $$
+CREATE FUNCTION plus_two(i int) RETURNS int AS $$
 DECLARE
-  r INTEGER;
+    r int;
 BEGIN
-  SELECT (i + 1 + 1.0)::INTEGER INTO r;
-  RETURN r;
-END; $$ LANGUAGE plpgsql;
-SELECT PLUS_TWO(-1);
+    SELECT (i + 1 + 1.0)::int INTO r;
+    RETURN r;
+END
+$$ LANGUAGE plpgsql;
+SELECT plus_two(-1);
  plus_two 
 ----------
         1
 (1 row)
 
-SELECT PLUS_TWO(2);
+SELECT plus_two(2);
  plus_two 
 ----------
         4
 (1 row)
 
 -- SQL function --- use LIMIT to keep it from being inlined
-CREATE FUNCTION PLUS_ONE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT (i + 1.0)::INTEGER LIMIT 1 $$ LANGUAGE SQL;
-SELECT PLUS_ONE(3);
+CREATE FUNCTION plus_one(i int) RETURNS int AS
+$$ SELECT (i + 1.0)::int LIMIT 1 $$ LANGUAGE sql;
+SELECT plus_one(3);
  plus_one 
 ----------
         4
 (1 row)
 
-SELECT PLUS_ONE(1);
+SELECT plus_one(1);
  plus_one 
 ----------
         2
 (1 row)
 
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |               query               
--------+------+-----------------------------------
-     2 |    2 | SELECT (i + $2 + $3)::INTEGER
-     2 |    2 | SELECT (i + $2)::INTEGER LIMIT $3
-     2 |    2 | SELECT PLUS_ONE($1)
-     2 |    2 | SELECT PLUS_TWO($1)
+ calls | rows |             query              
+-------+------+--------------------------------
+     2 |    2 | SELECT (i + $2 + $3)::int
+     2 |    2 | SELECT (i + $2)::int LIMIT $3
      1 |    1 | SELECT pg_stat_monitor_reset()
+     2 |    2 | SELECT plus_one($1)
+     2 |    2 | SELECT plus_two($1)
 (5 rows)
 
 -- immutable SQL function --- can be executed at plan time
-CREATE FUNCTION PLUS_THREE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE SQL;
-SELECT PLUS_THREE(8);
+CREATE FUNCTION plus_three(i int) RETURNS int AS
+$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE sql;
+SELECT plus_three(8);
  plus_three 
 ------------
          11
 (1 row)
 
-SELECT PLUS_THREE(10);
+SELECT plus_three(10);
  plus_three 
 ------------
          13
@@ -275,14 +285,14 @@ SELECT PLUS_THREE(10);
 SELECT toplevel, calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
  toplevel | calls | rows |                                   query                                   
 ----------+-------+------+---------------------------------------------------------------------------
- f        |     2 |    2 | SELECT (i + $2 + $3)::INTEGER
- f        |     2 |    2 | SELECT (i + $2)::INTEGER LIMIT $3
- t        |     2 |    2 | SELECT PLUS_ONE($1)
- t        |     2 |    2 | SELECT PLUS_THREE($1)
- t        |     2 |    2 | SELECT PLUS_TWO($1)
+ f        |     2 |    2 | SELECT (i + $2 + $3)::int
+ f        |     2 |    2 | SELECT (i + $2)::int LIMIT $3
  t        |     1 |    5 | SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C"
  f        |     2 |    2 | SELECT i + $2 LIMIT $3
  t        |     1 |    1 | SELECT pg_stat_monitor_reset()
+ t        |     2 |    2 | SELECT plus_one($1)
+ t        |     2 |    2 | SELECT plus_three($1)
+ t        |     2 |    2 | SELECT plus_two($1)
 (8 rows)
 
 --
@@ -295,13 +305,13 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-SELECT 1 AS "one";
+SELECT 1 AS one;
  one 
 -----
    1
 (1 row)
 
-SELECT 1 + 1 AS "two";
+SELECT 1 + 1 AS two;
  two 
 -----
    2

--- a/regression/expected/parallel.out
+++ b/regression/expected/parallel.out
@@ -1,6 +1,6 @@
 --
 -- Tests for parallel statistics
 --
-SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+SELECT setting::int < 180000 AS skip_test FROM pg_settings where name = 'server_version_num' \gset
 \if :skip_test
 \quit

--- a/regression/expected/parallel_1.out
+++ b/regression/expected/parallel_1.out
@@ -1,12 +1,12 @@
 --
 -- Tests for parallel statistics
 --
-SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+SELECT setting::int < 180000 AS skip_test FROM pg_settings where name = 'server_version_num' \gset
 \if :skip_test
 \quit
 \endif
 CREATE EXTENSION pg_stat_monitor;
-SET pgsm.track_utility = FALSE;
+SET pgsm.track_utility = off;
 -- encourage use of parallel plans
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;
@@ -25,12 +25,13 @@ SELECT count(*) FROM pgsm_parallel_tab;
      0
 (1 row)
 
-SELECT query,
-  parallel_workers_to_launch > 0 AS has_workers_to_launch,
-  parallel_workers_launched > 0 AS has_workers_launched
-  FROM pg_stat_monitor
-  WHERE query ~ 'SELECT count'
-  ORDER BY query COLLATE "C";
+SELECT
+    query,
+    parallel_workers_to_launch > 0 AS has_workers_to_launch,
+    parallel_workers_launched > 0 AS has_workers_launched
+FROM pg_stat_monitor
+WHERE query ~ 'SELECT count'
+ORDER BY query COLLATE "C";
                  query                  | has_workers_to_launch | has_workers_launched 
 ----------------------------------------+-----------------------+----------------------
  SELECT count(*) FROM pgsm_parallel_tab | t                     | t

--- a/regression/expected/pgsm_query_id.out
+++ b/regression/expected/pgsm_query_id.out
@@ -4,17 +4,17 @@ CREATE DATABASE db2;
 \c db1
 CREATE TABLE t1 (a int);
 CREATE TABLE t2 (b int);
-CREATE FUNCTION add(integer, integer) RETURNS integer
-    AS 'select $1 + $2;'
-    LANGUAGE SQL
+CREATE FUNCTION add(int, int) RETURNS int
+    AS 'SELECT $1 + $2;'
+    LANGUAGE sql
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
 \c db2
 CREATE TABLE t1 (a int);
 CREATE TABLE t3 (c int);
-CREATE FUNCTION add(integer, integer) RETURNS integer
-    AS 'select $1 + $2;'
-    LANGUAGE SQL
+CREATE FUNCTION add(int, int) RETURNS int
+    AS 'SELECT $1 + $2;'
+    LANGUAGE sql
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
 \c contrib_regression
@@ -30,7 +30,7 @@ SELECT * FROM t1;
 ---
 (0 rows)
 
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, add(1, 2) FROM t1;
  a | add 
 ---+-----
 (0 rows)
@@ -62,7 +62,7 @@ SELECT * FROM t1;
 ---
 (0 rows)
 
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, add(1, 2) FROM t1;
  a | add 
 ---+-----
 (0 rows)
@@ -74,7 +74,7 @@ SELECT * FROM t3;
 (0 rows)
 
 set pg_stat_monitor.pgsm_enable_pgsm_query_id = on;
-SELECT * FROM t3 where c = 20;
+SELECT * FROM t3 WHERE c = 20;
  c 
 ---
 (0 rows)
@@ -84,15 +84,15 @@ SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_q
       datname       |    pgsm_query_id    |                        query                        | calls 
 --------------------+---------------------+-----------------------------------------------------+-------
  contrib_regression |  689150021118383254 | SELECT pg_stat_monitor_reset()                      |     1
+ db2                | 1648576050146230147 | SELECT * FROM t3 WHERE c = 20                       |     1
  db1                | 1897482803466821995 | SELECT * FROM t2                                    |     3
  db1                | 1988437669671417938 | SELECT * FROM t1                                    |     1
  db2                | 1988437669671417938 | SELECT * FROM t1                                    |     1
- db1                | 2864453209316739369 | select $1 + $2                                      |     1
- db2                | 2864453209316739369 | select $1 + $2                                      |     1
+ db1                | 5193804135051352284 | SELECT $1 + $2                                      |     1
+ db2                | 5193804135051352284 | SELECT $1 + $2                                      |     1
  db2                | 6220142855706866455 | set pg_stat_monitor.pgsm_enable_pgsm_query_id = on  |     1
- db2                | 6633979598391393345 | SELECT * FROM t3 where c = 20                       |     1
- db1                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
- db2                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
+ db1                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
+ db2                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
  db2                |                     | SELECT * FROM t3                                    |     1
  db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     1
 (12 rows)
@@ -106,11 +106,11 @@ SELECT pg_stat_monitor_reset();
 \c db1
 DROP TABLE t1;
 DROP TABLE t2;
-DROP FUNCTION ADD;
+DROP FUNCTION add;
 \c db2
 DROP TABLE t1;
 DROP TABLE t3;
-DROP FUNCTION ADD;
+DROP FUNCTION add;
 \c contrib_regression
 DROP DATABASE db1;
 DROP DATABASE db2;

--- a/regression/expected/pgsm_query_id_1.out
+++ b/regression/expected/pgsm_query_id_1.out
@@ -4,17 +4,17 @@ CREATE DATABASE db2;
 \c db1
 CREATE TABLE t1 (a int);
 CREATE TABLE t2 (b int);
-CREATE FUNCTION add(integer, integer) RETURNS integer
-    AS 'select $1 + $2;'
-    LANGUAGE SQL
+CREATE FUNCTION add(int, int) RETURNS int
+    AS 'SELECT $1 + $2;'
+    LANGUAGE sql
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
 \c db2
 CREATE TABLE t1 (a int);
 CREATE TABLE t3 (c int);
-CREATE FUNCTION add(integer, integer) RETURNS integer
-    AS 'select $1 + $2;'
-    LANGUAGE SQL
+CREATE FUNCTION add(int, int) RETURNS int
+    AS 'SELECT $1 + $2;'
+    LANGUAGE sql
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
 \c contrib_regression
@@ -30,7 +30,7 @@ SELECT * FROM t1;
 ---
 (0 rows)
 
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, add(1, 2) FROM t1;
  a | add 
 ---+-----
 (0 rows)
@@ -62,7 +62,7 @@ SELECT * FROM t1;
 ---
 (0 rows)
 
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, add(1, 2) FROM t1;
  a | add 
 ---+-----
 (0 rows)
@@ -74,7 +74,7 @@ SELECT * FROM t3;
 (0 rows)
 
 set pg_stat_monitor.pgsm_enable_pgsm_query_id = on;
-SELECT * FROM t3 where c = 20;
+SELECT * FROM t3 WHERE c = 20;
  c 
 ---
 (0 rows)
@@ -84,13 +84,13 @@ SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_q
       datname       |    pgsm_query_id    |                        query                        | calls 
 --------------------+---------------------+-----------------------------------------------------+-------
  contrib_regression |  689150021118383254 | SELECT pg_stat_monitor_reset()                      |     1
+ db2                | 1648576050146230147 | SELECT * FROM t3 WHERE c = 20                       |     1
  db1                | 1897482803466821995 | SELECT * FROM t2                                    |     3
  db1                | 1988437669671417938 | SELECT * FROM t1                                    |     1
  db2                | 1988437669671417938 | SELECT * FROM t1                                    |     1
  db2                | 6220142855706866455 | set pg_stat_monitor.pgsm_enable_pgsm_query_id = on  |     1
- db2                | 6633979598391393345 | SELECT * FROM t3 where c = 20                       |     1
- db1                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
- db2                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
+ db1                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
+ db2                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
  db2                |                     | SELECT * FROM t3                                    |     1
  db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     1
 (10 rows)
@@ -104,11 +104,11 @@ SELECT pg_stat_monitor_reset();
 \c db1
 DROP TABLE t1;
 DROP TABLE t2;
-DROP FUNCTION ADD;
+DROP FUNCTION add;
 \c db2
 DROP TABLE t1;
 DROP TABLE t3;
-DROP FUNCTION ADD;
+DROP FUNCTION add;
 \c contrib_regression
 DROP DATABASE db1;
 DROP DATABASE db2;

--- a/regression/expected/pgsm_query_id_2.out
+++ b/regression/expected/pgsm_query_id_2.out
@@ -4,17 +4,17 @@ CREATE DATABASE db2;
 \c db1
 CREATE TABLE t1 (a int);
 CREATE TABLE t2 (b int);
-CREATE FUNCTION add(integer, integer) RETURNS integer
-    AS 'select $1 + $2;'
-    LANGUAGE SQL
+CREATE FUNCTION add(int, int) RETURNS int
+    AS 'SELECT $1 + $2;'
+    LANGUAGE sql
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
 \c db2
 CREATE TABLE t1 (a int);
 CREATE TABLE t3 (c int);
-CREATE FUNCTION add(integer, integer) RETURNS integer
-    AS 'select $1 + $2;'
-    LANGUAGE SQL
+CREATE FUNCTION add(int, int) RETURNS int
+    AS 'SELECT $1 + $2;'
+    LANGUAGE sql
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
 \c contrib_regression
@@ -30,7 +30,7 @@ SELECT * FROM t1;
 ---
 (0 rows)
 
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, add(1, 2) FROM t1;
  a | add 
 ---+-----
 (0 rows)
@@ -62,7 +62,7 @@ SELECT * FROM t1;
 ---
 (0 rows)
 
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, add(1, 2) FROM t1;
  a | add 
 ---+-----
 (0 rows)
@@ -74,7 +74,7 @@ SELECT * FROM t3;
 (0 rows)
 
 set pg_stat_monitor.pgsm_enable_pgsm_query_id = on;
-SELECT * FROM t3 where c = 20;
+SELECT * FROM t3 WHERE c = 20;
  c 
 ---
 (0 rows)
@@ -84,12 +84,12 @@ SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_q
       datname       |    pgsm_query_id    |                        query                        | calls 
 --------------------+---------------------+-----------------------------------------------------+-------
  contrib_regression |  689150021118383254 | SELECT pg_stat_monitor_reset()                      |     1
+ db2                | 1648576050146230147 | SELECT * FROM t3 WHERE c = 20                       |     1
  db1                | 1897482803466821995 | SELECT * FROM t2                                    |     3
  db1                | 1988437669671417938 | SELECT * FROM t1                                    |     1
  db2                | 1988437669671417938 | SELECT * FROM t1                                    |     1
- db2                | 6633979598391393345 | SELECT * FROM t3 where c = 20                       |     1
- db1                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
- db2                | 8140395000078788481 | SELECT *, ADD(1, 2) FROM t1                         |     1
+ db1                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
+ db2                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
  db2                |                     | SELECT * FROM t3                                    |     1
  db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     2
 (9 rows)
@@ -103,11 +103,11 @@ SELECT pg_stat_monitor_reset();
 \c db1
 DROP TABLE t1;
 DROP TABLE t2;
-DROP FUNCTION ADD;
+DROP FUNCTION add;
 \c db2
 DROP TABLE t1;
 DROP TABLE t3;
-DROP FUNCTION ADD;
+DROP FUNCTION add;
 \c contrib_regression
 DROP DATABASE db1;
 DROP DATABASE db2;

--- a/regression/expected/relations.out
+++ b/regression/expected/relations.out
@@ -5,10 +5,10 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-CREATE TABLE foo1(a int);
-CREATE TABLE foo2(b int);
-CREATE TABLE foo3(c int);
-CREATE TABLE foo4(d int);
+CREATE TABLE foo1 (a int);
+CREATE TABLE foo2 (b int);
+CREATE TABLE foo3 (c int);
+CREATE TABLE foo4 (d int);
 -- test the simple table names
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
@@ -36,7 +36,7 @@ SELECT * FROM foo1, foo2, foo3, foo4;
 ---+---+---+---
 (0 rows)
 
-SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+SELECT query, relations FROM pg_stat_monitor ORDER BY query COLLATE "C";
                 query                 |                     relations                     
 --------------------------------------+---------------------------------------------------
  SELECT * FROM foo1                   | {public.foo1}
@@ -57,10 +57,10 @@ CREATE SCHEMA sch1;
 CREATE SCHEMA sch2;
 CREATE SCHEMA sch3;
 CREATE SCHEMA sch4;
-CREATE TABLE sch1.foo1(a int);
-CREATE TABLE sch2.foo2(b int);
-CREATE TABLE sch3.foo3(c int);
-CREATE TABLE sch4.foo4(d int);
+CREATE TABLE sch1.foo1 (a int);
+CREATE TABLE sch2.foo2 (b int);
+CREATE TABLE sch3.foo3 (c int);
+CREATE TABLE sch4.foo4 (d int);
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------
@@ -87,7 +87,7 @@ SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3, sch4.foo4;
 ---+---+---+---
 (0 rows)
 
-SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+SELECT query, relations FROM pg_stat_monitor ORDER BY query COLLATE "C";
                           query                           |                 relations                 
 ----------------------------------------------------------+-------------------------------------------
  SELECT * FROM sch1.foo1                                  | {sch1.foo1}
@@ -119,7 +119,7 @@ SELECT * FROM sch1.foo1, sch2.foo2, foo1, foo2;
 ---+---+---+---
 (0 rows)
 
-SELECT query, relations from pg_stat_monitor ORDER BY query;
+SELECT query, relations FROM pg_stat_monitor ORDER BY query;
                      query                      |                   relations                   
 ------------------------------------------------+-----------------------------------------------
  SELECT * FROM sch1.foo1, foo1                  | {sch1.foo1,public.foo1}
@@ -134,10 +134,10 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 -- test the view
-CREATE VIEW v1 AS SELECT * from foo1;
-CREATE VIEW v2 AS SELECT * from foo1,foo2;
-CREATE VIEW v3 AS SELECT * from foo1,foo2,foo3;
-CREATE VIEW v4 AS SELECT * from foo1,foo2,foo3,foo4;
+CREATE VIEW v1 AS SELECT * FROM foo1;
+CREATE VIEW v2 AS SELECT * FROM foo1, foo2;
+CREATE VIEW v3 AS SELECT * FROM foo1, foo2, foo3;
+CREATE VIEW v4 AS SELECT * FROM foo1, foo2, foo3, foo4;
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------
@@ -149,28 +149,28 @@ SELECT * FROM v1;
 ---
 (0 rows)
 
-SELECT * FROM v1,v2;
+SELECT * FROM v1, v2;
  a | a | b 
 ---+---+---
 (0 rows)
 
-SELECT * FROM v1,v2,v3;
+SELECT * FROM v1, v2, v3;
  a | a | b | a | b | c 
 ---+---+---+---+---+---
 (0 rows)
 
-SELECT * FROM v1,v2,v3,v4;
+SELECT * FROM v1, v2, v3, v4;
  a | a | b | a | b | c | a | b | c | d 
 ---+---+---+---+---+---+---+---+---+---
 (0 rows)
 
-SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+SELECT query, relations FROM pg_stat_monitor ORDER BY query COLLATE "C";
              query              |                                           relations                                           
 --------------------------------+-----------------------------------------------------------------------------------------------
  SELECT * FROM v1               | {public.v1*,public.foo1}
- SELECT * FROM v1,v2            | {public.v1*,public.foo1,public.v2*,public.foo2}
- SELECT * FROM v1,v2,v3         | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3}
- SELECT * FROM v1,v2,v3,v4      | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3,public.v4*,public.foo4}
+ SELECT * FROM v1, v2           | {public.v1*,public.foo1,public.v2*,public.foo2}
+ SELECT * FROM v1, v2, v3       | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3}
+ SELECT * FROM v1, v2, v3, v4   | {public.v1*,public.foo1,public.v2*,public.foo2,public.v3*,public.foo3,public.v4*,public.foo4}
  SELECT pg_stat_monitor_reset() | 
 (5 rows)
 

--- a/regression/expected/relations_1.out
+++ b/regression/expected/relations_1.out
@@ -5,10 +5,10 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-CREATE TABLE foo1(a int);
-CREATE TABLE foo2(b int);
-CREATE TABLE foo3(c int);
-CREATE TABLE foo4(d int);
+CREATE TABLE foo1 (a int);
+CREATE TABLE foo2 (b int);
+CREATE TABLE foo3 (c int);
+CREATE TABLE foo4 (d int);
 -- test the simple table names
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
@@ -36,7 +36,7 @@ SELECT * FROM foo1, foo2, foo3, foo4;
 ---+---+---+---
 (0 rows)
 
-SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+SELECT query, relations FROM pg_stat_monitor ORDER BY query COLLATE "C";
                 query                 |                     relations                     
 --------------------------------------+---------------------------------------------------
  SELECT * FROM foo1                   | {public.foo1}
@@ -57,10 +57,10 @@ CREATE SCHEMA sch1;
 CREATE SCHEMA sch2;
 CREATE SCHEMA sch3;
 CREATE SCHEMA sch4;
-CREATE TABLE sch1.foo1(a int);
-CREATE TABLE sch2.foo2(b int);
-CREATE TABLE sch3.foo3(c int);
-CREATE TABLE sch4.foo4(d int);
+CREATE TABLE sch1.foo1 (a int);
+CREATE TABLE sch2.foo2 (b int);
+CREATE TABLE sch3.foo3 (c int);
+CREATE TABLE sch4.foo4 (d int);
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------
@@ -87,7 +87,7 @@ SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3, sch4.foo4;
 ---+---+---+---
 (0 rows)
 
-SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+SELECT query, relations FROM pg_stat_monitor ORDER BY query COLLATE "C";
                           query                           |                 relations                 
 ----------------------------------------------------------+-------------------------------------------
  SELECT * FROM sch1.foo1                                  | {sch1.foo1}
@@ -119,7 +119,7 @@ SELECT * FROM sch1.foo1, sch2.foo2, foo1, foo2;
 ---+---+---+---
 (0 rows)
 
-SELECT query, relations from pg_stat_monitor ORDER BY query;
+SELECT query, relations FROM pg_stat_monitor ORDER BY query;
                      query                      |                   relations                   
 ------------------------------------------------+-----------------------------------------------
  SELECT * FROM sch1.foo1, foo1                  | {sch1.foo1,public.foo1}
@@ -134,10 +134,10 @@ SELECT pg_stat_monitor_reset();
 (1 row)
 
 -- test the view
-CREATE VIEW v1 AS SELECT * from foo1;
-CREATE VIEW v2 AS SELECT * from foo1,foo2;
-CREATE VIEW v3 AS SELECT * from foo1,foo2,foo3;
-CREATE VIEW v4 AS SELECT * from foo1,foo2,foo3,foo4;
+CREATE VIEW v1 AS SELECT * FROM foo1;
+CREATE VIEW v2 AS SELECT * FROM foo1, foo2;
+CREATE VIEW v3 AS SELECT * FROM foo1, foo2, foo3;
+CREATE VIEW v4 AS SELECT * FROM foo1, foo2, foo3, foo4;
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------
@@ -149,28 +149,28 @@ SELECT * FROM v1;
 ---
 (0 rows)
 
-SELECT * FROM v1,v2;
+SELECT * FROM v1, v2;
  a | a | b 
 ---+---+---
 (0 rows)
 
-SELECT * FROM v1,v2,v3;
+SELECT * FROM v1, v2, v3;
  a | a | b | a | b | c 
 ---+---+---+---+---+---
 (0 rows)
 
-SELECT * FROM v1,v2,v3,v4;
+SELECT * FROM v1, v2, v3, v4;
  a | a | b | a | b | c | a | b | c | d 
 ---+---+---+---+---+---+---+---+---+---
 (0 rows)
 
-SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+SELECT query, relations FROM pg_stat_monitor ORDER BY query COLLATE "C";
              query              |                                           relations                                           
 --------------------------------+-----------------------------------------------------------------------------------------------
  SELECT * FROM v1               | {public.v1*,public.foo1}
- SELECT * FROM v1,v2            | {public.v1*,public.v2*,public.foo1,public.foo2}
- SELECT * FROM v1,v2,v3         | {public.v1*,public.v2*,public.v3*,public.foo1,public.foo2,public.foo3}
- SELECT * FROM v1,v2,v3,v4      | {public.v1*,public.v2*,public.v3*,public.v4*,public.foo1,public.foo2,public.foo3,public.foo4}
+ SELECT * FROM v1, v2           | {public.v1*,public.v2*,public.foo1,public.foo2}
+ SELECT * FROM v1, v2, v3       | {public.v1*,public.v2*,public.v3*,public.foo1,public.foo2,public.foo3}
+ SELECT * FROM v1, v2, v3, v4   | {public.v1*,public.v2*,public.v3*,public.v4*,public.foo1,public.foo2,public.foo3,public.foo4}
  SELECT pg_stat_monitor_reset() | 
 (5 rows)
 

--- a/regression/expected/rollback.out
+++ b/regression/expected/rollback.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION pg_stat_monitor;
 CREATE USER u WITH SUPERUSER;
 SET ROLE u;
-CREATE TABLE t (a int PRIMARY KEY) ;
+CREATE TABLE t (a int PRIMARY KEY);
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------

--- a/regression/expected/rows.out
+++ b/regression/expected/rows.out
@@ -1,8 +1,8 @@
 CREATE EXTENSION pg_stat_monitor;
-CREATE TABLE t1(a int);
-CREATE TABLE t2(b int);
-INSERT INTO t1 VALUES(generate_series(1,1000));
-INSERT INTO t2 VALUES(generate_series(1,5000));
+CREATE TABLE t1 (a int);
+CREATE TABLE t2 (b int);
+INSERT INTO t1 VALUES (generate_series(1, 1000));
+INSERT INTO t2 VALUES (generate_series(1, 5000));
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------

--- a/regression/expected/squashing.out
+++ b/regression/expected/squashing.out
@@ -1,6 +1,6 @@
 --
 -- Const squashing functionality
 --
-SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+SELECT setting::int < 180000 AS skip_test FROM pg_settings where name = 'server_version_num' \gset
 \if :skip_test
 \quit

--- a/regression/expected/squashing_1.out
+++ b/regression/expected/squashing_1.out
@@ -1,12 +1,12 @@
 --
 -- Const squashing functionality
 --
-SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+SELECT setting::int < 180000 AS skip_test FROM pg_settings where name = 'server_version_num' \gset
 \if :skip_test
 \quit
 \endif
 CREATE EXTENSION pg_stat_monitor;
-SET pg_stat_monitor.pgsm_normalized_query = TRUE;
+SET pg_stat_monitor.pgsm_normalized_query = on;
 --
 -- Simple Lists
 --
@@ -97,7 +97,7 @@ SELECT WHERE 1 IN (1, int4(1), int4(2), 2);
 --
 (1 row)
 
-SELECT WHERE 1 = ANY (ARRAY[1, int4(1), int4(2), 2]);
+SELECT WHERE 1 = ANY(ARRAY[1, int4(1), int4(2), 2]);
 --
 (1 row)
 
@@ -150,17 +150,17 @@ SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11) AND da
 ----+------
 (0 rows)
 
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]) AND data = 2;
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]) AND data = 2;
  id | data 
 ----+------
 (0 rows)
 
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) AND data = 2;
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) AND data = 2;
  id | data 
 ----+------
 (0 rows)
 
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) AND data = 2;
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) AND data = 2;
  id | data 
 ----+------
 (0 rows)
@@ -197,20 +197,20 @@ SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
 ----+------
 (0 rows)
 
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9])
-    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9])
+    AND data = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]);
  id | data 
 ----+------
 (0 rows)
 
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    AND data = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
  id | data 
 ----+------
 (0 rows)
 
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
-    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+    AND data = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
  id | data 
 ----+------
 (0 rows)
@@ -238,37 +238,37 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 (1 row)
 
 SELECT * FROM test_squash WHERE id IN
-	(1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9);
+    (1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9);
  id | data 
 ----+------
 (0 rows)
 
 SELECT * FROM test_squash WHERE id IN
-	(@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9');
+    (@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9');
  id | data 
 ----+------
 (0 rows)
 
 SELECT * FROM test_squash WHERE id = ANY(ARRAY
-	[1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9]);
+    [1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9]);
  id | data 
 ----+------
 (0 rows)
 
 SELECT * FROM test_squash WHERE id = ANY(ARRAY
-	[@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9']);
+    [@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9']);
  id | data 
 ----+------
 (0 rows)
 
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                                               query                                                | calls 
-----------------------------------------------------------------------------------------------------+-------
- SELECT * FROM test_squash WHERE id IN                                                             +|     2
-         ($1 + $2, $3 + $4, $5 + $6, $7 + $8, $9 + $10, $11 + $12, $13 + $14, $15 + $16, $17 + $18) | 
- SELECT * FROM test_squash WHERE id IN                                                             +|     2
-         (@ $1, @ $2, @ $3, @ $4, @ $5, @ $6, @ $7, @ $8, @ $9)                                     | 
- SELECT pg_stat_monitor_reset() IS NOT NULL AS t                                                    |     1
+                                             query                                              | calls 
+------------------------------------------------------------------------------------------------+-------
+ SELECT * FROM test_squash WHERE id IN                                                         +|     2
+     ($1 + $2, $3 + $4, $5 + $6, $7 + $8, $9 + $10, $11 + $12, $13 + $14, $15 + $16, $17 + $18) | 
+ SELECT * FROM test_squash WHERE id IN                                                         +|     2
+     (@ $1, @ $2, @ $3, @ $4, @ $5, @ $6, @ $7, @ $8, @ $9)                                     | 
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t                                                |     1
 (3 rows)
 
 --
@@ -402,15 +402,15 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 (1 row)
 
 SELECT * FROM test_squash_bigint WHERE data IN
-	(1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
-	 7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint);
+    (1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
+     7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint);
  id | data 
 ----+------
 (0 rows)
 
 SELECT * FROM test_squash_bigint WHERE data = ANY(ARRAY[
-	 1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
-	 7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint]);
+    1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
+    7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint]);
  id | data 
 ----+------
 (0 rows)
@@ -419,7 +419,7 @@ SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
                       query                      | calls 
 -------------------------------------------------+-------
  SELECT * FROM test_squash_bigint WHERE data IN +|     2
-         ($1 /*, ... */)                         | 
+     ($1 /*, ... */)                             | 
  SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
 (2 rows)
 
@@ -431,26 +431,26 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 (1 row)
 
 SELECT * FROM test_squash_bigint WHERE id IN
-	(abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
-	 abs(800), abs(900), abs(1000), ((abs(1100))));
+    (abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
+     abs(800), abs(900), abs(1000), ((abs(1100))));
  id | data 
 ----+------
 (0 rows)
 
 SELECT * FROM test_squash_bigint WHERE id = ANY(ARRAY[
-	 abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
-	 abs(800), abs(900), abs(1000), ((abs(1100)))]);
+    abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
+    abs(800), abs(900), abs(1000), ((abs(1100)))]);
  id | data 
 ----+------
 (0 rows)
 
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                                  query                                  | calls 
--------------------------------------------------------------------------+-------
- SELECT * FROM test_squash_bigint WHERE id IN                           +|     2
-         (abs($1), abs($2), abs($3), abs($4), abs($5), abs($6), abs($7),+| 
-          abs($8), abs($9), abs($10), ((abs($11))))                      | 
- SELECT pg_stat_monitor_reset() IS NOT NULL AS t                         |     1
+                                query                                | calls 
+---------------------------------------------------------------------+-------
+ SELECT * FROM test_squash_bigint WHERE id IN                       +|     2
+     (abs($1), abs($2), abs($3), abs($4), abs($5), abs($6), abs($7),+| 
+      abs($8), abs($9), abs($10), ((abs($11))))                      | 
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t                     |     1
 (2 rows)
 
 -- Multiple FuncExpr's. Will not squash
@@ -481,33 +481,34 @@ SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 -- Create some dummy type to force CoerceViaIO
 CREATE TYPE casttesttype;
 CREATE FUNCTION casttesttype_in(cstring)
-   RETURNS casttesttype
-   AS 'textin'
-   LANGUAGE internal STRICT IMMUTABLE;
+    RETURNS casttesttype
+    AS 'textin'
+    LANGUAGE internal STRICT IMMUTABLE;
 NOTICE:  return type casttesttype is only a shell
 CREATE FUNCTION casttesttype_out(casttesttype)
-   RETURNS cstring
-   AS 'textout'
-   LANGUAGE internal STRICT IMMUTABLE;
+    RETURNS cstring
+    AS 'textout'
+    LANGUAGE internal STRICT IMMUTABLE;
 NOTICE:  argument type casttesttype is only a shell
 LINE 1: CREATE FUNCTION casttesttype_out(casttesttype)
                                          ^
 CREATE TYPE casttesttype (
-   internallength = variable,
-   input = casttesttype_in,
-   output = casttesttype_out,
-   alignment = int4
+    internallength = variable,
+    input = casttesttype_in,
+    output = casttesttype_out,
+    alignment = int4
 );
 CREATE CAST (int4 AS casttesttype) WITH INOUT;
 CREATE FUNCTION casttesttype_eq(casttesttype, casttesttype)
-returns boolean language sql immutable as $$
+RETURNS boolean LANGUAGE sql IMMUTABLE AS $$
     SELECT true
 $$;
 CREATE OPERATOR = (
     leftarg = casttesttype,
     rightarg = casttesttype,
     procedure = casttesttype_eq,
-    commutator = =);
+    commutator = =
+);
 CREATE TABLE test_squash_cast (id int, data casttesttype);
 -- Use the introduced type to construct a list of CoerceViaIO around Const
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
@@ -517,19 +518,19 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 (1 row)
 
 SELECT * FROM test_squash_cast WHERE data IN
-	(1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
-	 4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
-	 7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
-	 10::int4::casttesttype, 11::int4::casttesttype);
+    (1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
+     4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
+     7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
+     10::int4::casttesttype, 11::int4::casttesttype);
  id | data 
 ----+------
 (0 rows)
 
-SELECT * FROM test_squash_cast WHERE data = ANY (ARRAY
-	[1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
-	 4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
-	 7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
-	 10::int4::casttesttype, 11::int4::casttesttype]);
+SELECT * FROM test_squash_cast WHERE data = ANY(ARRAY
+    [1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
+     4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
+     7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
+     10::int4::casttesttype, 11::int4::casttesttype]);
  id | data 
 ----+------
 (0 rows)
@@ -538,7 +539,7 @@ SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
                       query                      | calls 
 -------------------------------------------------+-------
  SELECT * FROM test_squash_cast WHERE data IN   +|     2
-         ($1 /*, ... */)                         | 
+     ($1 /*, ... */)                             | 
  SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
 (2 rows)
 
@@ -551,17 +552,17 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 (1 row)
 
 SELECT * FROM test_squash_jsonb WHERE data IN
-	(('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
-	 ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
-	 ('"9"')::jsonb, ('"10"')::jsonb);
+    (('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
+     ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
+     ('"9"')::jsonb, ('"10"')::jsonb);
  id | data 
 ----+------
 (0 rows)
 
-SELECT * FROM test_squash_jsonb WHERE data = ANY (ARRAY
-	[('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
-	 ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
-	 ('"9"')::jsonb, ('"10"')::jsonb]);
+SELECT * FROM test_squash_jsonb WHERE data = ANY(ARRAY
+    [('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
+     ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
+     ('"9"')::jsonb, ('"10"')::jsonb]);
  id | data 
 ----+------
 (0 rows)
@@ -570,7 +571,7 @@ SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
                       query                      | calls 
 -------------------------------------------------+-------
  SELECT * FROM test_squash_jsonb WHERE data IN  +|     2
-         ($1 /*, ... */)                         | 
+     ($1 /*, ... */)                             | 
  SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
 (2 rows)
 
@@ -582,32 +583,32 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 (1 row)
 
 SELECT * FROM test_squash_jsonb WHERE data IN
-	((SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
-	 (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
-	 (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
-	 (SELECT '"10"')::jsonb);
+    ((SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
+     (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
+     (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
+     (SELECT '"10"')::jsonb);
  id | data 
 ----+------
 (0 rows)
 
 SELECT * FROM test_squash_jsonb WHERE data = ANY(ARRAY
-	[(SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
-	 (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
-	 (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
-	 (SELECT '"10"')::jsonb]);
+    [(SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
+     (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
+     (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
+     (SELECT '"10"')::jsonb]);
  id | data 
 ----+------
 (0 rows)
 
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                                query                                 | calls 
-----------------------------------------------------------------------+-------
- SELECT * FROM test_squash_jsonb WHERE data IN                       +|     2
-         ((SELECT $1)::jsonb, (SELECT $2)::jsonb, (SELECT $3)::jsonb,+| 
-          (SELECT $4)::jsonb, (SELECT $5)::jsonb, (SELECT $6)::jsonb,+| 
-          (SELECT $7)::jsonb, (SELECT $8)::jsonb, (SELECT $9)::jsonb,+| 
-          (SELECT $10)::jsonb)                                        | 
- SELECT pg_stat_monitor_reset() IS NOT NULL AS t                      |     1
+                              query                               | calls 
+------------------------------------------------------------------+-------
+ SELECT * FROM test_squash_jsonb WHERE data IN                   +|     2
+     ((SELECT $1)::jsonb, (SELECT $2)::jsonb, (SELECT $3)::jsonb,+| 
+      (SELECT $4)::jsonb, (SELECT $5)::jsonb, (SELECT $6)::jsonb,+| 
+      (SELECT $7)::jsonb, (SELECT $8)::jsonb, (SELECT $9)::jsonb,+| 
+      (SELECT $10)::jsonb)                                        | 
+ SELECT pg_stat_monitor_reset() IS NOT NULL AS t                  |     1
 (2 rows)
 
 -- Multiple CoerceViaIO are squashed
@@ -643,7 +644,7 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 
 -- However many layers of RelabelType there are, the list will be squashable.
 SELECT * FROM test_squash WHERE id IN
-	(1::oid, 2::oid, 3::oid, 4::oid, 5::oid, 6::oid, 7::oid, 8::oid, 9::oid);
+    (1::oid, 2::oid, 3::oid, 4::oid, 5::oid, 6::oid, 7::oid, 8::oid, 9::oid);
  id | data 
 ----+------
 (0 rows)
@@ -679,7 +680,7 @@ SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
                       query                      | calls 
 -------------------------------------------------+-------
  SELECT * FROM test_squash WHERE id IN          +|     5
-         ($1 /*, ... */)                         | 
+     ($1 /*, ... */)                             | 
  SELECT ARRAY[$1 /*, ... */]                     |     1
  SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
 (3 rows)
@@ -719,7 +720,7 @@ SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- Test constants evaluation in a CTE, which was causing issues in the past
 WITH cte AS (
-    SELECT 'const' as const FROM test_squash
+    SELECT 'const' AS const FROM test_squash
 )
 SELECT ARRAY['a', 'b', 'c', const::varchar] AS result
 FROM cte;
@@ -734,21 +735,21 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 (1 row)
 
 -- Rewritten as an OpExpr, so it will not be squashed
-select where '1' IN ('1'::int, '2'::int::text);
+SELECT WHERE '1' IN ('1'::int, '2'::int::text);
 --
 (1 row)
 
 -- Rewritten as an ArrayExpr, so it will be squashed
-select where '1' IN ('1'::int, '2'::int);
+SELECT WHERE '1' IN ('1'::int, '2'::int);
 --
 (1 row)
 
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
                       query                      | calls 
 -------------------------------------------------+-------
+ SELECT WHERE $1 IN ($2 /*, ... */)              |     1
+ SELECT WHERE $1 IN ($2::int, $3::int::text)     |     1
  SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
- select where $1 IN ($2 /*, ... */)              |     1
- select where $1 IN ($2::int, $3::int::text)     |     1
 (3 rows)
 
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
@@ -759,19 +760,19 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 
 -- Both of these queries will be rewritten as an ArrayExpr, so they
 -- will be squashed, and have a similar queryId
-select where '1' IN ('1'::int::text, '2'::int::text);
+SELECT WHERE '1' IN ('1'::int::text, '2'::int::text);
 --
 (1 row)
 
-select where '1' = ANY (array['1'::int::text, '2'::int::text]);
+SELECT WHERE '1' = ANY(array['1'::int::text, '2'::int::text]);
 --
 (1 row)
 
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
                       query                      | calls 
 -------------------------------------------------+-------
+ SELECT WHERE $1 IN ($2 /*, ... */)              |     2
  SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1
- select where $1 IN ($2 /*, ... */)              |     2
 (2 rows)
 
 --

--- a/regression/expected/top_query.out
+++ b/regression/expected/top_query.out
@@ -6,40 +6,42 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-CREATE OR REPLACE FUNCTION add(int, int) RETURNS INTEGER AS
+CREATE FUNCTION add(int, int) RETURNS int AS
 $$
 BEGIN
-	return (select $1 + $2);
-END; $$ language plpgsql;
-CREATE OR REPLACE FUNCTION add2(int, int) RETURNS INTEGER AS
+    RETURN (SELECT $1 + $2);
+END
+$$ LANGUAGE plpgsql;
+CREATE FUNCTION add2(int, int) RETURNS int AS
 $$
 BEGIN
-	return add($1,$2);
-END;
-$$ language plpgsql;
-SELECT add2(1,2);
+    RETURN add($1, $2);
+END
+$$ LANGUAGE plpgsql;
+SELECT add2(1, 2);
  add2 
 ------
     3
 (1 row)
 
 SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
-                            query                             |     top_query     
---------------------------------------------------------------+-------------------
- (select $1 + $2)                                             | SELECT add2(1,2);
- CREATE OR REPLACE FUNCTION add(int, int) RETURNS INTEGER AS +| 
- $$                                                          +| 
- BEGIN                                                       +| 
-         return (select $1 + $2);                            +| 
- END; $$ language plpgsql                                     | 
- CREATE OR REPLACE FUNCTION add2(int, int) RETURNS INTEGER AS+| 
- $$                                                          +| 
- BEGIN                                                       +| 
-         return add($1,$2);                                  +| 
- END;                                                        +| 
- $$ language plpgsql                                          | 
- SELECT add2(1,2)                                             | 
- SELECT pg_stat_monitor_reset()                               | 
+                     query                     |     top_query      
+-----------------------------------------------+--------------------
+ (SELECT $1 + $2)                              | SELECT add2(1, 2);
+ CREATE FUNCTION add(int, int) RETURNS int AS +| 
+ $$                                           +| 
+ BEGIN                                        +| 
+     RETURN (SELECT $1 + $2);                 +| 
+ END                                          +| 
+ $$ LANGUAGE plpgsql                           | 
+ CREATE FUNCTION add2(int, int) RETURNS int AS+| 
+ $$                                           +| 
+ BEGIN                                        +| 
+     RETURN add($1, $2);                      +| 
+ END                                          +| 
+ $$ LANGUAGE plpgsql                           | 
+ SELECT add2(1, 2)                             | 
+ SELECT pg_stat_monitor_reset()                | 
 (5 rows)
 
 -- make sure that we handle nested queries correctly
@@ -52,7 +54,7 @@ BEGIN
     FOR i IN 1..50000 LOOP
         EXECUTE format('SELECT %s', i);
     END LOOP;
-END;
+END
 $$;
 COMMIT;
 SELECT pg_stat_monitor_reset();

--- a/regression/sql/application_name.sql
+++ b/regression/sql/application_name.sql
@@ -2,13 +2,13 @@ CREATE EXTENSION pg_stat_monitor;
 SELECT pg_stat_monitor_reset();
 
 SELECT 1 AS num;
-SELECT query,application_name FROM pg_stat_monitor ORDER BY query COLLATE "C";
+SELECT query, application_name FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset();
 
 SELECT 1 AS num;
-SET pg_stat_monitor.pgsm_track_application_names='no';
+SET pg_stat_monitor.pgsm_track_application_names = off;
 SELECT 1 AS num;
-SELECT query,application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
+SELECT query, application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
 SELECT pg_stat_monitor_reset();
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/application_name_unique.sql
+++ b/regression/sql/application_name_unique.sql
@@ -1,9 +1,9 @@
 CREATE EXTENSION pg_stat_monitor;
 SELECT pg_stat_monitor_reset();
-SET application_name = 'naeem' ; 
+SET application_name = 'naeem';
 SELECT 1 AS num;
-SET application_name = 'psql' ; 
+SET application_name = 'psql';
 SELECT 1 AS num;
-SELECT query,application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
+SELECT query, application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
 SELECT pg_stat_monitor_reset();
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/cmd_type.sql
+++ b/regression/sql/cmd_type.sql
@@ -1,9 +1,9 @@
 CREATE EXTENSION pg_stat_monitor;
 
 SELECT pg_stat_monitor_reset();
-CREATE TABLE t1 (a INTEGER);
-CREATE TABLE t2 (b INTEGER);
-INSERT INTO t1 VALUES(1);
+CREATE TABLE t1 (a int);
+CREATE TABLE t2 (b int);
+INSERT INTO t1 VALUES (1);
 SELECT a FROM t1;
 UPDATE t1 SET a = 2;
 DELETE FROM t1;
@@ -11,7 +11,7 @@ SELECT b FROM t2 FOR UPDATE;
 TRUNCATE t1;
 DROP TABLE t1;
 DROP TABLE t2;
-SELECT query, cmd_type,  cmd_type_text FROM pg_stat_monitor ORDER BY query COLLATE "C";
+SELECT query, cmd_type, cmd_type_text FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset();
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/counters.sql
+++ b/regression/sql/counters.sql
@@ -2,30 +2,31 @@ CREATE EXTENSION pg_stat_monitor;
 Set pg_stat_monitor.pgsm_track = 'all';
 SELECT pg_stat_monitor_reset();
 
-CREATE TABLE t1 (a INTEGER);
-CREATE TABLE t2 (b INTEGER);
-CREATE TABLE t3 (c INTEGER);
-CREATE TABLE t4 (d INTEGER);
+CREATE TABLE t1 (a int);
+CREATE TABLE t2 (b int);
+CREATE TABLE t3 (c int);
+CREATE TABLE t4 (d int);
 
 SELECT pg_stat_monitor_reset();
-SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
-SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
-SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
-SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
+SELECT a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
+SELECT a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
+SELECT a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
+SELECT a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
 SELECT query, sum(calls) as calls FROM pg_stat_monitor GROUP BY query ORDER BY query COLLATE "C";
 
 SELECT pg_stat_monitor_reset();
 
-do $$
-declare
-   n integer:= 1;
-begin
-	loop
-		PERFORM a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
-		exit when n = 1000;
-		n := n + 1;
-	end loop;
-end $$;
+DO $$
+DECLARE
+    n int := 1;
+BEGIN
+    LOOP
+        PERFORM a, b, c, d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
+        EXIT WHEN n = 1000;
+        n := n + 1;
+    END LOOP;
+END
+$$;
 SELECT query, sum(calls) as calls FROM pg_stat_monitor GROUP BY query ORDER BY query COLLATE "C";
 
 DROP TABLE t1;

--- a/regression/sql/database.sql
+++ b/regression/sql/database.sql
@@ -14,10 +14,10 @@ CREATE TABLE t4 (d int);
 \c contrib_regression
 SELECT pg_stat_monitor_reset();
 \c db1
-SELECT * FROM t1,t2 WHERE t1.a = t2.b;
+SELECT * FROM t1, t2 WHERE t1.a = t2.b;
 
 \c db2
-SELECT * FROM t3,t4 WHERE t3.c = t4.d;
+SELECT * FROM t3, t4 WHERE t3.c = t4.d;
 
 \c contrib_regression
 DROP DATABASE db2;

--- a/regression/sql/decode_error_level.sql
+++ b/regression/sql/decode_error_level.sql
@@ -2,11 +2,12 @@ CREATE EXTENSION pg_stat_monitor;
 
 DO $$
 DECLARE
-    i integer;
+    i int;
 BEGIN
     FOR i IN 10..24 LOOP
-         RAISE NOTICE 'error_code: %, error_level: %', i, decode_error_level(i);
+        RAISE NOTICE 'error_code: %, error_level: %', i, decode_error_level(i);
     END LOOP;
-END $$;
+END
+$$;
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/different_parent_queries.sql
+++ b/regression/sql/different_parent_queries.sql
@@ -2,23 +2,23 @@ CREATE EXTENSION pg_stat_monitor;
 SET pg_stat_monitor.pgsm_track = 'all';
 SELECT pg_stat_monitor_reset();
 
-CREATE OR REPLACE FUNCTION test() RETURNS VOID AS
-$$
+CREATE OR REPLACE FUNCTION test() RETURNS void AS $$
 BEGIN
-	PERFORM 1 + 2;
-END; $$ language plpgsql;
+    PERFORM 1 + 2;
+END
+$$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION test2() RETURNS VOID AS
-$$
+CREATE OR REPLACE FUNCTION test2() RETURNS void AS $$
 BEGIN
-	PERFORM 1 + 2;
-END; $$ language plpgsql;
+    PERFORM 1 + 2;
+END
+$$ LANGUAGE plpgsql;
 
 SELECT pg_stat_monitor_reset(); 
 SELECT test(); 
 SELECT test2();  	
 
 SELECT 1 + 2;
-SELECT left(query, 15) as query, calls, top_query, pgsm_query_id FROM pg_stat_monitor ORDER BY query, top_query COLLATE "C";
+SELECT left(query, 15) AS query, calls, top_query, pgsm_query_id FROM pg_stat_monitor ORDER BY query, top_query COLLATE "C";
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/error.sql
+++ b/regression/sql/error.sql
@@ -1,14 +1,15 @@
 CREATE EXTENSION pg_stat_monitor;
 SELECT pg_stat_monitor_reset();
-SELECT 1/0;   -- divide by zero
+SELECT 1 / 0; -- divide by zero
 SELECT * FROM unknown; -- unknown table
 ELECET * FROM unknown; -- syntax error
 
-do $$
+DO $$
 BEGIN
-RAISE WARNING 'warning message';
-END $$;
+    RAISE WARNING 'warning message';
+END
+$$;
 
-SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C",elevel;
+SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C", elevel;
 SELECT pg_stat_monitor_reset();
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/error_insert.sql
+++ b/regression/sql/error_insert.sql
@@ -1,17 +1,15 @@
-DROP TABLE IF EXISTS Company;
-
-CREATE TABLE Company(
-   ID INT PRIMARY KEY     NOT NULL,
-   NAME TEXT    NOT NULL
+DROP TABLE IF EXISTS company;
+CREATE TABLE company (
+    id int PRIMARY KEY NOT NULL,
+    name text NOT NULL
 );
-
 
 CREATE EXTENSION pg_stat_monitor;
 SELECT pg_stat_monitor_reset();
-INSERT  INTO Company(ID, Name) VALUES (1, 'Percona'); 
-INSERT  INTO Company(ID, Name) VALUES (1, 'Percona'); 
+INSERT INTO company (id, name) VALUES (1, 'Percona');
+INSERT INTO company (id, name) VALUES (1, 'Percona');
 
-DROP TABLE IF EXISTS Company;
-SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C",elevel;
+DROP TABLE IF EXISTS company;
+SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C", elevel;
 SELECT pg_stat_monitor_reset();
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/guc.sql
+++ b/regression/sql/guc.sql
@@ -1,21 +1,21 @@
 CREATE EXTENSION pg_stat_monitor;
 
-SELECT  name
-        , setting
-        , unit
-        , context
-        , vartype
-        , source
-        , min_val
-        , max_val
-        , enumvals
-        , boot_val
-        , reset_val
-        , pending_restart 
-FROM    pg_settings
-WHERE   name     LIKE     'pg_stat_monitor.%'
-ORDER
-BY      name
+SELECT
+    name,
+    setting,
+    unit,
+    context,
+    vartype,
+    source,
+    min_val,
+    max_val,
+    enumvals,
+    boot_val,
+    reset_val,
+    pending_restart
+FROM pg_settings
+WHERE name LIKE 'pg_stat_monitor.%'
+ORDER BY name
 COLLATE "C";
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/level_tracking.sql
+++ b/regression/sql/level_tracking.sql
@@ -3,8 +3,8 @@
 --
 
 CREATE EXTENSION pg_stat_monitor;
-SET pg_stat_monitor.pgsm_track_utility = TRUE;
-SET pg_stat_monitor.pgsm_normalized_query = TRUE;
+SET pg_stat_monitor.pgsm_track_utility = on;
+SET pg_stat_monitor.pgsm_normalized_query = on;
 SELECT pg_stat_monitor_reset();
 
 -- DO block - top-level tracking.
@@ -13,11 +13,11 @@ SET pg_stat_monitor.pgsm_track = 'top';
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END;
-$$ LANGUAGE plpgsql;
+    DELETE FROM stats_track_tab;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  WHERE query LIKE '%DELETE%' ORDER BY query COLLATE "C", toplevel;
+    WHERE query LIKE '%DELETE%' ORDER BY query COLLATE "C", toplevel;
 SELECT pg_stat_monitor_reset();
 
 -- DO block - all-level tracking.
@@ -25,32 +25,36 @@ SET pg_stat_monitor.pgsm_track = 'all';
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END; $$;
-DO LANGUAGE plpgsql $$
+    DELETE FROM stats_track_tab;
+END
+$$;
+DO $$
 BEGIN
-  -- this is a SELECT
-  PERFORM 'hello world'::TEXT;
-END; $$;
+    -- this is a SELECT
+    PERFORM 'hello world'::text;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  ORDER BY query COLLATE "C", toplevel;
+    ORDER BY query COLLATE "C", toplevel;
 
 -- DO block - top-level tracking without utility.
 SET pg_stat_monitor.pgsm_track = 'top';
-SET pg_stat_monitor.pgsm_track_utility = FALSE;
+SET pg_stat_monitor.pgsm_track_utility = off;
 SELECT pg_stat_monitor_reset();
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END; $$;
-DO LANGUAGE plpgsql $$
+    DELETE FROM stats_track_tab;
+END
+$$;
+DO $$
 BEGIN
-  -- this is a SELECT
-  PERFORM 'hello world'::TEXT;
-END; $$;
+    -- this is a SELECT
+    PERFORM 'hello world'::text;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  ORDER BY query COLLATE "C", toplevel;
+    ORDER BY query COLLATE "C", toplevel;
 
 -- DO block - all-level tracking without utility.
 SET pg_stat_monitor.pgsm_track = 'all';
@@ -58,46 +62,49 @@ SELECT pg_stat_monitor_reset();
 DELETE FROM stats_track_tab;
 DO $$
 BEGIN
-  DELETE FROM stats_track_tab;
-END; $$;
-DO LANGUAGE plpgsql $$
+    DELETE FROM stats_track_tab;
+END
+$$;
+DO $$
 BEGIN
-  -- this is a SELECT
-  PERFORM 'hello world'::TEXT;
-END; $$;
+    -- this is a SELECT
+    PERFORM 'hello world'::text;
+END
+$$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
-  ORDER BY query COLLATE "C", toplevel;
+    ORDER BY query COLLATE "C", toplevel;
 
 -- PL/pgSQL function - top-level tracking.
 SET pg_stat_monitor.pgsm_track = 'top';
-SET pg_stat_monitor.pgsm_track_utility = FALSE;
+SET pg_stat_monitor.pgsm_track_utility = off;
 SELECT pg_stat_monitor_reset();
-CREATE FUNCTION PLUS_TWO(i INTEGER) RETURNS INTEGER AS $$
+CREATE FUNCTION plus_two(i int) RETURNS int AS $$
 DECLARE
-  r INTEGER;
+    r int;
 BEGIN
-  SELECT (i + 1 + 1.0)::INTEGER INTO r;
-  RETURN r;
-END; $$ LANGUAGE plpgsql;
+    SELECT (i + 1 + 1.0)::int INTO r;
+    RETURN r;
+END
+$$ LANGUAGE plpgsql;
 
-SELECT PLUS_TWO(3);
-SELECT PLUS_TWO(7);
+SELECT plus_two(3);
+SELECT plus_two(7);
 
 -- SQL function --- use LIMIT to keep it from being inlined
-CREATE FUNCTION PLUS_ONE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT (i + 1.0)::INTEGER LIMIT 1 $$ LANGUAGE SQL;
+CREATE FUNCTION plus_one(i int) RETURNS int AS
+$$ SELECT (i + 1.0)::int LIMIT 1 $$ LANGUAGE sql;
 
-SELECT PLUS_ONE(8);
-SELECT PLUS_ONE(10);
+SELECT plus_one(8);
+SELECT plus_one(10);
 
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- immutable SQL function --- can be executed at plan time
-CREATE FUNCTION PLUS_THREE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE SQL;
+CREATE FUNCTION plus_three(i int) RETURNS int AS
+$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE sql;
 
-SELECT PLUS_THREE(8);
-SELECT PLUS_THREE(10);
+SELECT plus_three(8);
+SELECT plus_three(10);
 
 SELECT toplevel, calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
@@ -106,37 +113,38 @@ SET pg_stat_monitor.pgsm_track = 'all';
 SELECT pg_stat_monitor_reset();
 
 -- we drop and recreate the functions to avoid any caching funnies
-DROP FUNCTION PLUS_ONE(INTEGER);
-DROP FUNCTION PLUS_TWO(INTEGER);
-DROP FUNCTION PLUS_THREE(INTEGER);
+DROP FUNCTION plus_one(int);
+DROP FUNCTION plus_two(int);
+DROP FUNCTION plus_three(int);
 
 -- PL/pgSQL function
-CREATE FUNCTION PLUS_TWO(i INTEGER) RETURNS INTEGER AS $$
+CREATE FUNCTION plus_two(i int) RETURNS int AS $$
 DECLARE
-  r INTEGER;
+    r int;
 BEGIN
-  SELECT (i + 1 + 1.0)::INTEGER INTO r;
-  RETURN r;
-END; $$ LANGUAGE plpgsql;
+    SELECT (i + 1 + 1.0)::int INTO r;
+    RETURN r;
+END
+$$ LANGUAGE plpgsql;
 
-SELECT PLUS_TWO(-1);
-SELECT PLUS_TWO(2);
+SELECT plus_two(-1);
+SELECT plus_two(2);
 
 -- SQL function --- use LIMIT to keep it from being inlined
-CREATE FUNCTION PLUS_ONE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT (i + 1.0)::INTEGER LIMIT 1 $$ LANGUAGE SQL;
+CREATE FUNCTION plus_one(i int) RETURNS int AS
+$$ SELECT (i + 1.0)::int LIMIT 1 $$ LANGUAGE sql;
 
-SELECT PLUS_ONE(3);
-SELECT PLUS_ONE(1);
+SELECT plus_one(3);
+SELECT plus_one(1);
 
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- immutable SQL function --- can be executed at plan time
-CREATE FUNCTION PLUS_THREE(i INTEGER) RETURNS INTEGER AS
-$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE SQL;
+CREATE FUNCTION plus_three(i int) RETURNS int AS
+$$ SELECT i + 3 LIMIT 1 $$ IMMUTABLE LANGUAGE sql;
 
-SELECT PLUS_THREE(8);
-SELECT PLUS_THREE(10);
+SELECT plus_three(8);
+SELECT plus_three(10);
 
 SELECT toplevel, calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
@@ -146,8 +154,8 @@ SELECT toplevel, calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE 
 SET pg_stat_monitor.pgsm_track = 'none';
 SELECT pg_stat_monitor_reset();
 
-SELECT 1 AS "one";
-SELECT 1 + 1 AS "two";
+SELECT 1 AS one;
+SELECT 1 + 1 AS two;
 
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset();

--- a/regression/sql/parallel.sql
+++ b/regression/sql/parallel.sql
@@ -2,13 +2,13 @@
 -- Tests for parallel statistics
 --
 
-SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+SELECT setting::int < 180000 AS skip_test FROM pg_settings where name = 'server_version_num' \gset
 \if :skip_test
 \quit
 \endif
 
 CREATE EXTENSION pg_stat_monitor;
-SET pgsm.track_utility = FALSE;
+SET pgsm.track_utility = off;
 
 -- encourage use of parallel plans
 SET parallel_setup_cost = 0;
@@ -22,12 +22,13 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 
 SELECT count(*) FROM pgsm_parallel_tab;
 
-SELECT query,
-  parallel_workers_to_launch > 0 AS has_workers_to_launch,
-  parallel_workers_launched > 0 AS has_workers_launched
-  FROM pg_stat_monitor
-  WHERE query ~ 'SELECT count'
-  ORDER BY query COLLATE "C";
+SELECT
+    query,
+    parallel_workers_to_launch > 0 AS has_workers_to_launch,
+    parallel_workers_launched > 0 AS has_workers_launched
+FROM pg_stat_monitor
+WHERE query ~ 'SELECT count'
+ORDER BY query COLLATE "C";
 
 DROP TABLE pgsm_parallel_tab;
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/pgsm_query_id.sql
+++ b/regression/sql/pgsm_query_id.sql
@@ -7,9 +7,9 @@ CREATE DATABASE db2;
 CREATE TABLE t1 (a int);
 CREATE TABLE t2 (b int);
 
-CREATE FUNCTION add(integer, integer) RETURNS integer
-    AS 'select $1 + $2;'
-    LANGUAGE SQL
+CREATE FUNCTION add(int, int) RETURNS int
+    AS 'SELECT $1 + $2;'
+    LANGUAGE sql
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
 
@@ -17,9 +17,9 @@ CREATE FUNCTION add(integer, integer) RETURNS integer
 CREATE TABLE t1 (a int);
 CREATE TABLE t3 (c int);
 
-CREATE FUNCTION add(integer, integer) RETURNS integer
-    AS 'select $1 + $2;'
-    LANGUAGE SQL
+CREATE FUNCTION add(int, int) RETURNS int
+    AS 'SELECT $1 + $2;'
+    LANGUAGE sql
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
 
@@ -27,7 +27,7 @@ CREATE FUNCTION add(integer, integer) RETURNS integer
 SELECT pg_stat_monitor_reset();
 \c db1
 SELECT * FROM t1;
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, add(1, 2) FROM t1;
 SELECT * FROM t2;
 -- Check that spaces and comments do not generate a different pgsm_query_id
 SELECT     *     FROM t2 --WHATEVER;
@@ -40,13 +40,12 @@ More comments to check for spaces.
 
 \c db2
 SELECT * FROM t1;
-SELECT *, ADD(1, 2) FROM t1;
+SELECT *, add(1, 2) FROM t1;
 
 set pg_stat_monitor.pgsm_enable_pgsm_query_id = off;
 SELECT * FROM t3;
 set pg_stat_monitor.pgsm_enable_pgsm_query_id = on;
-SELECT * FROM t3 where c = 20;
-
+SELECT * FROM t3 WHERE c = 20;
 
 \c contrib_regression
 SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_query_id, query, datname;
@@ -55,12 +54,12 @@ SELECT pg_stat_monitor_reset();
 \c db1
 DROP TABLE t1;
 DROP TABLE t2;
-DROP FUNCTION ADD;
+DROP FUNCTION add;
 
 \c db2
 DROP TABLE t1;
 DROP TABLE t3;
-DROP FUNCTION ADD;
+DROP FUNCTION add;
 
 \c contrib_regression
 DROP DATABASE db1;

--- a/regression/sql/relations.sql
+++ b/regression/sql/relations.sql
@@ -1,9 +1,10 @@
 CREATE EXTENSION pg_stat_monitor;
+
 SELECT pg_stat_monitor_reset();
-CREATE TABLE foo1(a int);
-CREATE TABLE foo2(b int);
-CREATE TABLE foo3(c int);
-CREATE TABLE foo4(d int);
+CREATE TABLE foo1 (a int);
+CREATE TABLE foo2 (b int);
+CREATE TABLE foo3 (c int);
+CREATE TABLE foo4 (d int);
 
 -- test the simple table names
 SELECT pg_stat_monitor_reset();
@@ -11,9 +12,8 @@ SELECT * FROM foo1;
 SELECT * FROM foo1, foo2;
 SELECT * FROM foo1, foo2, foo3;
 SELECT * FROM foo1, foo2, foo3, foo4;
-SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+SELECT query, relations FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset();
-
 
 -- test the schema qualified table
 CREATE SCHEMA sch1;
@@ -21,39 +21,38 @@ CREATE SCHEMA sch2;
 CREATE SCHEMA sch3;
 CREATE SCHEMA sch4;
 
-CREATE TABLE sch1.foo1(a int);
-CREATE TABLE sch2.foo2(b int);
-CREATE TABLE sch3.foo3(c int);
-CREATE TABLE sch4.foo4(d int);
+CREATE TABLE sch1.foo1 (a int);
+CREATE TABLE sch2.foo2 (b int);
+CREATE TABLE sch3.foo3 (c int);
+CREATE TABLE sch4.foo4 (d int);
 
 SELECT pg_stat_monitor_reset();
 SELECT * FROM sch1.foo1;
 SELECT * FROM sch1.foo1, sch2.foo2;
 SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3;
 SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3, sch4.foo4;
-SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+SELECT query, relations FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset();
 
 SELECT pg_stat_monitor_reset();
 SELECT * FROM sch1.foo1, foo1;
 SELECT * FROM sch1.foo1, sch2.foo2, foo1, foo2;
-SELECT query, relations from pg_stat_monitor ORDER BY query;
+SELECT query, relations FROM pg_stat_monitor ORDER BY query;
 SELECT pg_stat_monitor_reset();
 
 -- test the view
-CREATE VIEW v1 AS SELECT * from foo1;
-CREATE VIEW v2 AS SELECT * from foo1,foo2;
-CREATE VIEW v3 AS SELECT * from foo1,foo2,foo3;
-CREATE VIEW v4 AS SELECT * from foo1,foo2,foo3,foo4;
+CREATE VIEW v1 AS SELECT * FROM foo1;
+CREATE VIEW v2 AS SELECT * FROM foo1, foo2;
+CREATE VIEW v3 AS SELECT * FROM foo1, foo2, foo3;
+CREATE VIEW v4 AS SELECT * FROM foo1, foo2, foo3, foo4;
 
 SELECT pg_stat_monitor_reset();
 SELECT * FROM v1;
-SELECT * FROM v1,v2;
-SELECT * FROM v1,v2,v3;
-SELECT * FROM v1,v2,v3,v4;
-SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
+SELECT * FROM v1, v2;
+SELECT * FROM v1, v2, v3;
+SELECT * FROM v1, v2, v3, v4;
+SELECT query, relations FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset();
-
 
 DROP VIEW v1;
 DROP VIEW v2;
@@ -74,6 +73,5 @@ DROP SCHEMA sch1;
 DROP SCHEMA sch2;
 DROP SCHEMA sch3;
 DROP SCHEMA sch4;
-
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/rollback.sql
+++ b/regression/sql/rollback.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION pg_stat_monitor;
 
 CREATE USER u WITH SUPERUSER;
 SET ROLE u;
-CREATE TABLE t (a int PRIMARY KEY) ;
+CREATE TABLE t (a int PRIMARY KEY);
 
 SELECT pg_stat_monitor_reset();
 

--- a/regression/sql/rows.sql
+++ b/regression/sql/rows.sql
@@ -1,9 +1,9 @@
 CREATE EXTENSION pg_stat_monitor;
 
-CREATE TABLE t1(a int);
-CREATE TABLE t2(b int);
-INSERT INTO t1 VALUES(generate_series(1,1000));
-INSERT INTO t2 VALUES(generate_series(1,5000));
+CREATE TABLE t1 (a int);
+CREATE TABLE t2 (b int);
+INSERT INTO t1 VALUES (generate_series(1, 1000));
+INSERT INTO t2 VALUES (generate_series(1, 5000));
 
 SELECT pg_stat_monitor_reset();
 SELECT * FROM t1;
@@ -17,4 +17,5 @@ SELECT pg_stat_monitor_reset();
 
 DROP TABLE t1;
 DROP TABLE t2;
+
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/squashing.sql
+++ b/regression/sql/squashing.sql
@@ -2,13 +2,13 @@
 -- Const squashing functionality
 --
 
-SELECT setting::integer < 180000 AS skip_test FROM pg_settings where name = 'server_version_num'  \gset
+SELECT setting::int < 180000 AS skip_test FROM pg_settings where name = 'server_version_num' \gset
 \if :skip_test
 \quit
 \endif
 
 CREATE EXTENSION pg_stat_monitor;
-SET pg_stat_monitor.pgsm_normalized_query = TRUE;
+SET pg_stat_monitor.pgsm_normalized_query = on;
 
 --
 -- Simple Lists
@@ -36,7 +36,7 @@ SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 -- the IN and ARRAY forms of this statement will have the same queryId
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 SELECT WHERE 1 IN (1, int4(1), int4(2), 2);
-SELECT WHERE 1 = ANY (ARRAY[1, int4(1), int4(2), 2]);
+SELECT WHERE 1 = ANY(ARRAY[1, int4(1), int4(2), 2]);
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- This tests are disabled due bug in PGSM, see: https://perconadev.atlassian.net/browse/PG-1936
@@ -66,9 +66,9 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9) AND data = 2;
 SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10) AND data = 2;
 SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11) AND data = 2;
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]) AND data = 2;
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) AND data = 2;
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) AND data = 2;
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]) AND data = 2;
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) AND data = 2;
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) AND data = 2;
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- Multiple squashed intervals
@@ -79,12 +79,12 @@ SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
     AND data IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 SELECT * FROM test_squash WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
     AND data IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9])
-    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]);
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-SELECT * FROM test_squash WHERE id = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
-    AND data = ANY (ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9])
+    AND data = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    AND data = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+SELECT * FROM test_squash WHERE id = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+    AND data = ANY(ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 
@@ -92,13 +92,13 @@ SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 -- The IN and ARRAY forms of this statement will have the same queryId
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 SELECT * FROM test_squash WHERE id IN
-	(1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9);
+    (1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9);
 SELECT * FROM test_squash WHERE id IN
-	(@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9');
+    (@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9');
 SELECT * FROM test_squash WHERE id = ANY(ARRAY
-	[1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9]);
+    [1 + 1, 2 + 2, 3 + 3, 4 + 4, 5 + 5, 6 + 6, 7 + 7, 8 + 8, 9 + 9]);
 SELECT * FROM test_squash WHERE id = ANY(ARRAY
-	[@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9']);
+    [@ '-1', @ '-2', @ '-3', @ '-4', @ '-5', @ '-6', @ '-7', @ '-8', @ '-9']);
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 --
@@ -139,21 +139,21 @@ SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 -- Bigint, explicit cast is squashed
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 SELECT * FROM test_squash_bigint WHERE data IN
-	(1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
-	 7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint);
+    (1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
+     7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint);
 SELECT * FROM test_squash_bigint WHERE data = ANY(ARRAY[
-	 1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
-	 7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint]);
+    1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint, 6::bigint,
+    7::bigint, 8::bigint, 9::bigint, 10::bigint, 11::bigint]);
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- Bigint, long tokens with parenthesis, will not squash
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 SELECT * FROM test_squash_bigint WHERE id IN
-	(abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
-	 abs(800), abs(900), abs(1000), ((abs(1100))));
+    (abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
+     abs(800), abs(900), abs(1000), ((abs(1100))));
 SELECT * FROM test_squash_bigint WHERE id = ANY(ARRAY[
-	 abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
-	 abs(800), abs(900), abs(1000), ((abs(1100)))]);
+    abs(100), abs(200), abs(300), abs(400), abs(500), abs(600), abs(700),
+    abs(800), abs(900), abs(1000), ((abs(1100)))]);
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- Multiple FuncExpr's. Will not squash
@@ -170,26 +170,26 @@ SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 CREATE TYPE casttesttype;
 
 CREATE FUNCTION casttesttype_in(cstring)
-   RETURNS casttesttype
-   AS 'textin'
-   LANGUAGE internal STRICT IMMUTABLE;
+    RETURNS casttesttype
+    AS 'textin'
+    LANGUAGE internal STRICT IMMUTABLE;
 
 CREATE FUNCTION casttesttype_out(casttesttype)
-   RETURNS cstring
-   AS 'textout'
-   LANGUAGE internal STRICT IMMUTABLE;
+    RETURNS cstring
+    AS 'textout'
+    LANGUAGE internal STRICT IMMUTABLE;
 
 CREATE TYPE casttesttype (
-   internallength = variable,
-   input = casttesttype_in,
-   output = casttesttype_out,
-   alignment = int4
+    internallength = variable,
+    input = casttesttype_in,
+    output = casttesttype_out,
+    alignment = int4
 );
 
 CREATE CAST (int4 AS casttesttype) WITH INOUT;
 
 CREATE FUNCTION casttesttype_eq(casttesttype, casttesttype)
-returns boolean language sql immutable as $$
+RETURNS boolean LANGUAGE sql IMMUTABLE AS $$
     SELECT true
 $$;
 
@@ -197,49 +197,50 @@ CREATE OPERATOR = (
     leftarg = casttesttype,
     rightarg = casttesttype,
     procedure = casttesttype_eq,
-    commutator = =);
+    commutator = =
+);
 
 CREATE TABLE test_squash_cast (id int, data casttesttype);
 
 -- Use the introduced type to construct a list of CoerceViaIO around Const
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 SELECT * FROM test_squash_cast WHERE data IN
-	(1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
-	 4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
-	 7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
-	 10::int4::casttesttype, 11::int4::casttesttype);
-SELECT * FROM test_squash_cast WHERE data = ANY (ARRAY
-	[1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
-	 4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
-	 7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
-	 10::int4::casttesttype, 11::int4::casttesttype]);
+    (1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
+     4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
+     7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
+     10::int4::casttesttype, 11::int4::casttesttype);
+SELECT * FROM test_squash_cast WHERE data = ANY(ARRAY
+    [1::int4::casttesttype, 2::int4::casttesttype, 3::int4::casttesttype,
+     4::int4::casttesttype, 5::int4::casttesttype, 6::int4::casttesttype,
+     7::int4::casttesttype, 8::int4::casttesttype, 9::int4::casttesttype,
+     10::int4::casttesttype, 11::int4::casttesttype]);
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- Some casting expression are simplified to Const
 CREATE TABLE test_squash_jsonb (id int, data jsonb);
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 SELECT * FROM test_squash_jsonb WHERE data IN
-	(('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
-	 ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
-	 ('"9"')::jsonb, ('"10"')::jsonb);
-SELECT * FROM test_squash_jsonb WHERE data = ANY (ARRAY
-	[('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
-	 ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
-	 ('"9"')::jsonb, ('"10"')::jsonb]);
+    (('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
+     ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
+     ('"9"')::jsonb, ('"10"')::jsonb);
+SELECT * FROM test_squash_jsonb WHERE data = ANY(ARRAY
+    [('"1"')::jsonb, ('"2"')::jsonb, ('"3"')::jsonb, ('"4"')::jsonb,
+     ('"5"')::jsonb, ('"6"')::jsonb, ('"7"')::jsonb, ('"8"')::jsonb,
+     ('"9"')::jsonb, ('"10"')::jsonb]);
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- CoerceViaIO, SubLink instead of a Const. Will not squash
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 SELECT * FROM test_squash_jsonb WHERE data IN
-	((SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
-	 (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
-	 (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
-	 (SELECT '"10"')::jsonb);
+    ((SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
+     (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
+     (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
+     (SELECT '"10"')::jsonb);
 SELECT * FROM test_squash_jsonb WHERE data = ANY(ARRAY
-	[(SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
-	 (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
-	 (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
-	 (SELECT '"10"')::jsonb]);
+    [(SELECT '"1"')::jsonb, (SELECT '"2"')::jsonb, (SELECT '"3"')::jsonb,
+     (SELECT '"4"')::jsonb, (SELECT '"5"')::jsonb, (SELECT '"6"')::jsonb,
+     (SELECT '"7"')::jsonb, (SELECT '"8"')::jsonb, (SELECT '"9"')::jsonb,
+     (SELECT '"10"')::jsonb]);
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- Multiple CoerceViaIO are squashed
@@ -255,7 +256,7 @@ SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 -- However many layers of RelabelType there are, the list will be squashable.
 SELECT * FROM test_squash WHERE id IN
-	(1::oid, 2::oid, 3::oid, 4::oid, 5::oid, 6::oid, 7::oid, 8::oid, 9::oid);
+    (1::oid, 2::oid, 3::oid, 4::oid, 5::oid, 6::oid, 7::oid, 8::oid, 9::oid);
 SELECT ARRAY[1::oid, 2::oid, 3::oid, 4::oid, 5::oid, 6::oid, 7::oid, 8::oid, 9::oid];
 SELECT * FROM test_squash WHERE id IN (1::oid, 2::oid::int::oid);
 SELECT * FROM test_squash WHERE id = ANY(ARRAY[1::oid, 2::oid::int::oid]);
@@ -280,23 +281,23 @@ SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- Test constants evaluation in a CTE, which was causing issues in the past
 WITH cte AS (
-    SELECT 'const' as const FROM test_squash
+    SELECT 'const' AS const FROM test_squash
 )
 SELECT ARRAY['a', 'b', 'c', const::varchar] AS result
 FROM cte;
 
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 -- Rewritten as an OpExpr, so it will not be squashed
-select where '1' IN ('1'::int, '2'::int::text);
+SELECT WHERE '1' IN ('1'::int, '2'::int::text);
 -- Rewritten as an ArrayExpr, so it will be squashed
-select where '1' IN ('1'::int, '2'::int);
+SELECT WHERE '1' IN ('1'::int, '2'::int);
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 -- Both of these queries will be rewritten as an ArrayExpr, so they
 -- will be squashed, and have a similar queryId
-select where '1' IN ('1'::int::text, '2'::int::text);
-select where '1' = ANY (array['1'::int::text, '2'::int::text]);
+SELECT WHERE '1' IN ('1'::int::text, '2'::int::text);
+SELECT WHERE '1' = ANY(array['1'::int::text, '2'::int::text]);
 SELECT query, calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 --

--- a/regression/sql/top_query.sql
+++ b/regression/sql/top_query.sql
@@ -1,25 +1,27 @@
 CREATE EXTENSION pg_stat_monitor;
 SET pg_stat_monitor.pgsm_track = 'all';
 SELECT pg_stat_monitor_reset();
-CREATE OR REPLACE FUNCTION add(int, int) RETURNS INTEGER AS
+CREATE FUNCTION add(int, int) RETURNS int AS
 $$
 BEGIN
-	return (select $1 + $2);
-END; $$ language plpgsql;
+    RETURN (SELECT $1 + $2);
+END
+$$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION add2(int, int) RETURNS INTEGER AS
+CREATE FUNCTION add2(int, int) RETURNS int AS
 $$
 BEGIN
-	return add($1,$2);
-END;
-$$ language plpgsql;
+    RETURN add($1, $2);
+END
+$$ LANGUAGE plpgsql;
 
-SELECT add2(1,2);
+SELECT add2(1, 2);
 SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- make sure that we handle nested queries correctly
 
 BEGIN;
+
 DO $$
 DECLARE
     i int;
@@ -28,7 +30,7 @@ BEGIN
     FOR i IN 1..50000 LOOP
         EXECUTE format('SELECT %s', i);
     END LOOP;
-END;
+END
 $$;
 
 COMMIT;


### PR DESCRIPTION
To make the code easier to work with we try to make the SQL a bit more consistent. Some changes:
    
 - Use uppercase for SQL keywords
 - Use lowercase for identifiers and identifier-like keywords
 - Always have space after comma
 - Standardize how we write SET
 - Clean up white space
 - Consistently format DO blocks and functions

PG-0
