### PR TITLE
Do not pass default params to psql() in TAP tests

### DIFF
--- a/t/002_settings_pgsm_track_planning.pl
+++ b/t/002_settings_pgsm_track_planning.pl
@@ -63,59 +63,50 @@ is($cmdret, 0, "SELECT FROM PGSM view");
 PGSM::append_to_file($stdout);
 
 # Test: total_plan_time is not 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT total_plan_time FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT total_plan_time FROM pg_stat_monitor WHERE calls = 2;');
 trim($stdout);
 isnt($stdout, '0', "Compare: total_plan_time is not 0).");
 
 # Test: min_plan_time is not 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT min_plan_time FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT min_plan_time FROM pg_stat_monitor WHERE calls = 2;');
 trim($stdout);
 isnt($stdout, '0', "Compare: min_plan_time is not 0).");
 
 # Test: max_plan_time is not 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT max_plan_time FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT max_plan_time FROM pg_stat_monitor WHERE calls = 2;');
 trim($stdout);
 isnt($stdout, '0', "Compare: max_plan_time is not 0).");
 
 # Test: mean_plan_time is not 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT mean_plan_time FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT mean_plan_time FROM pg_stat_monitor WHERE calls = 2;');
 trim($stdout);
 isnt($stdout, '0', "Compare: mean_plan_time is not 0).");
 
 # Test: stddev_plan_time is not 0
-#($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT stddev_plan_time FROM pg_stat_monitor WHERE calls = 2;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+#($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT stddev_plan_time FROM pg_stat_monitor WHERE calls = 2;');
 #trim($stdout);
 #isnt($stdout, '0', "Compare: stddev_plan_time is not 0).");
 
 # Test: total_plan_time  =  min_plan_time + max_plan_time
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT round(total_plan_time::numeric, 3) = round(min_plan_time::numeric + max_plan_time::numeric, 3) FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT round(total_plan_time::numeric, 3) = round(min_plan_time::numeric + max_plan_time::numeric, 3) FROM pg_stat_monitor WHERE calls = 2;'
+);
 trim($stdout);
 is($stdout, 't',
 	"Compare: round(total_plan_time::numeric, 3) = round(min_plan_time::numeric + max_plan_time::numeric, 3)."
 );
 
 # Test: mean_plan_time = total_plan_time/2
-#($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT round(mean_plan_time::numeric, 3) = round((total_plan_time / 2)::numeric, 3) FROM pg_stat_monitor WHERE calls = 2;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+#($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT round(mean_plan_time::numeric, 3) = round((total_plan_time / 2)::numeric, 3) FROM pg_stat_monitor WHERE calls = 2;');
 #trim($stdout);
 #is($stdout,'t',"Test mean_plan_time: round(mean_plan_time::numeric, 3) = round((total_plan_time / 2)::numeric, 3).");
 
 # Test: stddev_plan_time = mean_plan_time - min_plan_time
-#($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT round(stddev_plan_time::numeric, 3) = round(mean_plan_time::numeric - min_plan_time::numeric, 3) FROM pg_stat_monitor WHERE calls = 2;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+#($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT round(stddev_plan_time::numeric, 3) = round(mean_plan_time::numeric - min_plan_time::numeric, 3) FROM pg_stat_monitor WHERE calls = 2;');
 #trim($stdout);
 #is($stdout,'t',"Compare mean_plan_time: round(stddev_plan_time::numeric, 3) = round(mean_plan_time::numeric - min_plan_time::numeric, 3).");
 
@@ -162,42 +153,32 @@ is($cmdret, 0, "SELECT FROM PGSM view");
 PGSM::append_to_file($stdout);
 
 # Test: total_plan_time is 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT total_plan_time FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT total_plan_time FROM pg_stat_monitor WHERE calls = 2;');
 trim($stdout);
 is($stdout, '0', "Compare: total_plan_time is 0).");
 
 # Test: min_plan_time is 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT min_plan_time FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT min_plan_time FROM pg_stat_monitor WHERE calls = 2;');
 trim($stdout);
 is($stdout, '0', "Compare: min_plan_time is 0).");
 
 # Test: max_plan_time is 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT max_plan_time FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT max_plan_time FROM pg_stat_monitor WHERE calls = 2;');
 trim($stdout);
 is($stdout, '0', "Compare: max_plan_time is 0).");
 
 # Test: mean_plan_time is 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT mean_plan_time FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT mean_plan_time FROM pg_stat_monitor WHERE calls = 2;');
 trim($stdout);
 is($stdout, '0', "Compare: mean_plan_time is 0).");
 
 # Test: stddev_plan_time is 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT stddev_plan_time FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT stddev_plan_time FROM pg_stat_monitor WHERE calls = 2;');
 trim($stdout);
 is($stdout, '0', "Compare: stddev_plan_time is 0).");
 

