### PR TITLE
Clean up setting of PostgreSQL config in TAP tests

### DIFF
--- a/t/001_settings_default.pl
+++ b/t/001_settings_default.pl
@@ -14,12 +14,9 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-close $conf;
+$node->append_conf('postgresql.conf',
+	"shared_preload_libraries = 'pg_stat_monitor'");
 
 # Start server
 my $rt_value = $node->start;

--- a/t/002_settings_pgsm_track_planning.pl
+++ b/t/002_settings_pgsm_track_planning.pl
@@ -15,13 +15,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_track_planning = on\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_track_planning = on
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -130,7 +129,7 @@ PGSM::append_to_file($stdout);
 
 # Disable pgsm_track_planning
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_track_planning = 'no'\n");
+	'pg_stat_monitor.pgsm_track_planning = off');
 $node->restart();
 
 # Dump output to out file

--- a/t/003_settings_pgms_extract_comments.pl
+++ b/t/003_settings_pgms_extract_comments.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_extract_comments = on\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_extract_comments = on
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -68,7 +67,7 @@ PGSM::append_to_file($stdout);
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_extract_comments = 'no'\n");
+	'pg_stat_monitor.pgsm_extract_comments = off');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/004_settings_pgsm_track.pl
+++ b/t/004_settings_pgsm_track.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_track = 'none'\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_track = 'none'
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -55,7 +54,7 @@ PGSM::append_to_file($stdout);
 	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'all'\n");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'all'");
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -72,7 +71,7 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Reset PGSM EXTENSION");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'top'\n");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'top'");
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/005_settings_pgsm_enable_query_plan.pl
+++ b/t/005_settings_pgsm_enable_query_plan.pl
@@ -15,13 +15,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_enable_query_plan = on\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_enable_query_plan = on
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -96,7 +95,7 @@ isnt($stdout, '', "Test: planid should not be empty");
 ok(length($stdout) > 0, 'Length of planid is > 0');
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_enable_query_plan = off\n");
+	'pg_stat_monitor.pgsm_enable_query_plan = off');
 $node->restart();
 
 # Run required commands/queries and dump output to out file.

