### PR TITLE
Rewirite decode_error_level() and get_cmd_type() in C

### DIFF
--- a/pg_stat_monitor--2.3--next.sql
+++ b/pg_stat_monitor--2.3--next.sql
@@ -1,45 +1,17 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "ALTER EXTENSION pg_stat_monitor" to load this file. \quit
 
--- Drop PostgreSQL 13 support from function
 CREATE OR REPLACE FUNCTION decode_error_level(elevel int)
 RETURNS text
 PARALLEL SAFE
-LANGUAGE sql
-RETURN CASE
-    WHEN elevel = 0 THEN ''
-    WHEN elevel = 10 THEN 'DEBUG5'
-    WHEN elevel = 11 THEN 'DEBUG4'
-    WHEN elevel = 12 THEN 'DEBUG3'
-    WHEN elevel = 13 THEN 'DEBUG2'
-    WHEN elevel = 14 THEN 'DEBUG1'
-    WHEN elevel = 15 THEN 'LOG'
-    WHEN elevel = 16 THEN 'LOG_SERVER_ONLY'
-    WHEN elevel = 17 THEN 'INFO'
-    WHEN elevel = 18 THEN 'NOTICE'
-    WHEN elevel = 19 THEN 'WARNING'
-    WHEN elevel = 20 THEN 'WARNING_CLIENT_ONLY'
-    WHEN elevel = 21 THEN 'ERROR'
-    WHEN elevel = 22 THEN 'FATAL'
-    WHEN elevel = 23 THEN 'PANIC'
-END;
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'pg_stat_monitor_decode_error_level';
 
 CREATE OR REPLACE FUNCTION get_cmd_type(cmd_type int)
 RETURNS text
 PARALLEL SAFE
-LANGUAGE sql
-RETURN CASE
-    WHEN cmd_type = 0 THEN ''
-    WHEN cmd_type = 1 THEN 'SELECT'
-    WHEN cmd_type = 2 THEN 'UPDATE'
-    WHEN cmd_type = 3 THEN 'INSERT'
-    WHEN cmd_type = 4 THEN 'DELETE'
-    WHEN cmd_type = 5 AND current_setting('server_version_num')::int >= 150000 THEN 'MERGE'
-    WHEN cmd_type = 5 AND current_setting('server_version_num')::int < 150000 THEN 'UTILITY'
-    WHEN cmd_type = 6 AND current_setting('server_version_num')::int >= 150000 THEN 'UTILITY'
-    WHEN cmd_type = 6 AND current_setting('server_version_num')::int < 150000 THEN 'NOTHING'
-    WHEN cmd_type = 7 THEN 'NOTHING'
-END;
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'pg_stat_monitor_get_cmd_type';
 
 CREATE OR REPLACE FUNCTION range()
 RETURNS text[]

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -198,6 +198,8 @@ PG_FUNCTION_INFO_V1(pg_stat_monitor_2_3);
 PG_FUNCTION_INFO_V1(pg_stat_monitor);
 PG_FUNCTION_INFO_V1(get_histogram_timings);
 PG_FUNCTION_INFO_V1(pg_stat_monitor_hook_stats);
+PG_FUNCTION_INFO_V1(pg_stat_monitor_decode_error_level);
+PG_FUNCTION_INFO_V1(pg_stat_monitor_get_cmd_type);
 
 static uint pg_get_client_addr(void);
 static int	pg_get_application_name(char *name, int buff_size);
@@ -2430,6 +2432,96 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 	}
 	/* clean up and return the tuplestore */
 	pgsm_lock_release(pgsm);
+}
+
+static const char *
+decode_error_level(int elevel)
+{
+	switch (elevel)
+	{
+		case 0:					/* compatibility with legacy code */
+			return "";
+		case DEBUG5:
+			return "DEBUG5";
+		case DEBUG4:
+			return "DEBUG4";
+		case DEBUG3:
+			return "DEBUG3";
+		case DEBUG2:
+			return "DEBUG2";
+		case DEBUG1:
+			return "DEBUG1";
+		case LOG:
+			return "LOG";
+		case LOG_SERVER_ONLY:
+			return "LOG_SERVER_ONLY";
+		case INFO:
+			return "INFO";
+		case NOTICE:
+			return "NOTICE";
+		case WARNING:
+			return "WARNING";
+		case WARNING_CLIENT_ONLY:
+			return "WARNING_CLIENT_ONLY";
+		case ERROR:
+			return "ERROR";
+		case FATAL:
+			return "FATAL";
+		case PANIC:
+			return "PANIC";
+		default:
+			return NULL;
+	}
+}
+
+Datum
+pg_stat_monitor_decode_error_level(PG_FUNCTION_ARGS)
+{
+	const char *severity = decode_error_level(PG_GETARG_INT32(0));
+
+	if (severity == NULL)
+		PG_RETURN_NULL();
+
+	PG_RETURN_TEXT_P(cstring_to_text(severity));
+}
+
+static const char *
+get_cmd_type(int cmd_type)
+{
+	switch (cmd_type)
+	{
+		case CMD_UNKNOWN:
+			return "";			/* compatibility with legacy code */
+		case CMD_SELECT:
+			return "SELECT";
+		case CMD_UPDATE:
+			return "UPDATE";
+		case CMD_INSERT:
+			return "INSERT";
+		case CMD_DELETE:
+			return "DELETE";
+#if PG_VERSION_NUM >= 150000
+		case CMD_MERGE:
+			return "MERGE";
+#endif
+		case CMD_UTILITY:
+			return "UTILITY";
+		case CMD_NOTHING:
+			return "NOTHING";
+		default:
+			return NULL;
+	}
+}
+
+Datum
+pg_stat_monitor_get_cmd_type(PG_FUNCTION_ARGS)
+{
+	const char *cmd_string = get_cmd_type(PG_GETARG_INT32(0));
+
+	if (cmd_string == NULL)
+		PG_RETURN_NULL();
+
+	PG_RETURN_TEXT_P(cstring_to_text(cmd_string));
 }
 
 static uint64


### PR DESCRIPTION
While rewriting these functions in C means more lines of code it is a net improvement since we can use the defines in the C code instead of magic numbers plus that we can simply add an ifdef when a new value is added instead of having to update the SQL function and call `current_setting()`.

The way we handle the zero values is legacy to not break any old code.

PG-0