### PR TITLE
Simplify the SQL a bit in our regression tests

### DIFF
--- a/regression/expected/different_parent_queries.out
+++ b/regression/expected/different_parent_queries.out
@@ -6,12 +6,12 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-CREATE OR REPLACE FUNCTION test() RETURNS void AS $$
+CREATE FUNCTION test() RETURNS void AS $$
 BEGIN
     PERFORM 1 + 2;
 END
 $$ LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION test2() RETURNS void AS $$
+CREATE FUNCTION test2() RETURNS void AS $$
 BEGIN
     PERFORM 1 + 2;
 END

--- a/regression/expected/error_insert.out
+++ b/regression/expected/error_insert.out
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS company;
-NOTICE:  table "company" does not exist, skipping
 CREATE TABLE company (
     id int PRIMARY KEY NOT NULL,
     name text NOT NULL
@@ -15,11 +13,11 @@ INSERT INTO company (id, name) VALUES (1, 'Percona');
 INSERT INTO company (id, name) VALUES (1, 'Percona');
 ERROR:  duplicate key value violates unique constraint "company_pkey"
 DETAIL:  Key (id)=(1) already exists.
-DROP TABLE IF EXISTS company;
+DROP TABLE company;
 SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C", elevel;
                          query                         | elevel | sqlcode |                            message                            
 -------------------------------------------------------+--------+---------+---------------------------------------------------------------
- DROP TABLE IF EXISTS company                          |      0 |         | 
+ DROP TABLE company                                    |      0 |         | 
  INSERT INTO company (id, name) VALUES (1, 'Percona')  |      0 |         | 
  INSERT INTO company (id, name) VALUES (1, 'Percona'); |     21 | 23505   | duplicate key value violates unique constraint "company_pkey"
  SELECT pg_stat_monitor_reset()                        |      0 |         | 

--- a/regression/sql/different_parent_queries.sql
+++ b/regression/sql/different_parent_queries.sql
@@ -2,13 +2,13 @@ CREATE EXTENSION pg_stat_monitor;
 SET pg_stat_monitor.pgsm_track = 'all';
 SELECT pg_stat_monitor_reset();
 
-CREATE OR REPLACE FUNCTION test() RETURNS void AS $$
+CREATE FUNCTION test() RETURNS void AS $$
 BEGIN
     PERFORM 1 + 2;
 END
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION test2() RETURNS void AS $$
+CREATE FUNCTION test2() RETURNS void AS $$
 BEGIN
     PERFORM 1 + 2;
 END

--- a/regression/sql/error_insert.sql
+++ b/regression/sql/error_insert.sql
@@ -1,4 +1,3 @@
-DROP TABLE IF EXISTS company;
 CREATE TABLE company (
     id int PRIMARY KEY NOT NULL,
     name text NOT NULL
@@ -9,7 +8,7 @@ SELECT pg_stat_monitor_reset();
 INSERT INTO company (id, name) VALUES (1, 'Percona');
 INSERT INTO company (id, name) VALUES (1, 'Percona');
 
-DROP TABLE IF EXISTS company;
+DROP TABLE company;
 SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C", elevel;
 SELECT pg_stat_monitor_reset();
 DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
There is no need for `OR REPLACE` or `IF EXISTS` as we only support running on a clean database anyway.

PG-0

