### PR TITLE
Remove unnecessary imports in TAP files

### DIFF
--- a/t/001_settings_default.pl
+++ b/t/001_settings_default.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/002_settings_pgsm_track_planning.pl
+++ b/t/002_settings_pgsm_track_planning.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Text::Trim qw(trim);
 use Test::More;
 use lib 't';

--- a/t/003_settings_pgms_extract_comments.pl
+++ b/t/003_settings_pgms_extract_comments.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/004_settings_pgsm_track.pl
+++ b/t/004_settings_pgsm_track.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/005_settings_pgsm_enable_query_plan.pl
+++ b/t/005_settings_pgsm_enable_query_plan.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Text::Trim qw(trim);
 use Test::More;
 use lib 't';

--- a/t/006_settings_pgsm_overflow_target.pl
+++ b/t/006_settings_pgsm_overflow_target.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/007_settings_pgsm_query_shared_buffer.pl
+++ b/t/007_settings_pgsm_query_shared_buffer.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/008_settings_pgsm_histogram_buckets.pl
+++ b/t/008_settings_pgsm_histogram_buckets.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/009_settings_pgsm_histogram_max.pl
+++ b/t/009_settings_pgsm_histogram_max.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/010_settings_pgsm_histogram_min.pl
+++ b/t/010_settings_pgsm_histogram_min.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/011_settings_pgsm_bucket_time.pl
+++ b/t/011_settings_pgsm_bucket_time.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/012_settings_pgsm_max_buckets.pl
+++ b/t/012_settings_pgsm_max_buckets.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/013_settings_pgsm_normalized_query.pl
+++ b/t/013_settings_pgsm_normalized_query.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/014_settings_pgsm_track_utility.pl
+++ b/t/014_settings_pgsm_track_utility.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/015_settings_pgsm_query_max_len.pl
+++ b/t/015_settings_pgsm_query_max_len.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/016_settings_pgsm_max.pl
+++ b/t/016_settings_pgsm_max.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/017_execution_stats.pl
+++ b/t/017_execution_stats.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Text::Trim qw(trim);
 use Test::More;
 use lib 't';

--- a/t/018_column_names.pl
+++ b/t/018_column_names.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/019_insufficient_shared_space.pl
+++ b/t/019_insufficient_shared_space.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/020_buffer_overflow.pl
+++ b/t/020_buffer_overflow.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/021_misc_1.pl
+++ b/t/021_misc_1.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/022_misc_2.pl
+++ b/t/022_misc_2.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/023_missing_queries.pl
+++ b/t/023_missing_queries.pl
@@ -33,8 +33,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/024_check_timings.pl
+++ b/t/024_check_timings.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Text::Trim qw(trim);
 use Test::More;
 use lib 't';

--- a/t/025_compare_pgss.pl
+++ b/t/025_compare_pgss.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Text::Trim qw(trim);
 use Test::More;
 use lib 't';

--- a/t/026_shared_blocks.pl
+++ b/t/026_shared_blocks.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Text::Trim qw(trim);
 use Test::More;
 use lib 't';

--- a/t/027_local_blocks.pl
+++ b/t/027_local_blocks.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Text::Trim qw(trim);
 use Test::More;
 use lib 't';

--- a/t/028_temp_block.pl
+++ b/t/028_temp_block.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Text::Trim qw(trim);
 use Test::More;
 use lib 't';

--- a/t/029_bucket_done.pl
+++ b/t/029_bucket_done.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/030_histogram.pl
+++ b/t/030_histogram.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Text::Trim qw(trim);
 use Test::More;
 use lib 't';

--- a/t/031_query_stat.pl
+++ b/t/031_query_stat.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/032_multiple_extensions.pl
+++ b/t/032_multiple_extensions.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgsm;

--- a/t/033_stats_since.pl
+++ b/t/033_stats_since.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Text::Trim qw(trim);
 use Test::More;
 use lib 't';

--- a/t/034_update.pl
+++ b/t/034_update.pl
@@ -3,7 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
 use Test::More;
 use lib 't';
 use pgsm;


### PR DESCRIPTION
These imports are not used by anything in any of the tests.

PG-0
