### PR TITLE
Convert histogram() to an SQL function and clean it up

### DIFF
--- a/pg_stat_monitor--2.3--next.sql
+++ b/pg_stat_monitor--2.3--next.sql
@@ -46,6 +46,27 @@ RETURNS text[]
 LANGUAGE sql
 RETURN string_to_array(get_histogram_timings(), ',');
 
+-- Intentionally uses a string body so we can drop and recreate the pg_stat_monitor view
+CREATE OR REPLACE FUNCTION histogram(_bucket int, _quryid int8)
+RETURNS SETOF record
+LANGUAGE sql
+AS $$
+WITH stat AS (
+    SELECT
+        queryid,
+        bucket,
+        unnest(range()) AS range,
+        unnest(resp_calls)::int AS freq
+    FROM pg_stat_monitor
+)
+SELECT
+    range,
+    freq,
+    repeat('■', (freq::float / max(freq) OVER () * 30)::int) AS bar
+FROM stat
+WHERE queryid = _quryid AND bucket = _bucket
+$$;
+
 DROP FUNCTION pgsm_create_13_view();
 DROP VIEW pg_stat_monitor;
 


### PR DESCRIPTION
As `histogram()` did not use any real PL/PgSQL features the intent would be clearer as an SQL function. In addition also clean it up so it is readable.

PG-0
