### PR TITLE
Minor cleanups of comment extraction

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1715,7 +1715,7 @@ pgsm_store(pgsmEntry *entry)
 	BufferUsage bufusage;
 	WalUsage	walusage;
 	JitInstrumentation jitusage;
-	char		comments[COMMENTS_LEN] = {0};
+	char		comments[COMMENTS_LEN];
 
 	/* Safety check... */
 	if (!IsSystemInitialized())
@@ -3102,13 +3102,15 @@ extract_query_comments(const char *query, char *comments, size_t buf_len)
 	size_t		curr_len = 0;
 	const char *q_iter = query;
 
+	Assert(query != NULL);
+
 	if (!pgsm_extract_comments)
 	{
 		comments[0] = '\0';
 		return;
 	}
 
-	while (q_iter && *q_iter)
+	while (*q_iter)
 	{
 		/*
 		 * multiline comments, + 1 is safe even if we've reach end of string


### PR DESCRIPTION
- Do not initialize field unnecessarily
- Assume query cannot be NULL

PG-0
