### PR TITLE
Run CI actions for PGSM with assertions enabled

### DIFF
--- a/.github/scripts/build-postgres.sh
+++ b/.github/scripts/build-postgres.sh
@@ -10,18 +10,18 @@ PSP_DIR=$SCRIPT_DIR/../../../postgres
 case "$1" in
     debug)
         echo "Building with debug option"
-        ARGS+=" --enable-cassert --enable-injection-points"
+        ARGS+=" --enable-cassert"
         ;;
 
     debugoptimized)
         echo "Building with debugoptimized option"
         export CFLAGS="-O2"
-        ARGS+=" --enable-cassert --enable-injection-points"
+        ARGS+=" --enable-cassert"
         ;;
 
     coverage)
         echo "Building with coverage option"
-        ARGS+=" --enable-cassert --enable-injection-points --enable-coverage"
+        ARGS+=" --enable-cassert --enable-coverage"
         ;;
 
     sanitize)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,32 +38,50 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v7
         with:
+          path: src
           ref: ${{ github.ref }}
 
       - name: Install dependencies for Ubuntu
         if: startsWith(inputs.os, 'ubuntu-')
-        run: .github/scripts/ubuntu-deps.sh
+        run: src/.github/scripts/ubuntu-deps.sh
+
+      - name: Install dev dependencies for Ubuntu
+        if: startsWith(inputs.os, 'ubuntu-') && env.PG_PACKAGE == 'source'
+        run: src/.github/scripts/ubuntu-deps.sh dev
 
       - name: Install dependencies for MacOS
         if: startsWith(inputs.os,  'macos-')
-        run: .github/scripts/macos-deps.sh
+        run: src/.github/scripts/macos-deps.sh
 
       - name: Install PostgreSQL
-        run: .github/scripts/install-postgresql.sh ${{ env.PG_PACKAGE }} ${{ env.PG_VERSION }}
+        if: env.PG_PACKAGE != 'source'
+        run: src/.github/scripts/install-postgresql.sh ${{ env.PG_PACKAGE }} ${{ env.PG_VERSION }}
+
+      - name: Clone postgres repository
+        if: env.PG_PACKAGE == 'source'
+        uses: actions/checkout@v7
+        with:
+          path: postgres
+          repository: postgres/postgres.git
+          ref: REL_${{ env.PG_VERSION }}_STABLE
+
+      - name: Build PostgreSQL
+        if: env.PG_PACKAGE == 'source'
+        run: src/.github/scripts/build-postgres.sh ${{ env.BUILD_TYPE }}
 
       - name: Build pg_stat_monitor
-        run: .github/scripts/build.sh ${{ env.BUILD_TYPE }}
+        run: src/.github/scripts/build.sh ${{ env.BUILD_TYPE }}
 
       - name: Set permissions
-        if: startsWith(inputs.os, 'ubuntu-')
+        if: startsWith(inputs.os, 'ubuntu-') && env.PG_PACKAGE != 'source'
         run: sudo chown -R runner:runner /var/run/postgresql
 
       - name: Stop existing PostgreSQL instances
-        if: startsWith(inputs.os, 'ubuntu-')
+        if: startsWith(inputs.os, 'ubuntu-') && env.PG_PACKAGE != 'source'
         run: sudo service postgresql stop
 
       - name: Run tests
-        run: .github/scripts/test.sh ${{ env.BUILD_TYPE }}
+        run: src/.github/scripts/test.sh ${{ env.BUILD_TYPE }}
 
       - name: Report on test fail
         uses: actions/upload-artifact@v4
@@ -71,11 +89,11 @@ jobs:
         with:
           name: log-test-${{ env.PG_PACKAGE }}-${{ env.PG_VERSION }}-${{ env.OS }}-${{ env.CC }}-${{ env.BUILD_TYPE }}
           path: |
-            regression_install
-            regression_install.log
-            regression.diffs
-            regression.out
-            results
-            t/results
-            tmp_check
+            src/regression_install
+            src/regression_install.log
+            src/regression.diffs
+            src/regression.out
+            src/results
+            src/t/results
+            src/tmp_check
           retention-days: 3

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -19,7 +19,7 @@ jobs:
         pg_package: [psp]
         pg_version: [14, 15, 16, 17, 18]
         os: [ubuntu-24.04]
-        compiler: [gcc, clang]
+        compiler: [gcc]
         build_type: [debugoptimized]
     uses: ./.github/workflows/build-and-test.yml
     with:
@@ -36,6 +36,25 @@ jobs:
       fail-fast: false
       matrix:
         pg_package: [pgdg]
+        pg_version: [14, 15, 16, 17, 18]
+        os: [ubuntu-24.04]
+        compiler: [gcc]
+        build_type: [debugoptimized]
+    uses: ./.github/workflows/build-and-test.yml
+    with:
+        pg_package: ${{ matrix.pg_package }}
+        pg_version: ${{ matrix.pg_version }}
+        os: ${{ matrix.os }}
+        compiler: ${{ matrix.compiler }}
+        build_type: ${{ matrix.build_type }}
+    secrets: inherit
+
+  source:
+    name: Source
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_package: [source]
         pg_version: [14, 15, 16, 17, 18]
         os: [ubuntu-24.04]
         compiler: [gcc, clang]


### PR DESCRIPTION
While the sanitizer checks were ran with assertions enabled I do not think that is enough. We want to test with assertions enabled on all versions of PostgreSQL that we support.

To save some CPU cycles now that we will build much more we only build with gcc against packages on Linux.
    
Also disable building with injection points for now until we have some test case which actually uses them since PostgreSQL version before 17 did not support them.

PG-0