--- a/t/005_settings_pgsm_enable_query_plan.pl
+++ b/t/005_settings_pgsm_enable_query_plan.pl
@@ -85,10 +85,8 @@ PGSM::append_to_file($stdout);
 PGSM::append_to_file($stdout);
 
 # Test: planid is not 0 or empty
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT planid FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT planid FROM pg_stat_monitor WHERE calls = 2;');
 trim($stdout);
 isnt($stdout, '', "Test: planid should not be empty");
 ok(length($stdout) > 0, 'Length of planid is > 0');
@@ -155,10 +153,8 @@ PGSM::append_to_file($stdout);
 PGSM::append_to_file($stdout);
 
 # Test: planid is empty
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT planid FROM pg_stat_monitor WHERE calls = 2;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT planid FROM pg_stat_monitor WHERE calls = 2;');
 trim($stdout);
 is($stdout, '', "Test: planid should be empty");
 is(length($stdout), 0, 'Length of planid is 0');

--- a/t/017_execution_stats.pl
+++ b/t/017_execution_stats.pl
@@ -67,59 +67,50 @@ is($cmdret, 0, "SELECT FROM PGSM view");
 PGSM::append_to_file($stdout);
 
 # Test: ${col_total_time} is not 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT ${col_total_time} FROM pg_stat_monitor WHERE calls = 2;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT ${col_total_time} FROM pg_stat_monitor WHERE calls = 2;");
 trim($stdout);
 isnt($stdout, '0', "Compare: ${col_total_time} is not 0).");
 
 # Test: ${col_min_time} is not 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT ${col_min_time} FROM pg_stat_monitor WHERE calls = 2;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT ${col_min_time} FROM pg_stat_monitor WHERE calls = 2;");
 trim($stdout);
 isnt($stdout, '0', "Compare: ${col_min_time} is not 0).");
 
 # Test: ${col_max_time} is not 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT ${col_max_time} FROM pg_stat_monitor WHERE calls = 2;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT ${col_max_time} FROM pg_stat_monitor WHERE calls = 2;");
 trim($stdout);
 isnt($stdout, '0', "Compare: ${col_max_time} is not 0).");
 
 # Test: ${col_mean_time} is not 0
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT ${col_mean_time} FROM pg_stat_monitor WHERE calls = 2;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT ${col_mean_time} FROM pg_stat_monitor WHERE calls = 2;");
 trim($stdout);
 isnt($stdout, '0', "Compare: ${col_mean_time} is not 0).");
 
 # Test: ${col_stddev_time} is not 0
-#($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT ${col_stddev_time} FROM pg_stat_monitor WHERE calls = 2;", extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+#($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT ${col_stddev_time} FROM pg_stat_monitor WHERE calls = 2;");
 #trim($stdout);
 #isnt($stdout, '0', "Test: ${col_stddev_time} should not be 0).");
 
 # Test: ${col_total_time}  =  ${col_min_time} + ${col_max_time}
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT (round(${col_total_time}::numeric, 3) = round(${col_min_time}::numeric + ${col_max_time}::numeric, 3)) FROM pg_stat_monitor WHERE calls = 2;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT (round(${col_total_time}::numeric, 3) = round(${col_min_time}::numeric + ${col_max_time}::numeric, 3)) FROM pg_stat_monitor WHERE calls = 2;"
+);
 trim($stdout);
 is($stdout, 't',
 	"Compare: (round(${col_total_time}::numeric, 3) = round(${col_min_time}::numeric + ${col_max_time}::numeric, 3))."
 );
 
 # Test: ${col_mean_time} = ${col_total_time}/2
-#($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT (round(${col_mean_time}::numeric, 3) = round((${col_total_time} / 2)::numeric, 3)) FROM pg_stat_monitor WHERE calls = 2;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+#($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT (round(${col_mean_time}::numeric, 3) = round((${col_total_time} / 2)::numeric, 3)) FROM pg_stat_monitor WHERE calls = 2;');
 #trim($stdout);
 #is($stdout,'t',"Compare ${col_mean_time}: round(${col_mean_time}::numeric, 3) = round((${col_total_time} / 2)::numeric, 3).");
 
 # Test: ${col_stddev_time} = ${col_mean_time} - ${col_min_time}
-#($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT round(${col_stddev_time}::numeric, 3) = round(${col_mean_time}::numeric - ${col_min_time}::numeric, 3) FROM pg_stat_monitor WHERE calls = 2;', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+#($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT round(${col_stddev_time}::numeric, 3) = round(${col_mean_time}::numeric - ${col_min_time}::numeric, 3) FROM pg_stat_monitor WHERE calls = 2;');
 #trim($stdout);
 #is($stdout,'t',"Compare ${col_mean_time}: round(${col_stddev_time}::numeric, 3) = round(${col_mean_time}::numeric - ${col_min_time}::numeric, 3)).");
 

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -110,7 +110,7 @@ PGSM::append_to_file($stdout . "\n");
 ($cmdret, $stdout, $stderr) = $node->psql(
 	'postgres',
 	"SELECT column_name FROM information_schema.columns WHERE table_name = 'pg_stat_monitor' ORDER BY column_name;",
-	extra_params => [ '-A', '-R,', '-Ptuples_only=on' ]);
+	extra_params => ['-R,']);
 is($cmdret, 0,
 	"Get columns names in PGSM installation for PG version $PGSM::PG_MAJOR_VERSION"
 );

