### PR TITLE
Remove dead code when handling return from pgsm_get_entry_for_query()

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -707,11 +707,6 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 		SysInfo		sys_info;
 
 		entry = pgsm_get_entry_for_query(queryId, plan_ptr, queryDesc->sourceText, queryDesc->operation);
-		if (!entry)
-		{
-			elog(DEBUG2, "[pg_stat_monitor] pgsm_ExecutorEnd: Failed to find entry for [" INT64_FORMAT "] %s.", queryId, queryDesc->sourceText);
-			return;
-		}
 
 		if (entry->key.planid == 0)
 			entry->key.planid = plan_ptr ? plan_ptr->planid : 0;


### PR DESCRIPTION
As `pgsm_get_entry_for_query()` can never return NULL we should not try to handle that.

PG-0