### PR TITLE
Clean up handling of return system() values in TAP test

### DIFF
--- a/t/007_settings_pgsm_query_shared_buffer.pl
+++ b/t/007_settings_pgsm_query_shared_buffer.pl
@@ -50,12 +50,10 @@ PGSM::append_to_file($stdout);
 # CREATE example database and run pgbench init
 ($cmdret, $stdout, $stderr) =
   $node->psql('postgres', 'CREATE DATABASE example;', extra_params => ['-a']);
-print "cmdret $cmdret\n";
 is($cmdret, 0, "CREATE DATABASE example");
 PGSM::append_to_file($stdout);
 
 my $port = $node->port;
-print "port $port \n";
 
 $cmdret = system("pgbench -i -s 10 -p $port example");
 is($cmdret, 0, "Perform pgbench init");

--- a/t/007_settings_pgsm_query_shared_buffer.pl
+++ b/t/007_settings_pgsm_query_shared_buffer.pl
@@ -57,12 +57,10 @@ PGSM::append_to_file($stdout);
 my $port = $node->port;
 print "port $port \n";
 
-my $out = system("pgbench -i -s 10 -p $port example");
-print " out: $out \n";
+$cmdret = system("pgbench -i -s 10 -p $port example");
 is($cmdret, 0, "Perform pgbench init");
 
-$out = system("pgbench -c 10 -j 2 -t 1000 -p $port example");
-print " out: $out \n";
+$cmdret = system("pgbench -c 10 -j 2 -t 1000 -p $port example");
 is($cmdret, 0, "Run pgbench");
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -90,12 +88,10 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$out = system("pgbench -i -s 10 -p $port example");
-print " out: $out \n";
+$cmdret = system("pgbench -i -s 10 -p $port example");
 is($cmdret, 0, "Perform pgbench init");
 
-$out = system("pgbench -c 10 -j 2 -t 1000 -p $port example");
-print " out: $out \n";
+$cmdret = system("pgbench -c 10 -j 2 -t 1000 -p $port example");
 is($cmdret, 0, "Run pgbench");
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -123,12 +119,10 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$out = system("pgbench -i -s 10 -p $port example");
-print " out: $out \n";
+$cmdret = system("pgbench -i -s 10 -p $port example");
 is($cmdret, 0, "Perform pgbench init");
 
-$out = system("pgbench -c 10 -j 2 -t 1000 -p $port example");
-print " out: $out \n";
+$cmdret = system("pgbench -c 10 -j 2 -t 1000 -p $port example");
 is($cmdret, 0, "Run pgbench");
 
 ($cmdret, $stdout, $stderr) = $node->psql(
@@ -156,12 +150,10 @@ PGSM::append_to_file($stdout);
 is($cmdret, 0, "Print PGSM EXTENSION Settings");
 PGSM::append_to_file($stdout);
 
-$out = system("pgbench -i -s 10 -p $port example");
-print " out: $out \n";
+$cmdret = system("pgbench -i -s 10 -p $port example");
 is($cmdret, 0, "Perform pgbench init");
 
-$out = system("pgbench -c 10 -j 2 -t 1000 -p $port example");
-print " out: $out \n";
+$cmdret = system("pgbench -c 10 -j 2 -t 1000 -p $port example");
 is($cmdret, 0, "Run pgbench");
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/024_check_timings.pl
+++ b/t/024_check_timings.pl
@@ -69,10 +69,10 @@ PGSM::append_to_file($stdout);
 
 my $port = $node->port;
 
-my $out = system("pgbench -i -s 20 -p $port postgres");
+$cmdret = system("pgbench -i -s 20 -p $port postgres");
 is($cmdret, 0, "Perform pgbench init");
 
-$out = system("pgbench -c 10 -j 2 -t 2500 -p $port postgres");
+$cmdret = system("pgbench -c 10 -j 2 -t 2500 -p $port postgres");
 is($cmdret, 0, "Run pgbench");
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/025_compare_pgss.pl
+++ b/t/025_compare_pgss.pl
@@ -78,10 +78,10 @@ PGSM::append_to_file($stdout);
 
 my $port = $node->port;
 
-my $out = system("pgbench -i -s 10 -p $port postgres");
+$cmdret = system("pgbench -i -s 10 -p $port postgres");
 is($cmdret, 0, "Perform pgbench init");
 
-$out = system("pgbench -c 10 -j 2 -t 1000 -p $port postgres");
+$cmdret = system("pgbench -c 10 -j 2 -t 1000 -p $port postgres");
 is($cmdret, 0, "Run pgbench");
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/026_shared_blocks.pl
+++ b/t/026_shared_blocks.pl
@@ -88,10 +88,10 @@ PGSM::append_to_file($stdout);
 
 my $port = $node->port;
 
-my $out = system("pgbench -i -s 20 -p $port postgres");
+$cmdret = system("pgbench -i -s 20 -p $port postgres");
 is($cmdret, 0, "Perform pgbench init");
 
-$out = system("pgbench -c 10 -j 2 -t 2000 -p $port postgres");
+$cmdret = system("pgbench -c 10 -j 2 -t 2000 -p $port postgres");
 is($cmdret, 0, "Run pgbench");
 
 ($cmdret, $stdout, $stderr) = $node->psql(

--- a/t/032_multiple_extensions.pl
+++ b/t/032_multiple_extensions.pl
@@ -119,12 +119,10 @@ PGSM::append_to_debug_file($stdout);
 # Create example database and run pgbench init
 ($cmdret, $stdout, $stderr) =
   $node->psql('postgres', 'CREATE DATABASE example;', extra_params => ['-a']);
-print "cmdret $cmdret\n";
 is($cmdret, 0, "CREATE DATABASE example");
 PGSM::append_to_debug_file($stdout);
 
 my $port = $node->port;
-print "port $port \n";
 
 $cmdret = system("pgbench -i -s 20 -p $port example");
 is($cmdret, 0, "Perform pgbench init");

--- a/t/032_multiple_extensions.pl
+++ b/t/032_multiple_extensions.pl
@@ -126,12 +126,10 @@ PGSM::append_to_debug_file($stdout);
 my $port = $node->port;
 print "port $port \n";
 
-my $out = system("pgbench -i -s 20 -p $port example");
-print " out: $out \n";
+$cmdret = system("pgbench -i -s 20 -p $port example");
 is($cmdret, 0, "Perform pgbench init");
 
-$out = system("pgbench -c 10 -j 2 -t 5000 -p $port example");
-print " out: $out \n";
+$cmdret = system("pgbench -c 10 -j 2 -t 5000 -p $port example");
 is($cmdret, 0, "Run pgbench");
 
 ($cmdret, $stdout, $stderr) = $node->psql(


### PR DESCRIPTION
Stop printing the return values and use the same variable name for return values from `system()` as we use for ones from `psql()`.

PG-0
