### PR TITLE
Fix omission when converting functions to C

### DIFF
--- a/pg_stat_monitor--2.3--next.sql
+++ b/pg_stat_monitor--2.3--next.sql
@@ -3,12 +3,14 @@
 
 CREATE OR REPLACE FUNCTION decode_error_level(elevel int)
 RETURNS text
+STRICT
 PARALLEL SAFE
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'pg_stat_monitor_decode_error_level';
 
 CREATE OR REPLACE FUNCTION get_cmd_type(cmd_type int)
 RETURNS text
+STRICT
 PARALLEL SAFE
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'pg_stat_monitor_get_cmd_type';


### PR DESCRIPTION
In commit cc2dd600e0d455f4130643a1a36a0635be5f6a59 I forgot that the new versions of `decode_error_level()` and `get_cmd_type()` need to be strict since the C functions do not handle NULL.

PG-0