--- a/t/024_check_timings.pl
+++ b/t/024_check_timings.pl
@@ -111,202 +111,174 @@ PGSM::append_to_debug_file($stdout);
 PGSM::append_to_debug_file($stdout);
 
 # Compare values for query 'DELETE FROM pgbench_accounts WHERE $1 = $2'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.total_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.total_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: total_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.min_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.min_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: min_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.max_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.max_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: max_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.mean_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.mean_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: mean_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.stddev_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.stddev_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: stddev_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.cpu_user_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.cpu_user_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: cpu_user_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.cpu_sys_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.cpu_sys_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: cpu_sys_time should not be 0.");
 
 # Compare values for query 'INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.total_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.total_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: total_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.min_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.min_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: min_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.max_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.max_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: max_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.mean_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.mean_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: mean_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.stddev_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.stddev_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: stddev_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.cpu_user_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.cpu_user_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: cpu_user_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.cpu_sys_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.cpu_sys_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: cpu_sys_time should not be 0.");
 
 # Compare values for query 'SELECT abalance FROM pgbench_accounts WHERE aid = $1'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.total_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.total_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: total_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.min_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.min_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: min_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.max_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.max_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: max_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.mean_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.mean_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: mean_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.stddev_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.stddev_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: stddev_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.cpu_user_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.cpu_user_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: cpu_user_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.cpu_sys_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.cpu_sys_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: cpu_sys_time should not be 0.");
 
 # Compare values for query 'UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.total_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.total_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: total_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.min_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.min_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: min_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.max_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.max_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: max_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.mean_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.mean_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: mean_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.stddev_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.stddev_exec_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: stddev_exec_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.cpu_user_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.cpu_user_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: cpu_user_time should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.cpu_sys_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.cpu_sys_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: cpu_sys_time should not be 0.");
 