--- a/t/006_settings_pgsm_overflow_target.pl
+++ b/t/006_settings_pgsm_overflow_target.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_enable_overflow = false\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_enable_overflow = off
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -50,7 +49,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_enable_overflow = true\n");
+	'pg_stat_monitor.pgsm_enable_overflow = on');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/007_settings_pgsm_query_shared_buffer.pl
+++ b/t/007_settings_pgsm_query_shared_buffer.pl
@@ -14,16 +14,14 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_bucket_time = 360000\n";
-print $conf
-  "pg_stat_monitor.pgsm_query_shared_buffer = 1\n";    # Min possible value
-print $conf "pg_stat_monitor.pgsm_normalized_query = on\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_bucket_time = 360000
+pg_stat_monitor.pgsm_query_shared_buffer = 1 # Min possible value
+pg_stat_monitor.pgsm_normalized_query = on
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -78,7 +76,7 @@ is($cmdret, 0, "SELECT XXX FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_query_shared_buffer = 2\n");
+	'pg_stat_monitor.pgsm_query_shared_buffer = 2');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -111,7 +109,7 @@ is($cmdret, 0, "SELECT XXX FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_query_shared_buffer = 20\n");
+	'pg_stat_monitor.pgsm_query_shared_buffer = 20');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -144,7 +142,7 @@ is($cmdret, 0, "SELECT XXX FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_query_shared_buffer = 2048\n");
+	'pg_stat_monitor.pgsm_query_shared_buffer = 2048');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/008_settings_pgsm_histogram_buckets.pl
+++ b/t/008_settings_pgsm_histogram_buckets.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_histogram_buckets = 10000\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_histogram_buckets = 10000
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -50,7 +49,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_buckets = 1000\n");
+	'pg_stat_monitor.pgsm_histogram_buckets = 1000');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -68,7 +67,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_buckets = 100\n");
+	'pg_stat_monitor.pgsm_histogram_buckets = 100');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -86,7 +85,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_buckets = 10\n");
+	'pg_stat_monitor.pgsm_histogram_buckets = 10');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -104,7 +103,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_buckets = 5\n");
+	'pg_stat_monitor.pgsm_histogram_buckets = 5');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -122,7 +121,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_buckets = 1\n");
+	'pg_stat_monitor.pgsm_histogram_buckets = 1');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/009_settings_pgsm_histogram_max.pl
+++ b/t/009_settings_pgsm_histogram_max.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_histogram_max = 1\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_histogram_max = 1
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -50,9 +49,9 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_max = 50\n");
+	'pg_stat_monitor.pgsm_histogram_max = 50');
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_buckets = 3\n");
+	'pg_stat_monitor.pgsm_histogram_buckets = 3');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -70,7 +69,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_max = 1000\n");
+	'pg_stat_monitor.pgsm_histogram_max = 1000');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/010_settings_pgsm_histogram_min.pl
+++ b/t/010_settings_pgsm_histogram_min.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_histogram_min = 1\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_histogram_min = 1
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -50,7 +49,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_min = 20\n");
+	'pg_stat_monitor.pgsm_histogram_min = 20');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -68,7 +67,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_min = 100\n");
+	'pg_stat_monitor.pgsm_histogram_min = 100');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/011_settings_pgsm_bucket_time.pl
+++ b/t/011_settings_pgsm_bucket_time.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_bucket_time = 10000\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_bucket_time = 10000
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -50,7 +49,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 1000\n");
+	'pg_stat_monitor.pgsm_bucket_time = 1000');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -68,7 +67,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 100\n");
+	'pg_stat_monitor.pgsm_bucket_time = 100');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -86,7 +85,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 60\n");
+	'pg_stat_monitor.pgsm_bucket_time = 60');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -103,8 +102,7 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 1\n");
+$node->append_conf('postgresql.conf', 'pg_stat_monitor.pgsm_bucket_time = 1');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -121,8 +119,7 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 0\n");
+$node->append_conf('postgresql.conf', 'pg_stat_monitor.pgsm_bucket_time = 0');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/012_settings_pgsm_max_buckets.pl
+++ b/t/012_settings_pgsm_max_buckets.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_max_buckets = 1\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_max_buckets = 1
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -49,8 +48,24 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_max_buckets = 2\n");
+$node->append_conf('postgresql.conf', 'pg_stat_monitor.pgsm_max_buckets = 2');
+$node->restart();
+
+($cmdret, $stdout, $stderr) = $node->psql(
+	'postgres',
+	'SELECT pg_stat_monitor_reset();',
+	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
+is($cmdret, 0, "Reset PGSM EXTENSION");
+PGSM::append_to_file($stdout);
+
+($cmdret, $stdout, $stderr) = $node->psql(
+	'postgres',
+	"SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name = 'pg_stat_monitor.pgsm_max_buckets';",
+	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
+is($cmdret, 0, "Print PGSM EXTENSION Settings");
+PGSM::append_to_file($stdout);
+
+$node->append_conf('postgresql.conf', 'pg_stat_monitor.pgsm_max_buckets = 5');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -68,7 +83,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_max_buckets = 5\n");
+	'pg_stat_monitor.pgsm_max_buckets = 10');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -86,7 +101,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_max_buckets = 10\n");
+	'pg_stat_monitor.pgsm_max_buckets = 11');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -103,26 +118,7 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_max_buckets = 11\n");
-$node->restart();
-
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT pg_stat_monitor_reset();',
-	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
-is($cmdret, 0, "Reset PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name = 'pg_stat_monitor.pgsm_max_buckets';",
-	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
-is($cmdret, 0, "Print PGSM EXTENSION Settings");
-PGSM::append_to_file($stdout);
-
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_max_buckets = 0\n");
+$node->append_conf('postgresql.conf', 'pg_stat_monitor.pgsm_max_buckets = 0');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/013_settings_pgsm_normalized_query.pl
+++ b/t/013_settings_pgsm_normalized_query.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_normalized_query = 'no'\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_normalized_query = off
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -87,7 +86,7 @@ is($cmdret, 0, "SELECT XXX FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_normalized_query = on\n");
+	'pg_stat_monitor.pgsm_normalized_query = on');
 $node->restart();
 
 # Run required commands/queries and dump output to out file.

