### PR TITLE
Move creation of memory context to _PG_init()

### DIFF
--- a/src/hash_query.c
+++ b/src/hash_query.c
@@ -26,7 +26,6 @@ typedef struct pgsmLocalState
 	dsa_area   *dsa;			/* local dsa area for backend attached to the
 								 * dsa area created by postmaster at startup. */
 	HTAB	   *shared_hash;
-	MemoryContext pgsm_mem_cxt;
 } pgsmLocalState;
 
 static pgsmLocalState pgsmStateLocal;
@@ -122,9 +121,6 @@ pgsm_startup(void)
 	LWLockRelease(AddinShmemInitLock);
 
 	pgsmStateLocal.shared_pgsmState = pgsm;
-	pgsmStateLocal.pgsm_mem_cxt = AllocSetContextCreate(TopMemoryContext,
-														"pg_stat_monitor local store",
-														ALLOCSET_DEFAULT_SIZES);
 
 	/* Reset in case this is a restart within the postmaster */
 	pgsmStateLocal.dsa = NULL;
@@ -175,12 +171,6 @@ pgsm_attach_shmem(void)
 	dsa_pin_mapping(pgsmStateLocal.dsa);
 	pgsmStateLocal.shared_hash = pgsmStateLocal.shared_pgsmState->hash_handle;
 	MemoryContextSwitchTo(oldcontext);
-}
-
-MemoryContext
-GetPgsmMemoryContext(void)
-{
-	return pgsmStateLocal.pgsm_mem_cxt;
 }
 
 dsa_area *

--- a/src/hash_query.h
+++ b/src/hash_query.h
@@ -242,7 +242,6 @@ typedef struct pgsmSharedState
 
 /* hash_query.c */
 void		pgsm_startup(void);
-MemoryContext GetPgsmMemoryContext(void);
 dsa_area   *get_dsa_area_for_query_text(void);
 HTAB	   *get_pgsmHash(void);
 bool		IsSystemOOM(void);

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -98,6 +98,8 @@ typedef enum pgsmStoreKind
 /*---- Initialization Function Declarations ----*/
 void		_PG_init(void);
 
+static MemoryContext PgsmMemoryContext;
+
 /* Current nesting depth of planner/ExecutorRun/ProcessUtility calls */
 static int	nesting_level = 0;
 static int	max_nesting_level;
@@ -337,6 +339,10 @@ _PG_init(void)
 	max_nesting_level = max_stack_depth;
 
 	oldctx = MemoryContextSwitchTo(TopMemoryContext);
+
+	PgsmMemoryContext = AllocSetContextCreate(TopMemoryContext,
+											  "pg_stat_monitor local store",
+											  ALLOCSET_DEFAULT_SIZES);
 
 	nested_queryids = palloc_array(int64, max_nesting_level);
 	nested_query_txts = palloc0_array(char *, max_nesting_level);
@@ -1527,7 +1533,7 @@ static void
 pgsm_add_to_list(pgsmEntry *entry, const char *query_text, int query_len)
 {
 	/* Switch to pgsm memory context */
-	MemoryContext oldctx = MemoryContextSwitchTo(GetPgsmMemoryContext());
+	MemoryContext oldctx = MemoryContextSwitchTo(PgsmMemoryContext);
 
 	entry->query_text.query_pointer = pnstrdup(query_text, query_len);
 	lentries = lappend(lentries, entry);
@@ -1614,7 +1620,7 @@ static void
 pgsm_cleanup_callback(void *arg)
 {
 	/* Reset the memory context holding the list */
-	MemoryContextReset(GetPgsmMemoryContext());
+	MemoryContextReset(PgsmMemoryContext);
 
 	lentries = NIL;
 	callback_setup = false;
@@ -1631,7 +1637,7 @@ pgsm_create_hash_entry(int64 queryid, const PlanInfo *plan_info)
 	MemoryContext oldctx;
 
 	/* Create an entry in the pgsm memory context */
-	oldctx = MemoryContextSwitchTo(GetPgsmMemoryContext());
+	oldctx = MemoryContextSwitchTo(PgsmMemoryContext);
 	entry = palloc0_object(pgsmEntry);
 
 	/*


### PR DESCRIPTION
As the memory context has not connection to the shared memory setting it up in `pgsm_startup()` only confused to code.

PG-0

