### PR TITLE
Avoid adding entry to the list in utility hook 

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -227,7 +227,6 @@ static MemoryContextCallback mem_cxt_reset_callback =
 static bool callback_setup = false;
 
 static void pgsm_update_entry(pgsmEntry *entry,
-							  const char *query,
 							  const char *comments,
 							  const PlanInfo *plan_info,
 							  const SysInfo *sys_info,
@@ -724,7 +723,6 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 		entry->counters.info.cmd_type = queryDesc->operation;
 
 		pgsm_update_entry(entry,	/* entry */
-						  NULL, /* query */
 						  NULL, /* comments */
 						  plan_ptr, /* PlanInfo */
 						  &sys_info,	/* SysInfo */
@@ -918,7 +916,6 @@ pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, Par
 		/* The plan details are captured when the query finishes */
 		if (entry)
 			pgsm_update_entry(entry,	/* entry */
-							  NULL, /* query */
 							  NULL, /* comments */
 							  NULL, /* PlanInfo */
 							  NULL, /* SysInfo */
@@ -1107,7 +1104,6 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 
 		/* The plan details are captured when the query finishes */
 		pgsm_update_entry(entry,	/* entry */
-						  query_text,	/* query */
 						  NULL, /* comments */
 						  NULL, /* PlanInfo */
 						  &sys_info,	/* SysInfo */
@@ -1237,7 +1233,6 @@ pg_get_client_addr(void)
 
 static void
 pgsm_update_entry(pgsmEntry *entry,
-				  const char *query,
 				  const char *comments,
 				  const PlanInfo *plan_info,
 				  const SysInfo *sys_info,
@@ -1876,7 +1871,6 @@ pgsm_store(pgsmEntry *entry)
 	}
 
 	pgsm_update_entry(shared_hash_entry,	/* entry */
-					  query,	/* query */
 					  pgsm_extract_comments ? comments : NULL,	/* comments */
 					  &entry->counters.planinfo,	/* PlanInfo */
 					  &entry->counters.sysinfo, /* SysInfo */

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1095,12 +1095,9 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 
 		query_text = CleanQuerytext(queryString, &location, &query_len);
 
+		entry->query_text.query_pointer = pnstrdup(query_text, query_len);
 		entry->pgsm_query_id = get_pgsm_query_id_hash(query_text, query_len);
 		entry->counters.info.cmd_type = cmd_type;
-
-		pgsm_add_to_list(entry, query_text, query_len);
-
-		Assert(list_length(lentries) <= max_nesting_level);
 
 		/* The plan details are captured when the query finishes */
 		pgsm_update_entry(entry,	/* entry */
@@ -1120,7 +1117,8 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 
 		pgsm_store(entry);
 
-		pgsm_delete_entry(queryId);
+		pfree(entry->query_text.query_pointer);
+		pfree(entry);
 	}
 	else
 	{


### PR DESCRIPTION
Entry was added to the list just to cause side effect: create null terminated query text. Do it explicitly instead. Also we can do it in the current context as pgsm_store will make its own copies.

Also remove redundant argument from pgsm_update_entry function.