--- a/t/014_settings_pgsm_track_utility.pl
+++ b/t/014_settings_pgsm_track_utility.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_track_utility = 'no'\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_track_utility = off
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -99,7 +98,7 @@ is($cmdret, 0, "SELECT XXX FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_track_utility = on\n");
+	'pg_stat_monitor.pgsm_track_utility = on');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/015_settings_pgsm_query_max_len.pl
+++ b/t/015_settings_pgsm_query_max_len.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_query_max_len = 10240\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_query_max_len = 10240
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -50,7 +49,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_query_max_len = 1024\n");
+	'pg_stat_monitor.pgsm_query_max_len = 1024');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -82,7 +81,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_query_max_len = 100\n");
+	'pg_stat_monitor.pgsm_query_max_len = 100');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -100,7 +99,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_query_max_len = 10\n");
+	'pg_stat_monitor.pgsm_query_max_len = 10');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -118,7 +117,7 @@ is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_query_max_len = 0\n");
+	'pg_stat_monitor.pgsm_query_max_len = 0');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/016_settings_pgsm_max.pl
+++ b/t/016_settings_pgsm_max.pl
@@ -14,13 +14,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_max = 2048\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_max = 2048
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -49,7 +48,7 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_max = 500\n");
+$node->append_conf('postgresql.conf', 'pg_stat_monitor.pgsm_max = 500');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -66,7 +65,7 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_max = 100\n");
+$node->append_conf('postgresql.conf', 'pg_stat_monitor.pgsm_max = 100');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -83,7 +82,7 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_max = 10\n")
+$node->append_conf('postgresql.conf', 'pg_stat_monitor.pgsm_max = 10')
   ;    # Min possible value
 $node->restart();
 
@@ -101,7 +100,7 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_max = 0\n");
+$node->append_conf('postgresql.conf', 'pg_stat_monitor.pgsm_max = 0');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/017_execution_stats.pl
+++ b/t/017_execution_stats.pl
@@ -15,12 +15,9 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-close $conf;
+$node->append_conf('postgresql.conf',
+	"shared_preload_libraries = 'pg_stat_monitor'");
 
 # Start server
 my $rt_value = $node->start;

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -14,12 +14,9 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-close $conf;
+$node->append_conf('postgresql.conf',
+	"shared_preload_libraries = 'pg_stat_monitor'");
 
 # Dictionary for expected PGSM columns names on different PG server versions
 my %pg_versions_pgsm_columns = (

--- a/t/019_insufficient_shared_space.pl
+++ b/t/019_insufficient_shared_space.pl
@@ -14,15 +14,14 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_enable_overflow = false\n";
-print $conf "pg_stat_monitor.pgsm_max = 1\n";
-print $conf "pg_stat_monitor.pgsm_query_shared_buffer = 1\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_enable_overflow = off
+pg_stat_monitor.pgsm_max = 1
+pg_stat_monitor.pgsm_query_shared_buffer = 1
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -81,7 +80,7 @@ is($cmdret, 0, "SELECT count(queryid) FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_enable_overflow = true\n");
+	'pg_stat_monitor.pgsm_enable_overflow = on');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/020_buffer_overflow.pl
+++ b/t/020_buffer_overflow.pl
@@ -14,17 +14,16 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_enable_overflow = false\n";
-print $conf "pg_stat_monitor.pgsm_bucket_time = 1\n";
-print $conf "pg_stat_monitor.pgsm_max_buckets = 2\n";
-print $conf "pg_stat_monitor.pgsm_max = 1\n";
-print $conf "pg_stat_monitor.pgsm_query_shared_buffer = 1\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_enable_overflow = off
+pg_stat_monitor.pgsm_bucket_time = 1
+pg_stat_monitor.pgsm_max_buckets = 2
+pg_stat_monitor.pgsm_max = 1
+pg_stat_monitor.pgsm_query_shared_buffer = 1
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -84,7 +83,7 @@ is($cmdret, 0, "SELECT count(queryid) FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_enable_overflow = true\n");
+	'pg_stat_monitor.pgsm_enable_overflow = on');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/021_misc_1.pl
+++ b/t/021_misc_1.pl
@@ -14,20 +14,19 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_enable_overflow = false\n";
-print $conf "pg_stat_monitor.pgsm_max = 1\n";
-print $conf "pg_stat_monitor.pgsm_query_shared_buffer = 1\n";
-print $conf "pg_stat_monitor.pgsm_query_max_len =10000\n";
-print $conf " pg_stat_monitor.pgsm_enable_query_plan = on\n";
-print $conf "pg_stat_monitor.pgsm_track_planning = on\n";
-print $conf "pg_stat_monitor.pgsm_track = 'all'\n";
-print $conf "pg_stat_monitor.pgsm_extract_comments = on\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_enable_overflow = off
+pg_stat_monitor.pgsm_max = 1
+pg_stat_monitor.pgsm_query_shared_buffer = 1
+pg_stat_monitor.pgsm_query_max_len = 10000
+pg_stat_monitor.pgsm_enable_query_plan = on
+pg_stat_monitor.pgsm_track_planning = on
+pg_stat_monitor.pgsm_track = 'all'
+pg_stat_monitor.pgsm_extract_comments = on
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -87,7 +86,7 @@ is($cmdret, 0, "SELECT count(queryid) FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
 $node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_enable_overflow = true\n");
+	'pg_stat_monitor.pgsm_enable_overflow = on');
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/022_misc_2.pl
+++ b/t/022_misc_2.pl
@@ -14,20 +14,19 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_enable_overflow = false\n";
-print $conf "pg_stat_monitor.pgsm_max = 1\n";
-print $conf "pg_stat_monitor.pgsm_query_shared_buffer = 1\n";
-print $conf "pg_stat_monitor.pgsm_query_max_len =10000\n";
-print $conf " pg_stat_monitor.pgsm_enable_query_plan = on\n";
-print $conf "pg_stat_monitor.pgsm_track_planning = on\n";
-print $conf "pg_stat_monitor.pgsm_track = 'top'\n";
-print $conf "pg_stat_monitor.pgsm_extract_comments = 'no'\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_enable_overflow = off
+pg_stat_monitor.pgsm_max = 1
+pg_stat_monitor.pgsm_query_shared_buffer = 1
+pg_stat_monitor.pgsm_query_max_len = 10000
+pg_stat_monitor.pgsm_enable_query_plan = on
+pg_stat_monitor.pgsm_track_planning = on
+pg_stat_monitor.pgsm_track = 'top'
+pg_stat_monitor.pgsm_extract_comments = off
+));
 
 # Start server
 my $rt_value = $node->start;
