### PR TITLE
PG-2547 Fix EXEC_BACKEND support

### DIFF
--- a/.github/scripts/build-postgres.sh
+++ b/.github/scripts/build-postgres.sh
@@ -29,9 +29,15 @@ case "$1" in
         export CFLAGS="-fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer -fno-inline-functions"
         ;;
 
+    exec-backend)
+        echo "Building with exec-backend option"
+        export CFLAGS="-DEXEC_BACKEND"
+        ARGS+=" --enable-cassert"
+        ;;
+
     *)
         echo "Unknown build type: $1"
-        echo "Please use one of the following: debug, debugoptimized, sanitize"
+        echo "Please use one of the following: debug, debugoptimized, sanitize, exec-backend"
         exit 1
         ;;
 esac

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -12,7 +12,7 @@ case "$1" in
         echo "Building with debug option"
         ;;
 
-    debugoptimized)
+    debugoptimized | exec-backend)
         echo "Building with debugoptimized option"
         PG_CFLAGS+=" -O2"
         ;;
@@ -29,7 +29,7 @@ case "$1" in
 
     *)
         echo "Unknown build type: $1"
-        echo "Please use one of the following: debug, debugoptimized, sanitize"
+        echo "Please use one of the following: debug, debugoptimized, sanitize, exec-backend"
         exit 1
         ;;
 esac

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -68,6 +68,25 @@ jobs:
         build_type: ${{ matrix.build_type }}
     secrets: inherit
 
+  exec_backend:
+    name: EXEC_BACKEND
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_package: [source]
+        pg_version: [14, 15, 16, 17, 18]
+        os: [ubuntu-24.04]
+        compiler: [gcc]
+        build_type: [exec-backend]
+    uses: ./.github/workflows/build-and-test.yml
+    with:
+        pg_package: ${{ matrix.pg_package }}
+        pg_version: ${{ matrix.pg_version }}
+        os: ${{ matrix.os }}
+        compiler: ${{ matrix.compiler }}
+        build_type: ${{ matrix.build_type }}
+    secrets: inherit
+
   macos:
     name: MacOS
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Support for `EXEC_BACKEND` builds ([PG-2547](https://perconadev.atlassian.net/browse/PG-2547))

--- a/src/hash_query.c
+++ b/src/hash_query.c
@@ -121,8 +121,6 @@ pgsm_startup(void)
 		dsa_pin(dsa);
 		dsa_set_size_limit(dsa, pgsm_query_area_size());
 
-		pgsm->hash_handle = pgsm_create_bucket_hash();
-
 		/*
 		 * If overflow is enabled, set the DSA size to unlimited, and allow
 		 * the DSA to grow beyond the shared memory space into the swap area
@@ -137,13 +135,14 @@ pgsm_startup(void)
 		dsa_detach(dsa);
 	}
 
+	pgsmStateLocal.shared_hash = pgsm_create_bucket_hash();
+
 	LWLockRelease(AddinShmemInitLock);
 
 	pgsmStateLocal.shared_pgsmState = pgsm;
 
 	/* Reset in case this is a restart within the postmaster */
 	pgsmStateLocal.dsa = NULL;
-	pgsmStateLocal.shared_hash = NULL;
 }
 
 /*
@@ -190,7 +189,6 @@ pgsm_attach_shmem(void)
 	 * explicit detach.
 	 */
 	dsa_pin_mapping(pgsmStateLocal.dsa);
-	pgsmStateLocal.shared_hash = pgsmStateLocal.shared_pgsmState->hash_handle;
 	MemoryContextSwitchTo(oldcontext);
 }
 
@@ -254,9 +252,6 @@ hash_entry_dealloc(int bucket_id)
 {
 	HASH_SEQ_STATUS hstat;
 	pgsmEntry  *entry;
-
-	if (!pgsmStateLocal.shared_hash)
-		return;
 
 	/* Iterate over the hash table. */
 	hash_seq_init(&hstat, pgsmStateLocal.shared_hash);

--- a/src/hash_query.h
+++ b/src/hash_query.h
@@ -23,7 +23,6 @@
 #include <storage/lwlock.h>
 #include <storage/spin.h>
 #include <utils/dsa.h>
-#include <utils/hsearch.h>
 #include <utils/timestamp.h>
 
 #define ERROR_MESSAGE_LEN	100
@@ -200,7 +199,6 @@ typedef struct pgsmSharedState
 	pg_atomic_uint64 current_wbucket;
 	pg_atomic_uint64 prev_bucket_sec;
 	void	   *raw_dsa_area;	/* DSA area pointer to store query texts */
-	HTAB	   *hash_handle;
 
 	bool		pgsm_oom;
 	TimestampTz bucket_start_time[];	/* start time of the bucket */


### PR DESCRIPTION
Fix the remaining issue with the initialization of the shared hash tables which needs to be initialized in every backend in an `EXEC_BACKEND` build plus add CI to ensure we do not break `EXEC_BACKEND` again.

PG-2547
