### PR TITLE
Clean up get_histogram_bucket()

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -3099,13 +3099,13 @@ histogram_bucket_timings(int index, double *b_start, double *b_end)
 static int
 get_histogram_bucket(double q_time)
 {
-	for (int index = 0; index < hist_bucket_count_total - 1; index++)
+	for (int index = 0; index < hist_bucket_count_total; index++)
 	{
-		if (q_time >= hist_bucket_timings[index].start && q_time <= hist_bucket_timings[index].end)
+		if (q_time <= hist_bucket_timings[index].end)
 			return index;
 	}
 
-	/* Given the uppermost bound is inifity we should never reach this */
+	/* Given the uppermost bound is infinity we should never reach this */
 	return hist_bucket_count_total - 1;
 }
 


### PR DESCRIPTION
In commit b2e5c69c2c1421e13ee7207201136e3a4ed3370d I accidentally pushed the wrong thing plus a typo in a comment. While at it also remove a pointless lower range check because we already know that as we loop from low to high.

PG-0

Question for the reviewers: I am not sure what the cleanest way to write this function is but what I accidentally merged was a bit of mess where the comment contradicted the code.