--- a/t/025_compare_pgss.pl
+++ b/t/025_compare_pgss.pl
@@ -139,416 +139,359 @@ PGSM::append_to_debug_file($stdout);
 PGSM::append_to_debug_file($stdout);
 
 # Compare values for query 'DELETE FROM pgbench_accounts WHERE $1 = $2'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.calls) = sum(pgss.calls) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.calls) = sum(pgss.calls) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: calls are equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.rows) = sum(pgss.rows) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.rows) = sum(pgss.rows) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: rows are equal).");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.total_exec_time) = sum(round(pgss.total_exec_time::numeric, 4)) OR sum(pgss.total_exec_time::numeric) % sum(pgsm.total_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.total_exec_time) = sum(round(pgss.total_exec_time::numeric, 4)) OR sum(pgss.total_exec_time::numeric) % sum(pgsm.total_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: total_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.min_exec_time) = sum(round(pgss.min_exec_time::numeric, 4)) OR sum(pgss.min_exec_time::numeric) % sum(pgsm.min_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.min_exec_time) = sum(round(pgss.min_exec_time::numeric, 4)) OR sum(pgss.min_exec_time::numeric) % sum(pgsm.min_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: min_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.max_exec_time) = sum(round(pgss.max_exec_time::numeric, 4)) OR sum(pgss.max_exec_time::numeric) % sum(pgsm.max_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.max_exec_time) = sum(round(pgss.max_exec_time::numeric, 4)) OR sum(pgss.max_exec_time::numeric) % sum(pgsm.max_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: max_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.mean_exec_time) = sum(round(pgss.mean_exec_time::numeric, 4)) OR sum(pgss.mean_exec_time::numeric) % sum(pgsm.mean_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.mean_exec_time) = sum(round(pgss.mean_exec_time::numeric, 4)) OR sum(pgss.mean_exec_time::numeric) % sum(pgsm.mean_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: mean_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.stddev_exec_time) = sum(round(pgss.stddev_exec_time::numeric, 4)) OR sum(pgss.stddev_exec_time::numeric) % sum(pgsm.stddev_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.stddev_exec_time) = sum(round(pgss.stddev_exec_time::numeric, 4)) OR sum(pgss.stddev_exec_time::numeric) % sum(pgsm.stddev_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: stddev_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_records) = sum(pgss.wal_records) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_records) = sum(pgss.wal_records) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_records are equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_fpi) = sum(pgss.wal_fpi) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_fpi) = sum(pgss.wal_fpi) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_fpi is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_bytes) = sum(pgss.wal_bytes) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_bytes) = sum(pgss.wal_bytes) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_bytes are equal.");
 
 if ($PGSM::PG_MAJOR_VERSION >= 18)
 {
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.wal_buffers_full) = sum(pgss.wal_buffers_full) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.wal_buffers_full) = sum(pgss.wal_buffers_full) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: wal_buffers_full are equal.");
 
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.parallel_workers_to_launch) = sum(pgss.parallel_workers_to_launch) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.parallel_workers_to_launch) = sum(pgss.parallel_workers_to_launch) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: parallel_workers_to_launch are equal.");
 
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.parallel_workers_launched) = sum(pgss.parallel_workers_launched) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.parallel_workers_launched) = sum(pgss.parallel_workers_launched) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: parallel_workers_launched are equal.");
 }
 
 # Compare values for query 'INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.calls) = sum(pgss.calls) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.calls) = sum(pgss.calls) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: calls are equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.rows) = sum(pgss.rows) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.rows) = sum(pgss.rows) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: rows are equal).");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.total_exec_time) = sum(round(pgss.total_exec_time::numeric, 4)) OR sum(pgss.total_exec_time::numeric) % sum(pgsm.total_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.total_exec_time) = sum(round(pgss.total_exec_time::numeric, 4)) OR sum(pgss.total_exec_time::numeric) % sum(pgsm.total_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: total_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.min_exec_time) = sum(round(pgss.min_exec_time::numeric, 4)) OR sum(pgss.min_exec_time::numeric) % sum(pgsm.min_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.min_exec_time) = sum(round(pgss.min_exec_time::numeric, 4)) OR sum(pgss.min_exec_time::numeric) % sum(pgsm.min_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: min_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.max_exec_time) = sum(round(pgss.max_exec_time::numeric, 4)) OR sum(pgss.max_exec_time::numeric) % sum(pgsm.max_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.max_exec_time) = sum(round(pgss.max_exec_time::numeric, 4)) OR sum(pgss.max_exec_time::numeric) % sum(pgsm.max_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: max_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.mean_exec_time) = sum(round(pgss.mean_exec_time::numeric, 4)) OR sum(pgss.mean_exec_time::numeric) % sum(pgsm.mean_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.mean_exec_time) = sum(round(pgss.mean_exec_time::numeric, 4)) OR sum(pgss.mean_exec_time::numeric) % sum(pgsm.mean_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: mean_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.stddev_exec_time) = sum(round(pgss.stddev_exec_time::numeric, 4)) OR sum(pgss.stddev_exec_time::numeric) % sum(pgsm.stddev_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.stddev_exec_time) = sum(round(pgss.stddev_exec_time::numeric, 4)) OR sum(pgss.stddev_exec_time::numeric) % sum(pgsm.stddev_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: stddev_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(round(pgsm.${col_shared_blk_read_time}::numeric, 4)) = sum(round(pgss.${col_shared_blk_read_time}::numeric, 4)) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(round(pgsm.${col_shared_blk_read_time}::numeric, 4)) = sum(round(pgss.${col_shared_blk_read_time}::numeric, 4)) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;"
