### PR TITLE
Simplify logic around debug_query_string

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1477,12 +1477,7 @@ pgsm_store_error(const char *query, const ErrorData *edata)
 {
 	pgsmEntry  *entry;
 	int64		queryid;
-	int			len;
-
-	if (!query || query[0] == '\0')
-		return;
-
-	len = strlen(query);
+	int			len = strlen(query);
 
 	queryid = pgsm_hash_string(query, len);
 
@@ -2970,8 +2965,8 @@ pgsm_emit_log_hook(ErrorData *edata)
 	if (MyProc == NULL)
 		goto exit;
 
-	if (edata->elevel >= WARNING && !disable_error_capture && !IsSystemOOM())
-		pgsm_store_error(debug_query_string ? debug_query_string : "", edata);
+	if (edata->elevel >= WARNING && debug_query_string && !disable_error_capture && !IsSystemOOM())
+		pgsm_store_error(debug_query_string, edata);
 
 	/* We need to make sure we re-enable error capture if query was aborted */
 	if (edata->elevel >= ERROR)


### PR DESCRIPTION
Instead of, if `debug_query_string` is `NULL`, first setting it to the empty string and then calling `pgsm_store_error()` to finally return from it because the string is empty we just do not call `pgsm_store_error()` if `debug_query_string` is `NULL`. Also do not treat the empty query string as a special case anymore.

PG-0

