### PR TITLE
Simplify code related to pgsm_extract_comments

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1273,14 +1273,6 @@ pgsm_update_entry(pgsmEntry *entry,
 	if (kind == PGSM_STORE)
 		SpinLockAcquire(&entry->mutex);
 
-	/*
-	 * Extract comments if enabled and only when the query has completed with
-	 * or without error
-	 */
-	if (pgsm_extract_comments && kind == PGSM_STORE
-		&& !entry->counters.info.comments[0] && comments && comments[0])
-		strlcpy(entry->counters.info.comments, comments, COMMENTS_LEN);
-
 	if (kind == PGSM_PLAN || kind == PGSM_STORE)
 	{
 		entry->counters.plancalls.calls += 1;
@@ -1350,6 +1342,9 @@ pgsm_update_entry(pgsmEntry *entry,
 	/* Only should process this once when storing the data */
 	if (kind == PGSM_STORE)
 	{
+		if (pgsm_extract_comments && comments && comments[0] && !entry->counters.info.comments[0])
+			strlcpy(entry->counters.info.comments, comments, COMMENTS_LEN);
+
 		if (pgsm_track_application_names && app_name[0] != '\0' && !entry->counters.info.application_name[0])
 			strlcpy(entry->counters.info.application_name, app_name, APPLICATIONNAME_LEN);
 
@@ -1739,7 +1734,9 @@ pgsm_store(pgsmEntry *entry)
 	query = entry->query_text.query_pointer;
 
 	/* Let's do all the leg work here before we acquire any locks */
-	extract_query_comments(query, comments, sizeof(comments));
+
+	if (pgsm_extract_comments)
+		extract_query_comments(query, comments, sizeof(comments));
 
 	/* bufusage */
 	bufusage.shared_blks_hit = entry->counters.blocks.shared_blks_hit;
@@ -1885,7 +1882,7 @@ pgsm_store(pgsmEntry *entry)
 
 	pgsm_update_entry(shared_hash_entry,	/* entry */
 					  query,	/* query */
-					  comments, /* comments */
+					  pgsm_extract_comments ? comments : NULL,	/* comments */
 					  &entry->counters.planinfo,	/* PlanInfo */
 					  &entry->counters.sysinfo, /* SysInfo */
 					  &entry->counters.error,	/* ErrorInfo */
@@ -3196,12 +3193,6 @@ extract_query_comments(const char *query, char *comments, size_t buf_len)
 	const char *q_iter = query;
 
 	Assert(query != NULL);
-
-	if (!pgsm_extract_comments)
-	{
-		comments[0] = '\0';
-		return;
-	}
 
 	while (*q_iter)
 	{


### PR DESCRIPTION
Checks related to `pgsm_extract_comments` were all over the place so move them to where they make more sense. I think most people for example would not expect `extract_query_comments()` to check against a GUC.

Also make the code in `pgsm_update_entry()` more similar to the code handling the application name.

PG-0
