### PR TITLE
Move defines used only in hash_query.c to that file

### DIFF
--- a/src/hash_query.c
+++ b/src/hash_query.c
@@ -18,7 +18,14 @@
 #include <storage/shmem.h>
 #include <utils/memutils.h>
 
+#include "guc.h"
 #include "hash_query.h"
+
+#define MAX_QUERY_BUF			((int64) pgsm_query_shared_buffer * 1024 * 1024)
+#define MAX_BUCKETS_MEM 		((int64) pgsm_max * 1024 * 1024)
+#define MAX_BUCKET_ENTRIES 		(MAX_BUCKETS_MEM / sizeof(pgsmEntry))
+#define PGSM_BUCKET_INFO_SIZE	(sizeof(TimestampTz) * pgsm_max_buckets)
+#define PGSM_SHARED_STATE_SIZE	(sizeof(pgsmSharedState) + PGSM_BUCKET_INFO_SIZE)
 
 typedef struct pgsmLocalState
 {
@@ -33,9 +40,6 @@ static pgsmLocalState pgsmStateLocal;
 static void pgsm_attach_shmem(void);
 static HTAB *pgsm_create_bucket_hash(void);
 static Size pgsm_get_shared_area_size(void);
-
-#define PGSM_BUCKET_INFO_SIZE	(sizeof(TimestampTz) * pgsm_max_buckets)
-#define PGSM_SHARED_STATE_SIZE	(sizeof(pgsmSharedState) + PGSM_BUCKET_INFO_SIZE)
 
 /*
  * Returns the shared memory area size for storing the query texts

--- a/src/hash_query.h
+++ b/src/hash_query.h
@@ -26,8 +26,6 @@
 #include <utils/hsearch.h>
 #include <utils/timestamp.h>
 
-#include "guc.h"
-
 #define ERROR_MESSAGE_LEN	100
 #define REL_LST				10
 /* schema + dot + relname + view indication + string terminator */
@@ -35,12 +33,7 @@
 #define APPLICATIONNAME_LEN	NAMEDATALEN
 #define COMMENTS_LEN		256
 #define PLAN_TEXT_LEN		1024
-
-#define MAX_QUERY_BUF		((int64) pgsm_query_shared_buffer * 1024 * 1024)
-#define MAX_BUCKETS_MEM 	((int64) pgsm_max * 1024 * 1024)
-#define MAX_BUCKET_ENTRIES 	(MAX_BUCKETS_MEM / sizeof(pgsmEntry))
 #define SQLCODE_LEN			20
-#define TOTAL_RELS_LENGTH	(REL_LST * REL_LEN)
 
 #define INVALID_BUCKET_ID	-1
 


### PR DESCRIPTION
These macros were only used in the C file so belong there. Also remove `TOTAL_RELS_LENGTH` which was not used anymore.

PG-0