+);
 trim($stdout);
 is($stdout, 't', "Compare: ${col_shared_blk_read_time} is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(round(pgsm.${col_shared_blk_write_time}::numeric, 4)) = sum(round(pgss.${col_shared_blk_write_time}::numeric, 4)) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(round(pgsm.${col_shared_blk_write_time}::numeric, 4)) = sum(round(pgss.${col_shared_blk_write_time}::numeric, 4)) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;"
+);
 trim($stdout);
 is($stdout, 't', "Compare: ${col_shared_blk_write_time} is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_records) = sum(pgss.wal_records) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_records) = sum(pgss.wal_records) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_records are equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_fpi) = sum(pgss.wal_fpi) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_fpi) = sum(pgss.wal_fpi) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_fpi is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_bytes) = sum(pgss.wal_bytes) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_bytes) = sum(pgss.wal_bytes) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_bytes are equal.");
 
 if ($PGSM::PG_MAJOR_VERSION >= 18)
 {
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.wal_buffers_full) = sum(pgss.wal_buffers_full) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.wal_buffers_full) = sum(pgss.wal_buffers_full) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: wal_buffers_full are equal.");
 
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.parallel_workers_to_launch) = sum(pgss.parallel_workers_to_launch) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.parallel_workers_to_launch) = sum(pgss.parallel_workers_to_launch) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: parallel_workers_to_launch are equal.");
 
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.parallel_workers_launched) = sum(pgss.parallel_workers_launched) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.parallel_workers_launched) = sum(pgss.parallel_workers_launched) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: parallel_workers_launched are equal.");
 }
 
 # Compare values for query 'SELECT abalance FROM pgbench_accounts WHERE aid = $1'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.calls) = sum(pgss.calls) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.calls) = sum(pgss.calls) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: calls are equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.rows) = sum(pgss.rows) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.rows) = sum(pgss.rows) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: rows are equal).");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.total_exec_time) = sum(round(pgss.total_exec_time::numeric, 4)) OR sum(pgss.total_exec_time::numeric) % sum(pgsm.total_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.total_exec_time) = sum(round(pgss.total_exec_time::numeric, 4)) OR sum(pgss.total_exec_time::numeric) % sum(pgsm.total_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: total_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.min_exec_time) = sum(round(pgss.min_exec_time::numeric, 4)) OR sum(pgss.min_exec_time::numeric) % sum(pgsm.min_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.min_exec_time) = sum(round(pgss.min_exec_time::numeric, 4)) OR sum(pgss.min_exec_time::numeric) % sum(pgsm.min_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: min_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.max_exec_time) = sum(round(pgss.max_exec_time::numeric, 4)) OR sum(pgss.max_exec_time::numeric) % sum(pgsm.max_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.max_exec_time) = sum(round(pgss.max_exec_time::numeric, 4)) OR sum(pgss.max_exec_time::numeric) % sum(pgsm.max_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: max_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.mean_exec_time) = sum(round(pgss.mean_exec_time::numeric, 4)) OR sum(pgss.mean_exec_time::numeric) % sum(pgsm.mean_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.mean_exec_time) = sum(round(pgss.mean_exec_time::numeric, 4)) OR sum(pgss.mean_exec_time::numeric) % sum(pgsm.mean_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: mean_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.stddev_exec_time) = sum(round(pgss.stddev_exec_time::numeric, 4)) OR sum(pgss.stddev_exec_time::numeric) % sum(pgsm.stddev_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.stddev_exec_time) = sum(round(pgss.stddev_exec_time::numeric, 4)) OR sum(pgss.stddev_exec_time::numeric) % sum(pgsm.stddev_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: stddev_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(round(pgsm.${col_shared_blk_read_time}::numeric, 4)) = sum(round(pgss.${col_shared_blk_read_time}::numeric, 4)) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(round(pgsm.${col_shared_blk_read_time}::numeric, 4)) = sum(round(pgss.${col_shared_blk_read_time}::numeric, 4)) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;"
+);
 trim($stdout);
 is($stdout, 't', "Compare: ${col_shared_blk_read_time} is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(round(pgsm.${col_shared_blk_write_time}::numeric, 4)) = sum(round(pgss.${col_shared_blk_write_time}::numeric, 4)) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(round(pgsm.${col_shared_blk_write_time}::numeric, 4)) = sum(round(pgss.${col_shared_blk_write_time}::numeric, 4)) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;"
+);
 trim($stdout);
 is($stdout, 't', "Compare: ${col_shared_blk_write_time} is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_records) = sum(pgss.wal_records) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_records) = sum(pgss.wal_records) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_records are equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_fpi) = sum(pgss.wal_fpi) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_fpi) = sum(pgss.wal_fpi) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_fpi is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_bytes) = sum(pgss.wal_bytes) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_bytes) = sum(pgss.wal_bytes) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_bytes are equal.");
 
 if ($PGSM::PG_MAJOR_VERSION >= 18)
 {
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.wal_buffers_full) = sum(pgss.wal_buffers_full) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.wal_buffers_full) = sum(pgss.wal_buffers_full) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: wal_buffers_full are equal.");
 
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.parallel_workers_to_launch) = sum(pgss.parallel_workers_to_launch) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.parallel_workers_to_launch) = sum(pgss.parallel_workers_to_launch) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: parallel_workers_to_launch are equal.");
 
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.parallel_workers_launched) = sum(pgss.parallel_workers_launched) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.parallel_workers_launched) = sum(pgss.parallel_workers_launched) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%SELECT abalance FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: parallel_workers_launched are equal.");
 }
 
 # Compare values for query 'UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.calls) = sum(pgss.calls) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.calls) = sum(pgss.calls) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: calls are equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.rows) = sum(pgss.rows) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.rows) = sum(pgss.rows) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: rows are equal).");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.total_exec_time) = sum(round(pgss.total_exec_time::numeric, 4)) OR sum(pgss.total_exec_time::numeric) % sum(pgsm.total_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.total_exec_time) = sum(round(pgss.total_exec_time::numeric, 4)) OR sum(pgss.total_exec_time::numeric) % sum(pgsm.total_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: total_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.min_exec_time) = sum(round(pgss.min_exec_time::numeric, 4)) OR sum(pgss.min_exec_time::numeric) % sum(pgsm.min_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.min_exec_time) = sum(round(pgss.min_exec_time::numeric, 4)) OR sum(pgss.min_exec_time::numeric) % sum(pgsm.min_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: min_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.max_exec_time) = sum(round(pgss.max_exec_time::numeric, 4)) OR sum(pgss.max_exec_time::numeric) % sum(pgsm.max_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.max_exec_time) = sum(round(pgss.max_exec_time::numeric, 4)) OR sum(pgss.max_exec_time::numeric) % sum(pgsm.max_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: max_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.mean_exec_time) = sum(round(pgss.mean_exec_time::numeric, 4)) OR sum(pgss.mean_exec_time::numeric) % sum(pgsm.mean_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.mean_exec_time) = sum(round(pgss.mean_exec_time::numeric, 4)) OR sum(pgss.mean_exec_time::numeric) % sum(pgsm.mean_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: mean_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.stddev_exec_time) = sum(round(pgss.stddev_exec_time::numeric, 4)) OR sum(pgss.stddev_exec_time::numeric) % sum(pgsm.stddev_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.stddev_exec_time) = sum(round(pgss.stddev_exec_time::numeric, 4)) OR sum(pgss.stddev_exec_time::numeric) % sum(pgsm.stddev_exec_time::numeric) < 1 FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: stddev_exec_time is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(round(pgsm.${col_shared_blk_write_time}::numeric, 4)) = sum(round(pgss.${col_shared_blk_write_time}::numeric, 4)) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(round(pgsm.${col_shared_blk_write_time}::numeric, 4)) = sum(round(pgss.${col_shared_blk_write_time}::numeric, 4)) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;"