@@ -86,34 +85,24 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "SELECT count(queryid) FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_max = 100\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_query_max_len = 1024\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_track_utility = on\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_normalized_query = on\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_max_buckets = 10\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 60\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_min = 0\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_max = 100000\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_histogram_buckets = 10\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_query_shared_buffer = 20\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_enable_overflow = true\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_enable_query_plan = 'no'\n");
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'top'\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_extract_comments = 'no'\n");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_track_planning = 'no'\n");
+$node->append_conf(
+	'postgresql.conf', qq(
+pg_stat_monitor.pgsm_max = 100
+pg_stat_monitor.pgsm_query_max_len = 1024
+pg_stat_monitor.pgsm_track_utility = on
+pg_stat_monitor.pgsm_normalized_query = on
+pg_stat_monitor.pgsm_max_buckets = 10
+pg_stat_monitor.pgsm_bucket_time = 60
+pg_stat_monitor.pgsm_histogram_min = 0
+pg_stat_monitor.pgsm_histogram_max = 100000
+pg_stat_monitor.pgsm_histogram_buckets = 10
+pg_stat_monitor.pgsm_query_shared_buffer = 20
+pg_stat_monitor.pgsm_enable_overflow = on
+pg_stat_monitor.pgsm_enable_query_plan = off
+pg_stat_monitor.pgsm_track = 'top'
+pg_stat_monitor.pgsm_extract_comments = off
+pg_stat_monitor.pgsm_track_planning = off
+));
 $node->restart();
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/023_missing_queries.pl
+++ b/t/023_missing_queries.pl
@@ -44,13 +44,12 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-$node->append_conf('postgresql.conf',
-	"shared_preload_libraries = 'pg_stat_monitor'");
-# Set bucket duration to 14 seconds so tests don't take too long.
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 14");
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_bucket_time = 14
+));
 
 # Start server
 my $rt_value = $node->start;

--- a/t/024_check_timings.pl
+++ b/t/024_check_timings.pl
@@ -15,21 +15,17 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-$node->append_conf('postgresql.conf',
-	"shared_preload_libraries = 'pg_stat_statements,pg_stat_monitor'");
-# Set bucket duration to 3600 seconds so bucket doesn't change.
-$node->append_conf('postgresql.conf',
-	"pg_stat_statements.track_utility = off");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 36000");
-$node->append_conf('postgresql.conf', "track_io_timing = on");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_track_utility = off");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_normalized_query = on");
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor'
+# Set bucket duration to 36000 seconds so bucket doesn't change.
+pg_stat_monitor.pgsm_bucket_time = 36000
+track_io_timing = on
+pg_stat_monitor.pgsm_track_utility = off
+pg_stat_monitor.pgsm_normalized_query = on
+));
+
 # Start server
 my $rt_value = $node->start;
 is($rt_value, 1, "Start Server");

