### PR TITLE
Do not check return from cluster start in TAP tests

### DIFF
--- a/t/001_settings_default.pl
+++ b/t/001_settings_default.pl
@@ -22,8 +22,7 @@ print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/002_settings_pgsm_track_planning.pl
+++ b/t/002_settings_pgsm_track_planning.pl
@@ -24,8 +24,7 @@ print $conf "pg_stat_monitor.pgsm_track_planning = on\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/003_settings_pgms_extract_comments.pl
+++ b/t/003_settings_pgms_extract_comments.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_extract_comments = on\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/004_settings_pgsm_track.pl
+++ b/t/004_settings_pgsm_track.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_track = 'none'\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/005_settings_pgsm_enable_query_plan.pl
+++ b/t/005_settings_pgsm_enable_query_plan.pl
@@ -24,8 +24,7 @@ print $conf "pg_stat_monitor.pgsm_enable_query_plan = on\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/006_settings_pgsm_overflow_target.pl
+++ b/t/006_settings_pgsm_overflow_target.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_enable_overflow = false\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/007_settings_pgsm_query_shared_buffer.pl
+++ b/t/007_settings_pgsm_query_shared_buffer.pl
@@ -26,8 +26,7 @@ print $conf "pg_stat_monitor.pgsm_normalized_query = on\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/008_settings_pgsm_histogram_buckets.pl
+++ b/t/008_settings_pgsm_histogram_buckets.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_histogram_buckets = 10000\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/009_settings_pgsm_histogram_max.pl
+++ b/t/009_settings_pgsm_histogram_max.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_histogram_max = 1\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/010_settings_pgsm_histogram_min.pl
+++ b/t/010_settings_pgsm_histogram_min.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_histogram_min = 1\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/011_settings_pgsm_bucket_time.pl
+++ b/t/011_settings_pgsm_bucket_time.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_bucket_time = 10000\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/012_settings_pgsm_max_buckets.pl
+++ b/t/012_settings_pgsm_max_buckets.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_max_buckets = 1\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/013_settings_pgsm_normalized_query.pl
+++ b/t/013_settings_pgsm_normalized_query.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_normalized_query = 'no'\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/014_settings_pgsm_track_utility.pl
+++ b/t/014_settings_pgsm_track_utility.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_track_utility = 'no'\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/015_settings_pgsm_query_max_len.pl
+++ b/t/015_settings_pgsm_query_max_len.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_query_max_len = 10240\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/016_settings_pgsm_max.pl
+++ b/t/016_settings_pgsm_max.pl
@@ -23,8 +23,7 @@ print $conf "pg_stat_monitor.pgsm_max = 2048\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/017_execution_stats.pl
+++ b/t/017_execution_stats.pl
@@ -23,8 +23,7 @@ print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 my $col_total_time = "total_exec_time";
 my $col_min_time = "min_exec_time";

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -99,8 +99,7 @@ my %pg_versions_pgsm_columns = (
 );
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/019_insufficient_shared_space.pl
+++ b/t/019_insufficient_shared_space.pl
@@ -25,8 +25,7 @@ print $conf "pg_stat_monitor.pgsm_query_shared_buffer = 1\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/020_buffer_overflow.pl
+++ b/t/020_buffer_overflow.pl
@@ -27,8 +27,7 @@ print $conf "pg_stat_monitor.pgsm_query_shared_buffer = 1\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/021_misc_1.pl
+++ b/t/021_misc_1.pl
@@ -30,8 +30,7 @@ print $conf "pg_stat_monitor.pgsm_extract_comments = on\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/022_misc_2.pl
+++ b/t/022_misc_2.pl
@@ -30,8 +30,7 @@ print $conf "pg_stat_monitor.pgsm_extract_comments = 'no'\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/023_missing_queries.pl
+++ b/t/023_missing_queries.pl
@@ -53,8 +53,7 @@ $node->append_conf('postgresql.conf',
 	"pg_stat_monitor.pgsm_bucket_time = 14");
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 my ($cmdret, $stdout, $stderr) = $node->psql(
 	'postgres',

--- a/t/024_check_timings.pl
+++ b/t/024_check_timings.pl
@@ -31,8 +31,7 @@ $node->append_conf('postgresql.conf',
 $node->append_conf('postgresql.conf',
 	"pg_stat_monitor.pgsm_normalized_query = on");
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/025_compare_pgss.pl
+++ b/t/025_compare_pgss.pl
@@ -32,8 +32,7 @@ $node->append_conf('postgresql.conf',
 	"pg_stat_monitor.pgsm_normalized_query = on");
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 my $col_shared_blk_read_time = "shared_blk_read_time";
 my $col_shared_blk_write_time = "shared_blk_write_time";

--- a/t/026_shared_blocks.pl
+++ b/t/026_shared_blocks.pl
@@ -37,8 +37,7 @@ $node->append_conf('postgresql.conf',
 	"pg_stat_monitor.pgsm_normalized_query = on");
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 my $col_shared_blk_read_time = "shared_blk_read_time";
 my $col_shared_blk_write_time = "shared_blk_write_time";

--- a/t/027_local_blocks.pl
+++ b/t/027_local_blocks.pl
@@ -30,8 +30,7 @@ $node->append_conf('postgresql.conf',
 	"pg_stat_monitor.pgsm_normalized_query = on");
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/028_temp_block.pl
+++ b/t/028_temp_block.pl
@@ -32,8 +32,7 @@ $node->append_conf('postgresql.conf',
 	"pg_stat_monitor.pgsm_normalized_query = on");
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/029_bucket_done.pl
+++ b/t/029_bucket_done.pl
@@ -28,8 +28,7 @@ $node->append_conf('postgresql.conf',
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'all'");
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # Create EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/030_histogram.pl
+++ b/t/030_histogram.pl
@@ -178,8 +178,7 @@ $node->append_conf('postgresql.conf',
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'all'");
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # Create functions required for testing
 my ($cmdret, $stdout, $stderr) =

--- a/t/031_query_stat.pl
+++ b/t/031_query_stat.pl
@@ -26,8 +26,7 @@ print $conf
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # CREATE EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/032_multiple_extensions.pl
+++ b/t/032_multiple_extensions.pl
@@ -33,8 +33,7 @@ print $conf "pg_stat_monitor.pgsm_normalized_query = on\n";
 close $conf;
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # Create PGSM extension
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/033_stats_since.pl
+++ b/t/033_stats_since.pl
@@ -34,8 +34,7 @@ $node->append_conf('postgresql.conf',
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'all'");
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # Create EXTENSION and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/034_update.pl
+++ b/t/034_update.pl
@@ -20,8 +20,7 @@ $node->append_conf('postgresql.conf',
 	"shared_preload_libraries = 'pg_stat_monitor'");
 
 # Start server
-my $rt_value = $node->start;
-is($rt_value, 1, "Start Server");
+$node->start;
 
 # Create EXTENSION version 2.0
 my ($cmdret, $stdout, $stderr) = $node->psql(


### PR DESCRIPTION
By default `PostgreSQL::Test::Cluster::start` bails out on failure so we do not need to check the return value.

PG-0

