### PR TITLE
Remove unnecessary explicit transaction in regression tests

### DIFF
--- a/regression/expected/top_query.out
+++ b/regression/expected/top_query.out
@@ -45,7 +45,6 @@ SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 (5 rows)
 
 -- make sure that we handle nested queries correctly
-BEGIN;
 DO $$
 DECLARE
     i int;
@@ -56,7 +55,6 @@ BEGIN
     END LOOP;
 END
 $$;
-COMMIT;
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 
 -----------------------

--- a/regression/sql/top_query.sql
+++ b/regression/sql/top_query.sql
@@ -20,8 +20,6 @@ SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 
 -- make sure that we handle nested queries correctly
 
-BEGIN;
-
 DO $$
 DECLARE
     i int;
@@ -32,8 +30,6 @@ BEGIN
     END LOOP;
 END
 $$;
-
-COMMIT;
 
 SELECT pg_stat_monitor_reset();
 DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
Whatever is in a `DO` block already happens within a transaction so there is no need to wrap it an an explicit transaction.

PG-0