+);
 trim($stdout);
 is($stdout, 't', "Compare: ${col_shared_blk_write_time} is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_records) = sum(pgss.wal_records) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_records) = sum(pgss.wal_records) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_records are equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_fpi) = sum(pgss.wal_fpi) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_fpi) = sum(pgss.wal_fpi) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_fpi is equal.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.wal_bytes) = sum(pgss.wal_bytes) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.wal_bytes) = sum(pgss.wal_bytes) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Compare: wal_bytes are equal.");
 
 if ($PGSM::PG_MAJOR_VERSION >= 18)
 {
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.wal_buffers_full) = sum(pgss.wal_buffers_full) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.wal_buffers_full) = sum(pgss.wal_buffers_full) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: wal_buffers_full are equal.");
 
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.parallel_workers_to_launch) = sum(pgss.parallel_workers_to_launch) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.parallel_workers_to_launch) = sum(pgss.parallel_workers_to_launch) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: parallel_workers_to_launch are equal.");
 
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.parallel_workers_launched) = sum(pgss.parallel_workers_launched) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.parallel_workers_launched) = sum(pgss.parallel_workers_launched) FROM pg_stat_monitor AS pgsm INNER JOIN pg_stat_statements AS pgss ON pgss.query = pgsm.query WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts%\' GROUP BY pgsm.query;'
+	);
 	trim($stdout);
 	is($stdout, 't', "Compare: parallel_workers_launched are equal.");
 }

--- a/t/026_shared_blocks.pl
+++ b/t/026_shared_blocks.pl
@@ -137,117 +137,101 @@ PGSM::append_to_debug_file("--------");
 PGSM::append_to_debug_file($stdout);
 
 # Compare values for query 'DELETE FROM pgbench_accounts WHERE $1 = $2'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.shared_blks_hit) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.shared_blks_hit) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: shared_blks_hit should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.shared_blks_read) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.shared_blks_read) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: shared_blks_read should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.shared_blks_dirtied) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.shared_blks_dirtied) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: shared_blks_dirtied should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.shared_blks_written) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.shared_blks_written) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%DELETE FROM pgbench_accounts%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: shared_blks_written should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(pgsm.${col_shared_blk_read_time}) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE '%DELETE FROM pgbench_accounts%' GROUP BY pgsm.query;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(pgsm.${col_shared_blk_read_time}) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE '%DELETE FROM pgbench_accounts%' GROUP BY pgsm.query;"
+);
 trim($stdout);
 is($stdout, 't', "Check: ${col_shared_blk_read_time} should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(pgsm.${col_shared_blk_write_time}) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE '%DELETE FROM pgbench_accounts%' GROUP BY pgsm.query;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(pgsm.${col_shared_blk_write_time}) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE '%DELETE FROM pgbench_accounts%' GROUP BY pgsm.query;"
+);
 trim($stdout);
 is($stdout, 't', "Check: ${col_shared_blk_write_time} should not be 0.");
 
 # Compare values for query 'INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.shared_blks_hit) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.shared_blks_hit) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: shared_blks_hit should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.shared_blks_dirtied) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.shared_blks_dirtied) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: shared_blks_dirtied should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.shared_blks_written) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.shared_blks_written) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO pgbench_history%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: shared_blks_written should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(pgsm.${col_shared_blk_write_time}) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE '%INSERT INTO pgbench_history%' GROUP BY pgsm.query;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(pgsm.${col_shared_blk_write_time}) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE '%INSERT INTO pgbench_history%' GROUP BY pgsm.query;"
