### PR TITLE
Fix local_blk_read_time counter

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1412,7 +1412,7 @@ pgsm_update_entry(pgsmEntry *entry,
 #if PG_VERSION_NUM >= 170000
 		entry->counters.blocks.instr_shared_blk_read_time = bufusage->shared_blk_read_time;
 		entry->counters.blocks.instr_shared_blk_write_time = bufusage->shared_blk_write_time;
-		entry->counters.blocks.instr_local_blk_write_time = bufusage->local_blk_write_time;
+		entry->counters.blocks.instr_local_blk_read_time = bufusage->local_blk_read_time;
 		entry->counters.blocks.instr_local_blk_write_time = bufusage->local_blk_write_time;
 #else
 		entry->counters.blocks.instr_shared_blk_read_time = bufusage->blk_read_time;


### PR DESCRIPTION
Due typo `local_blk_write_time` was assigned twice, while `local_blk_read_time` never.

