### PR TITLE
Do not drop extension at end of TAP tests

### DIFF
--- a/t/001_settings_default.pl
+++ b/t/001_settings_default.pl
@@ -61,21 +61,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT pg_stat_monitor_reset();',
-	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
-is($cmdret, 0, "Reset PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/002_settings_pgsm_track_planning.pl
+++ b/t/002_settings_pgsm_track_planning.pl
@@ -202,27 +202,10 @@ is($stdout, '0', "Compare: mean_plan_time is 0).");
 trim($stdout);
 is($stdout, '0', "Compare: stddev_plan_time is 0).");
 
-# Dump output to out file
 ($cmdret, $stdout, $stderr) = $node->psql(
 	'postgres',
 	'SELECT substr(query, 0, 100) AS query, calls, total_plan_time, min_plan_time, max_plan_time, mean_plan_time, stddev_plan_time FROM pg_stat_monitor ORDER BY query;',
 	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
-PGSM::append_to_file($stdout);
-
-# Dump output to out file
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT pg_stat_monitor_reset();',
-	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
-is($cmdret, 0, "Reset PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
 PGSM::append_to_file($stdout);
 
 # Stop the server

--- a/t/003_settings_pgms_extract_comments.pl
+++ b/t/003_settings_pgms_extract_comments.pl
@@ -96,14 +96,6 @@ PGSM::append_to_file($stdout);
 	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/004_settings_pgsm_track.pl
+++ b/t/004_settings_pgsm_track.pl
@@ -81,14 +81,6 @@ $node->restart();
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/005_settings_pgsm_enable_query_plan.pl
+++ b/t/005_settings_pgsm_enable_query_plan.pl
@@ -164,14 +164,6 @@ trim($stdout);
 is($stdout, '', "Test: planid should be empty");
 is(length($stdout), 0, 'Length of planid is 0');
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/006_settings_pgsm_overflow_target.pl
+++ b/t/006_settings_pgsm_overflow_target.pl
@@ -66,14 +66,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/007_settings_pgsm_query_shared_buffer.pl
+++ b/t/007_settings_pgsm_query_shared_buffer.pl
@@ -175,14 +175,6 @@ is($cmdret, 0, "Run pgbench");
 is($cmdret, 0, "SELECT XXX FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/008_settings_pgsm_histogram_buckets.pl
+++ b/t/008_settings_pgsm_histogram_buckets.pl
@@ -138,14 +138,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/009_settings_pgsm_histogram_max.pl
+++ b/t/009_settings_pgsm_histogram_max.pl
@@ -86,14 +86,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/010_settings_pgsm_histogram_min.pl
+++ b/t/010_settings_pgsm_histogram_min.pl
@@ -84,14 +84,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/011_settings_pgsm_bucket_time.pl
+++ b/t/011_settings_pgsm_bucket_time.pl
@@ -138,14 +138,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/012_settings_pgsm_max_buckets.pl
+++ b/t/012_settings_pgsm_max_buckets.pl
@@ -138,14 +138,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/013_settings_pgsm_normalized_query.pl
+++ b/t/013_settings_pgsm_normalized_query.pl
@@ -147,14 +147,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "SELECT XXX FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/014_settings_pgsm_track_utility.pl
+++ b/t/014_settings_pgsm_track_utility.pl
@@ -164,14 +164,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "SELECT XXX FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/015_settings_pgsm_query_max_len.pl
+++ b/t/015_settings_pgsm_query_max_len.pl
@@ -134,14 +134,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/016_settings_pgsm_max.pl
+++ b/t/016_settings_pgsm_max.pl
@@ -117,14 +117,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/017_execution_stats.pl
+++ b/t/017_execution_stats.pl
@@ -141,14 +141,6 @@ PGSM::append_to_debug_file($stdout);
 is($cmdret, 0, "Reset PGSM EXTENSION");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -132,14 +132,6 @@ is($stdout, $pg_versions_pgsm_columns{$PGSM::PG_MAJOR_VERSION},
 is($cmdret, 0, "SELECT statement against expected column names");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/019_insufficient_shared_space.pl
+++ b/t/019_insufficient_shared_space.pl
@@ -119,14 +119,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "SELECT count(queryid) FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/020_buffer_overflow.pl
+++ b/t/020_buffer_overflow.pl
@@ -122,14 +122,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "SELECT count(queryid) FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/021_misc_1.pl
+++ b/t/021_misc_1.pl
@@ -125,14 +125,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "SELECT count(queryid) FROM pg_stat_monitor");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/022_misc_2.pl
+++ b/t/022_misc_2.pl
@@ -158,14 +158,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/024_check_timings.pl
+++ b/t/024_check_timings.pl
@@ -314,14 +314,6 @@ is($stdout, 't', "Check: cpu_user_time should not be 0.");
 trim($stdout);
 is($stdout, 't', "Check: cpu_sys_time should not be 0.");
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/025_compare_pgss.pl
+++ b/t/025_compare_pgss.pl
@@ -558,14 +558,6 @@ if ($PGSM::PG_MAJOR_VERSION >= 18)
 	is($stdout, 't', "Compare: parallel_workers_launched are equal.");
 }
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/026_shared_blocks.pl
+++ b/t/026_shared_blocks.pl
@@ -256,14 +256,6 @@ is($stdout, 't', "Check: ${col_shared_blk_read_time} should not be 0.");
 trim($stdout);
 is($stdout, 't', "Check: ${col_shared_blk_write_time} should not be 0.");
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/027_local_blocks.pl
+++ b/t/027_local_blocks.pl
@@ -120,14 +120,6 @@ is($stdout, 't', "Check: local_blks_hit should not be 0.");
 #     is($stdout,'t',"Check: local_blk_read_time should not be 0.");
 # }
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/028_temp_block.pl
+++ b/t/028_temp_block.pl
@@ -143,14 +143,6 @@ if ($PGSM::PG_MAJOR_VERSION >= 15)
 	is($stdout, 't', "Check: temp_blk_write_time should not be 0.");
 }
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/029_bucket_done.pl
+++ b/t/029_bucket_done.pl
@@ -98,14 +98,6 @@ PGSM::append_to_debug_file($stdout);
 is($cmdret, 0, "Print what is in pg_stat_monitor view");
 PGSM::append_to_debug_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_debug_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/030_histogram.pl
+++ b/t/030_histogram.pl
@@ -263,14 +263,6 @@ generate_histogram_with_configurations(0, 49999999, 20, 2,
 	"{2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}",
 	21, 0, 11);
 
-# Drop extension
-$stdout = $node->safe_psql(
-	'postgres',
-	'Drop extension pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "Drop PGSM  Extension");
-PGSM::append_to_debug_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/031_query_stat.pl
+++ b/t/031_query_stat.pl
@@ -58,14 +58,6 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Check query stats");
 PGSM::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/032_multiple_extensions.pl
+++ b/t/032_multiple_extensions.pl
@@ -145,14 +145,6 @@ is($cmdret, 0, "Run pgbench");
 is($cmdret, 0, "SELECT XXX FROM pg_stat_monitor");
 PGSM::append_to_debug_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_debug_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/033_stats_since.pl
+++ b/t/033_stats_since.pl
@@ -106,14 +106,6 @@ trim($stdout);
 is($stdout, 0, "Check: minmax_stats_since always match stats_since");
 PGSM::append_to_debug_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_debug_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/034_update.pl
+++ b/t/034_update.pl
@@ -54,14 +54,6 @@ PGSM::append_to_debug_file($stdout);
 is($cmdret, 0, "Check PGSM returns some results for version 2.1");
 PGSM::append_to_debug_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql(
-	'postgres',
-	'DROP EXTENSION pg_stat_monitor;',
-	extra_params => ['-a']);
-is($cmdret, 0, "DROP PGSM EXTENSION");
-PGSM::append_to_debug_file($stdout);
-
 # Stop the server
 $node->stop;
 

--- a/t/expected/001_settings_default.out
+++ b/t/expected/001_settings_default.out
@@ -56,10 +56,3 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default |         |            |                | on       | on        | f
 (17 rows)
 
-SELECT pg_stat_monitor_reset();
- pg_stat_monitor_reset 
------------------------
- 
-(1 row)
-
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/003_settings_pgms_extract_comments.out
+++ b/t/expected/003_settings_pgms_extract_comments.out
@@ -58,4 +58,3 @@ SELECT query, comments FROM pg_stat_monitor ORDER BY query COLLATE "C";
  SELECT pg_stat_monitor_reset()                                                                                                                                                               | 
 (3 rows)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/004_settings_pgsm_track.out
+++ b/t/expected/004_settings_pgsm_track.out
@@ -35,4 +35,3 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_track | top     |      | user    | enum    | configuration file |         |         | {none,top,all} | top      | top       | f
 (1 row)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/005_settings_pgsm_enable_query_plan.out
+++ b/t/expected/005_settings_pgsm_enable_query_plan.out
@@ -77,4 +77,3 @@ SELECT substr(query, 0, 50) AS query, calls, query_plan FROM pg_stat_monitor ORD
  UPDATE tbl_0 SET value_0 = 1681692777             |     1 | 
 (6 rows)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/006_settings_pgsm_overflow_target.out
+++ b/t/expected/006_settings_pgsm_overflow_target.out
@@ -23,4 +23,3 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_enable_overflow | on      |      | postmaster | bool    | configuration file |         |         |          | on       | on        | f
 (1 row)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/007_settings_pgsm_query_shared_buffer.out
+++ b/t/expected/007_settings_pgsm_query_shared_buffer.out
@@ -148,4 +148,3 @@ SELECT datname, substr(query, 0, 150) AS query, sum(calls) AS calls FROM pg_stat
  example | insert into pgbench_tellers(tid,bid,tbalance) values ($1,$2,$3)                                               |   100
 (20 rows)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/007_settings_pgsm_query_shared_buffer.out.15
+++ b/t/expected/007_settings_pgsm_query_shared_buffer.out.15
@@ -148,4 +148,3 @@ SELECT datname, substr(query, 0, 150) AS query, sum(calls) AS calls FROM pg_stat
  example | insert into pgbench_tellers(tid,bid,tbalance) values ($1,$2,$3)                                               |   100
 (20 rows)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/007_settings_pgsm_query_shared_buffer.out.16
+++ b/t/expected/007_settings_pgsm_query_shared_buffer.out.16
@@ -148,4 +148,3 @@ SELECT datname, substr(query, 0, 150) AS query, sum(calls) AS calls FROM pg_stat
  example | select o.n, p.partstrat, pg_catalog.count(i.inhparent) from pg_catalog.pg_class as c join pg_catalog.pg_namespace as n on (n.oid = c.relnamespace) cr |     1
 (20 rows)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/007_settings_pgsm_query_shared_buffer.out.17
+++ b/t/expected/007_settings_pgsm_query_shared_buffer.out.17
@@ -148,4 +148,3 @@ SELECT datname, substr(query, 0, 150) AS query, sum(calls) AS calls FROM pg_stat
  example | select o.n, p.partstrat, pg_catalog.count(i.inhparent) from pg_catalog.pg_class as c join pg_catalog.pg_namespace as n on (n.oid = c.relnamespace) cr |     1
 (20 rows)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/007_settings_pgsm_query_shared_buffer.out.18
+++ b/t/expected/007_settings_pgsm_query_shared_buffer.out.18
@@ -148,4 +148,3 @@ SELECT datname, substr(query, 0, 150) AS query, sum(calls) AS calls FROM pg_stat
  example | select count(*) from pgbench_branches                                                                         |     1
 (20 rows)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/008_settings_pgsm_histogram_buckets.out
+++ b/t/expected/008_settings_pgsm_histogram_buckets.out
@@ -71,4 +71,3 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_histogram_buckets | 20      |      | postmaster | integer | default | 2       | 50      |          | 20       | 20        | f
 (1 row)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/009_settings_pgsm_histogram_max.out
+++ b/t/expected/009_settings_pgsm_histogram_max.out
@@ -35,4 +35,3 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_histogram_max | 1000    | ms   | postmaster | real    | configuration file | 10      | 5e+07   |          | 100000   | 1000      | f
 (1 row)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/010_settings_pgsm_histogram_min.out
+++ b/t/expected/010_settings_pgsm_histogram_min.out
@@ -35,4 +35,3 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_histogram_min | 100     | ms   | postmaster | real    | configuration file | 0       | 5e+07   |          | 1        | 100       | f
 (1 row)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/011_settings_pgsm_bucket_time.out
+++ b/t/expected/011_settings_pgsm_bucket_time.out
@@ -71,4 +71,3 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_bucket_time | 60      | s    | postmaster | integer | default | 1       | 2147483647 |          | 60       | 60        | f
 (1 row)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/012_settings_pgsm_max_buckets.out
+++ b/t/expected/012_settings_pgsm_max_buckets.out
@@ -71,4 +71,3 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_max_buckets | 10      |      | postmaster | integer | default | 1       | 20000   |          | 10       | 10        | f
 (1 row)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/013_settings_pgsm_normalized_query.out
+++ b/t/expected/013_settings_pgsm_normalized_query.out
@@ -76,4 +76,3 @@ SELECT datname, substr(query, 0, 100) AS query, calls FROM pg_stat_monitor ORDER
  postgres | UPDATE tbl_0 SET value_0 = $1                                                                       |     1
 (6 rows)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/014_settings_pgsm_track_utility.out
+++ b/t/expected/014_settings_pgsm_track_utility.out
@@ -80,4 +80,3 @@ SELECT datname, substr(query, 0, 100) AS query, calls FROM pg_stat_monitor ORDER
  postgres | UPDATE tbl_0 SET value_0 = 1681692777                                                               |     1
 (8 rows)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/015_settings_pgsm_query_max_len.out
+++ b/t/expected/015_settings_pgsm_query_max_len.out
@@ -72,4 +72,3 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_query_max_len | 2048    | B    | postmaster | integer | default | 1024    | 2147483647 |          | 2048     | 2048      | f
 (1 row)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/016_settings_pgsm_max.out
+++ b/t/expected/016_settings_pgsm_max.out
@@ -59,4 +59,3 @@ SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals
  pg_stat_monitor.pgsm_max | 256     | MB   | postmaster | integer | default | 10      | 10240   |          | 256      | 256       | f
 (1 row)
 
-DROP EXTENSION pg_stat_monitor;

--- a/t/expected/031_query_stat.out
+++ b/t/expected/031_query_stat.out
@@ -18,4 +18,3 @@ SELECT query, comments FROM pg_stat_monitor ORDER BY query COLLATE "C";
  SELECT pg_stat_monitor_reset() | 
 (2 rows)
 
-DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
It is just a waste of lines of code and CPU cycles to drop the extension at the end of TAP tests since we will delete the whole cluster a bit later anyway. And the pg_regress tests exercise the code path for dropping the extension anyway.

We also remove a couple of cases where we pointlessly reset the statics at the end too.

PG-0