+);
 trim($stdout);
 is($stdout, 't', "Check: ${col_shared_blk_write_time} should not be 0.");
 
 # Compare values for query 'UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.shared_blks_hit) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.shared_blks_hit) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: shared_blks_hit should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.shared_blks_read) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.shared_blks_read) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: shared_blks_read should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.shared_blks_dirtied) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.shared_blks_dirtied) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: shared_blks_dirtied should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT sum(pgsm.shared_blks_written) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY pgsm.query;',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT sum(pgsm.shared_blks_written) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%UPDATE pgbench_accounts SET abalance%\' GROUP BY pgsm.query;'
+);
 trim($stdout);
 is($stdout, 't', "Check: shared_blks_written should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(pgsm.${col_shared_blk_read_time}) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE '%UPDATE pgbench_accounts SET abalance%' GROUP BY pgsm.query;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(pgsm.${col_shared_blk_read_time}) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE '%UPDATE pgbench_accounts SET abalance%' GROUP BY pgsm.query;"
+);
 trim($stdout);
 is($stdout, 't', "Check: ${col_shared_blk_read_time} should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(pgsm.${col_shared_blk_write_time}) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE '%UPDATE pgbench_accounts SET abalance%' GROUP BY pgsm.query;",
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(pgsm.${col_shared_blk_write_time}) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE '%UPDATE pgbench_accounts SET abalance%' GROUP BY pgsm.query;"
+);
 trim($stdout);
 is($stdout, 't', "Check: ${col_shared_blk_write_time} should not be 0.");
 

--- a/t/027_local_blocks.pl
+++ b/t/027_local_blocks.pl
@@ -76,43 +76,39 @@ PGSM::append_to_file($stdout);
 PGSM::append_to_debug_file($stdout);
 
 # Compare values for query 'INSERT INTO t1 SELECT generate_series($1, $2)'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT pgsm.local_blks_hit <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO t1%\';',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT pgsm.local_blks_hit <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO t1%\';'
+);
 trim($stdout);
 is($stdout, 't', "Check: local_blks_hit should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT pgsm.local_blks_dirtied <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO t1%\';',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT pgsm.local_blks_dirtied <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO t1%\';'
+);
 trim($stdout);
 is($stdout, 't', "Check: local_blks_dirtied should not be 0.");
 
 if ($PGSM::PG_MAJOR_VERSION >= 17)
 {
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.local_blk_write_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO t1%\'',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.local_blk_write_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%INSERT INTO t1%\''
+	);
 	trim($stdout);
 	is($stdout, 't', "Check: local_blk_write_time should not be 0.");
 }
 
 
 # Compare values for query 'SELECT * FROM t1'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT pgsm.local_blks_hit <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\';',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT pgsm.local_blks_hit <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\';'
+);
 trim($stdout);
 is($stdout, 't', "Check: local_blks_hit should not be 0.");
 
 # TODO: Find a way how to bypass cache and get real block reads
 # if ($PGSM::PG_MAJOR_VERSION >= 17)
 # {
-#     ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT sum(pgsm.local_blk_read_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\';', extra_params => ['-Pformat=unaligned','-Ptuples_only=on']);
+#     ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT sum(pgsm.local_blk_read_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\';');
 #     trim($stdout);
 #     is($stdout,'t',"Check: local_blk_read_time should not be 0.");
 # }

--- a/t/028_temp_block.pl
+++ b/t/028_temp_block.pl
@@ -109,33 +109,29 @@ PGSM::append_to_debug_file($stdout);
 PGSM::append_to_debug_file($stdout);
 
 # Compare values for query 'SELECT * FROM t1'
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT pgsm.temp_blks_read <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\';',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT pgsm.temp_blks_read <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\';'
+);
 trim($stdout);
 is($stdout, 't', "Check: temp_blks_read should not be 0.");
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT pgsm.temp_blks_written <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\';',
-	extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT pgsm.temp_blks_written <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\';'
+);
 trim($stdout);
 is($stdout, 't', "Check: temp_blks_written should not be 0.");
 
 if ($PGSM::PG_MAJOR_VERSION >= 15)
 {
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.temp_blk_read_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\';',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.temp_blk_read_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\';'
+	);
 	trim($stdout);
 	is($stdout, 't', "Check: temp_blk_read_time should not be 0.");
 
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT sum(pgsm.temp_blk_write_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\'',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT sum(pgsm.temp_blk_write_time) <> 0 FROM pg_stat_monitor AS pgsm WHERE pgsm.query LIKE \'%FROM t1%\''
+	);
 	trim($stdout);
 	is($stdout, 't', "Check: temp_blk_write_time should not be 0.");
 }