--- a/t/025_compare_pgss.pl
+++ b/t/025_compare_pgss.pl
@@ -15,21 +15,16 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-$node->append_conf('postgresql.conf',
-	"shared_preload_libraries = 'pg_stat_statements,pg_stat_monitor'");
-# Set bucket duration to 3600 seconds so bucket doesn't change.
-$node->append_conf('postgresql.conf',
-	"pg_stat_statements.track_utility = off");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 360000");
-$node->append_conf('postgresql.conf', "track_io_timing = on");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_track_utility = off");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_normalized_query = on");
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor'
+# Set bucket duration to 36000 seconds so bucket doesn't change.
+pg_stat_monitor.pgsm_bucket_time = 36000
+track_io_timing = on
+pg_stat_monitor.pgsm_track_utility = off
+pg_stat_monitor.pgsm_normalized_query = on
+));
 
 # Start server
 my $rt_value = $node->start;

--- a/t/026_shared_blocks.pl
+++ b/t/026_shared_blocks.pl
@@ -20,21 +20,16 @@ if ($PGSM::PG_MAJOR_VERSION <= 12)
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-$node->append_conf('postgresql.conf',
-	"shared_preload_libraries = 'pg_stat_statements,pg_stat_monitor'");
-# Set bucket duration to 3600 seconds so bucket doesn't change.
-$node->append_conf('postgresql.conf',
-	"pg_stat_statements.track_utility = off");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 360000");
-$node->append_conf('postgresql.conf', "track_io_timing = on");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_track_utility = off");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_normalized_query = on");
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor'
+# Set bucket duration to 360000 seconds so bucket doesn't change.
+pg_stat_monitor.pgsm_bucket_time = 360000
+track_io_timing = on
+pg_stat_monitor.pgsm_track_utility = off
+pg_stat_monitor.pgsm_normalized_query = on
+));
 
 # Start server
 my $rt_value = $node->start;

--- a/t/027_local_blocks.pl
+++ b/t/027_local_blocks.pl
@@ -15,19 +15,16 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-$node->append_conf('postgresql.conf',
-	"shared_preload_libraries = 'pg_stat_monitor'");
-# Set bucket duration to 3600 seconds so bucket doesn't change.
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 1800");
-$node->append_conf('postgresql.conf', "track_io_timing = on");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_track_utility = off");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_normalized_query = on");
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+# Set bucket duration to 1800 seconds so bucket doesn't change.
+pg_stat_monitor.pgsm_bucket_time = 1800
+track_io_timing = on
+pg_stat_monitor.pgsm_track_utility = off
+pg_stat_monitor.pgsm_normalized_query = on
+));
 
 # Start server
 my $rt_value = $node->start;

--- a/t/028_temp_block.pl
+++ b/t/028_temp_block.pl
@@ -15,21 +15,18 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-$node->append_conf('postgresql.conf',
-	"shared_preload_libraries = 'pg_stat_monitor'");
-# Set bucket duration to 3600 seconds so bucket doesn't change.
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 1800");
-$node->append_conf('postgresql.conf', "track_io_timing = on");
-$node->append_conf('postgresql.conf', "log_temp_files = 0");
-$node->append_conf('postgresql.conf', "work_mem = 64kB");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_track_utility = off");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_normalized_query = on");
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+# Set bucket duration to 1800 seconds so bucket doesn't change.
+pg_stat_monitor.pgsm_bucket_time = 1800
+track_io_timing = on
+log_temp_files = 0
+work_mem = 64kB
+pg_stat_monitor.pgsm_track_utility = off
+pg_stat_monitor.pgsm_normalized_query = on
+));
 
 # Start server
 my $rt_value = $node->start;

--- a/t/029_bucket_done.pl
+++ b/t/029_bucket_done.pl
@@ -14,18 +14,15 @@ PGSM::setup_files_dir(basename($0));
 
 # Create new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# Update postgresql.conf to include/load pg_stat_monitor library
-$node->append_conf('postgresql.conf',
-	"shared_preload_libraries = 'pg_stat_monitor'");
-
-# Set change postgresql.conf for this test case.
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_bucket_time = 3");
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_max_buckets = 3");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_normalized_query = yes");
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'all'");
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_bucket_time = 3
+pg_stat_monitor.pgsm_max_buckets = 3
+pg_stat_monitor.pgsm_normalized_query = on
+pg_stat_monitor.pgsm_track = 'all'
+));
 
 # Start server
 my $rt_value = $node->start;

