### PR TITLE
Remove arguments related git submodules from our CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v7
         with:
-          submodules: recursive
           ref: ${{ github.ref }}
 
       - name: Install dependencies for Ubuntu

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: src
-          submodules: recursive
 
       - name: Clone postgres repository
         uses: actions/checkout@v7


### PR DESCRIPTION
This was most likely copied from the `pg_tde` repo where we use submodules but as we do not in PGSM this may just confuse a reader.

PG-0