--- a/t/029_bucket_done.pl
+++ b/t/029_bucket_done.pl
@@ -72,26 +72,23 @@ PGSM::append_to_debug_file($stdout);
 is($cmdret, 0, "3 - Run pg_sleep(3)");
 PGSM::append_to_debug_file($stdout);
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(calls) AS calls FROM pg_stat_monitor WHERE query LIKE '%sleep%' AND bucket_done GROUP BY calls;",
-	extra_params => [ '-t', '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(calls) AS calls FROM pg_stat_monitor WHERE query LIKE '%sleep%' AND bucket_done GROUP BY calls;"
+);
 is($cmdret, 0, "Run query to get count where bucket is done.");
 is($stdout, 2, "Compare: Calls count is 2");
 PGSM::append_to_debug_file($stdout);
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT sum(calls) AS calls FROM pg_stat_monitor WHERE query LIKE '%sleep%' AND NOT bucket_done GROUP BY calls;",
-	extra_params => [ '-t', '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT sum(calls) AS calls FROM pg_stat_monitor WHERE query LIKE '%sleep%' AND NOT bucket_done GROUP BY calls;"
+);
 is($cmdret, 0, "Run query to get count where bucket is not done.");
 is($stdout, 1, "Compare: Calls count is 1");
 PGSM::append_to_debug_file($stdout);
 
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'SELECT bucket, bucket_done, query, calls AS calls FROM pg_stat_monitor;',
-	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	'SELECT bucket, bucket_done, query, calls AS calls FROM pg_stat_monitor;'
+);
 is($cmdret, 0, "Print what is in pg_stat_monitor view");
 PGSM::append_to_debug_file($stdout);
 

--- a/t/030_histogram.pl
+++ b/t/030_histogram.pl
@@ -126,10 +126,8 @@ sub generate_histogram_with_configurations
 		"Scenario $scenario_number : Print what is in pg_stat_monitor view");
 	PGSM::append_to_debug_file($stdout);
 
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT calls FROM pg_stat_monitor ORDER BY calls DESC LIMIT 1;',
-		extra_params => [ '-Pformat=unaligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT calls FROM pg_stat_monitor ORDER BY calls DESC LIMIT 1;');
 	is($cmdret, 0, "Scenario $scenario_number : Get calls into a variable");
 	is($stdout, $expected_calls_count,
 		"Scenario $scenario_number : Calls are $expected_calls_count");
@@ -137,10 +135,9 @@ sub generate_histogram_with_configurations
 	PGSM::append_to_debug_file(
 		"Scenario $scenario_number : Got Calls from query : " . $stdout);
 
-	($cmdret, $stdout, $stderr) = $node->psql(
-		'postgres',
-		'SELECT resp_calls FROM pg_stat_monitor ORDER BY calls DESC LIMIT 1;',
-		extra_params => [ '-Pformat=aligned', '-Ptuples_only=on' ]);
+	($cmdret, $stdout, $stderr) = $node->psql('postgres',
+		'SELECT resp_calls FROM pg_stat_monitor ORDER BY calls DESC LIMIT 1;'
+	);
 	is($cmdret, 0,
 		"Scenario $scenario_number : Get resp_calls into a variable");
 	is(trim($stdout), "$expected_resp_calls",

--- a/t/033_stats_since.pl
+++ b/t/033_stats_since.pl
@@ -79,26 +79,23 @@ is($cmdret, 0, "3 - Run pg_sleep(1)");
 PGSM::append_to_debug_file($stdout);
 
 # Check that we have more than one bucket
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT count(bucket) <> 0 AS pgsm FROM pg_stat_monitor WHERE query LIKE '%sleep%';",
-	extra_params => [ '-t', '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT count(bucket) <> 0 AS pgsm FROM pg_stat_monitor WHERE query LIKE '%sleep%';"
+);
 trim($stdout);
 is($stdout, 't', "Check: we have more that one bucket");
 
 # Check that stats timestamps are different for each query/bucket
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT count(DISTINCT stats_since) = count(stats_since) AS pgsm FROM pg_stat_monitor WHERE query LIKE '%sleep%';",
-	extra_params => [ '-t', '-Pformat=unaligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT count(DISTINCT stats_since) = count(stats_since) AS pgsm FROM pg_stat_monitor WHERE query LIKE '%sleep%';"
+);
 trim($stdout);
 is($stdout, 't', "Check: for every bucket stats_since should be unique");
 
 # Check that minmax_stats_since always match stats_since
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	"SELECT count(*) AS st FROM pg_stat_monitor WHERE query LIKE '%sleep%' AND stats_since <> minmax_stats_since;",
-	extra_params => [ '-t', '-Pformat=aligned', '-Ptuples_only=on' ]);
+($cmdret, $stdout, $stderr) = $node->psql('postgres',
+	"SELECT count(*) AS st FROM pg_stat_monitor WHERE query LIKE '%sleep%' AND stats_since <> minmax_stats_since;"
+);
 trim($stdout);
 is($stdout, 0, "Check: minmax_stats_since always match stats_since");
 PGSM::append_to_debug_file($stdout);


### PR DESCRIPTION
Make the intent of the code more clear by not passing default arguments to the `psql()` function. The unaligned format and tuples_only are defaults in the test helper.

PG-0