--- a/t/030_histogram.pl
+++ b/t/030_histogram.pl
@@ -15,7 +15,6 @@ PGSM::setup_files_dir(basename($0));
 
 # Create new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
 my $run_pg_sleep_function_sql =
   "CREATE FUNCTION run_pg_sleep(loops int) RETURNS void AS \$\$
@@ -166,16 +165,13 @@ sub generate_histogram_with_configurations
 	PGSM::append_to_debug_file("===============End===============");
 }
 
-# Update postgresql.conf to include/load pg_stat_monitor library
-$node->append_conf('postgresql.conf',
-	"shared_preload_libraries = 'pg_stat_monitor'");
-
-# Set change postgresql.conf for this test case.
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_bucket_time = 36000");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_normalized_query = yes");
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'all'");
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_bucket_time = 36000
+pg_stat_monitor.pgsm_normalized_query = on
+pg_stat_monitor.pgsm_track = 'all'
+));
 
 # Start server
 my $rt_value = $node->start;

--- a/t/031_query_stat.pl
+++ b/t/031_query_stat.pl
@@ -14,16 +14,13 @@ PGSM::setup_files_dir(basename($0));
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_stat_monitor'\n";
-print $conf "pg_stat_monitor.pgsm_bucket_time = 2147483647\n"
-  ;    # Max value for this parameter
-print $conf
-  "pg_stat_monitor.pgsm_max_buckets = 20000\n"; # Max value for this parameter
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_bucket_time = 2147483647 # Max value for this parameter
+pg_stat_monitor.pgsm_max_buckets = 20000      # Max value for this parameter
+));
 
 # Start server
 my $rt_value = $node->start;

--- a/t/032_multiple_extensions.pl
+++ b/t/032_multiple_extensions.pl
@@ -22,15 +22,13 @@ if (index(lc($PG_VERSION_STRING), lc("percona")) == -1)
 
 # CREATE new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf
-  "shared_preload_libraries = 'pg_stat_monitor, pgaudit, set_user, pg_repack'\n";
-print $conf "pg_stat_monitor.pgsm_bucket_time = 360000\n";
-print $conf "pg_stat_monitor.pgsm_normalized_query = on\n";
-close $conf;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor, pgaudit, set_user, pg_repack'
+pg_stat_monitor.pgsm_bucket_time = 360000
+pg_stat_monitor.pgsm_normalized_query = on
+));
 
 # Start server
 my $rt_value = $node->start;

--- a/t/033_stats_since.pl
+++ b/t/033_stats_since.pl
@@ -20,18 +20,15 @@ if ($PGSM::PG_MAJOR_VERSION <= 16)
 
 # Create new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# Update postgresql.conf to include/load pg_stat_monitor library
-$node->append_conf('postgresql.conf',
-	"shared_preload_libraries = 'pg_stat_monitor'");
-
-# Set change postgresql.conf for this test case.
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_bucket_time = 1");
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_max_buckets = 3");
-$node->append_conf('postgresql.conf',
-	"pg_stat_monitor.pgsm_normalized_query = yes");
-$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_track = 'all'");
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pg_stat_monitor'
+pg_stat_monitor.pgsm_bucket_time = 1
+pg_stat_monitor.pgsm_max_buckets = 3
+pg_stat_monitor.pgsm_normalized_query = on
+pg_stat_monitor.pgsm_track = 'all'
+));
 
 # Start server
 my $rt_value = $node->start;

--- a/t/034_update.pl
+++ b/t/034_update.pl
@@ -13,9 +13,7 @@ PGSM::setup_files_dir(basename($0));
 
 # Create new PostgreSQL node and do initdb
 my $node = PGSM->pgsm_init_pg();
-my $pgdata = $node->data_dir;
 
-# Update postgresql.conf to include/load pg_stat_monitor library
 $node->append_conf('postgresql.conf',
 	"shared_preload_libraries = 'pg_stat_monitor'");
 


### PR DESCRIPTION
Some of our tests wrote directly to the config file while others used the `append_conf()` helper. Consistently use the helper, group multiple GUCs into one call and remove unnecessary newlines.

Additionally we standardize boolean GUCs to on/off and fix a couple of comments.

PG-0
