### PR TITLE
Do not assign people autoamtically to Github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,9 +1,6 @@
 name: Bug Report
 description: File a bug report
 labels: ["bug"]
-assignees:
-  - artemgavrilov
-  - dutow
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,9 +1,6 @@
 name: Feature Request
 description: Suggest an idea for this project
 labels: ["feature"]
-assignees:
-  - artemgavrilov
-  - dutow
 
 body:
   - type: markdown


### PR DESCRIPTION
Since commit bae21bf19e0026291c2e1ec1a8c069577a513425 remove the code owners it makes no sense to automatically assign normal issues.
