### PR TITLE
Remove unused argument to hash_entry_dealloc()

### DIFF
--- a/src/hash_query.c
+++ b/src/hash_query.c
@@ -243,16 +243,13 @@ hash_entry_alloc(pgsmSharedState *pgsm, const pgsmHashKey *key)
 
 /*
  * Prepare resources for using the new bucket:
- *    - Deallocate finished hash table entries in new_bucket_id (entries whose
- *      state is PGSM_EXEC or PGSM_ERROR).
- *    - Clear query buffer for new_bucket_id.
- *    - If old_bucket_id != -1, move all pending hash table entries in
- *      old_bucket_id to the new bucket id.
+ *    - Deallocate hash table entries in the bucket
+ *    - Clear query buffer for the bucket
  *
  * Caller must hold an exclusive lock on pgsm->lock.
  */
 void
-hash_entry_dealloc(int new_bucket_id, int old_bucket_id)
+hash_entry_dealloc(int bucket_id)
 {
 	HASH_SEQ_STATUS hstat;
 	pgsmEntry  *entry;
@@ -269,12 +266,8 @@ hash_entry_dealloc(int new_bucket_id, int old_bucket_id)
 	{
 		dsa_pointer pdsa;
 
-		/*
-		 * Remove all entries if new_bucket_id == -1. Otherwise remove entry
-		 * in new_bucket_id if it has finished already.
-		 */
-		if (new_bucket_id == INVALID_BUCKET_ID ||
-			entry->key.bucket_id == new_bucket_id)
+		/*  Remove all entries if new_bucket_id == -1 */
+		if (bucket_id == INVALID_BUCKET_ID || entry->key.bucket_id == bucket_id)
 		{
 			dsa_pointer parent_qdsa = entry->counters.info.parent_query;
 

--- a/src/hash_query.h
+++ b/src/hash_query.h
@@ -248,7 +248,7 @@ HTAB	   *get_pgsmHash(void);
 bool		IsSystemOOM(void);
 Size		pgsm_ShmemSize(void);
 pgsmSharedState *pgsm_get_ss(void);
-void		hash_entry_dealloc(int new_bucket_id, int old_bucket_id);
+void		hash_entry_dealloc(int bucket_id);
 pgsmEntry  *hash_entry_alloc(pgsmSharedState *pgsm, const pgsmHashKey *key);
 
 #endif							/* __PGSM_HASH_QUERY_H__ */

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1908,7 +1908,7 @@ pg_stat_monitor_reset(PG_FUNCTION_ARGS)
 
 	pgsm = pgsm_get_ss();
 	pgsm_lock_aquire(pgsm, LW_EXCLUSIVE);
-	hash_entry_dealloc(INVALID_BUCKET_ID, INVALID_BUCKET_ID);
+	hash_entry_dealloc(INVALID_BUCKET_ID);
 	pgsm_lock_release(pgsm);
 	PG_RETURN_VOID();
 }
@@ -2458,15 +2458,14 @@ get_next_wbucket(pgsmSharedState *pgsm)
 	if (update_bucket)
 	{
 		uint64		new_bucket_id;
-		uint64		prev_bucket_id;
 
 		new_bucket_id = (tv.tv_sec / pgsm_bucket_time) % pgsm_max_buckets;
 
 		/* Update bucket id and retrieve the previous one. */
-		prev_bucket_id = pg_atomic_exchange_u64(&pgsm->current_wbucket, new_bucket_id);
+		pg_atomic_exchange_u64(&pgsm->current_wbucket, new_bucket_id);
 
 		pgsm_lock_aquire(pgsm, LW_EXCLUSIVE);
-		hash_entry_dealloc(new_bucket_id, prev_bucket_id);
+		hash_entry_dealloc(new_bucket_id);
 
 		pgsm_lock_release(pgsm);
 


### PR DESCRIPTION
The `old_bucket_id` argument was no longer used and could be removed. While at it we also rename the remaining argument and improve the some comments.
