### PR TITLE
Actually pop DDL queries from our entry stack

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1120,6 +1120,8 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 						  PGSM_EXEC);	/* kind */
 
 		pgsm_store(entry);
+
+		pgsm_delete_entry(queryId);
 	}
 	else
 	{
@@ -1176,7 +1178,6 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		PG_END_TRY();
 #endif
 	}
-	pgsm_delete_entry(pstmt->queryId);
 }
 
 /*


### PR DESCRIPTION
Since we for DDL set the query ID to zero we need to actually use the original query ID also when we pop from the stack, not just when we add it to the stack. This is not a memory leak since we free the whole list in `pgsm_cleanup_callback()` but it is clearly a mistake.

Also while at it change it so we only try to pop in code paths where we pushed to the stack.

PG-0

