### PR TITLE
PG-2557 Read utility statement exec info before executing this statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 ### Changed
 
 - Do not leave the `pgsm_create_view()` function after running `CREATE EXTENSION`
+- Read utility statement exec info before executing this statement ([PG-2557](https://perconadev.atlassian.net/browse/PG-2557))

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ REGRESS = basic \
 	squashing \
 	tags \
 	user \
+	security_definer \
 	rollback \
 	level_tracking \
 	decode_error_level \

--- a/regression/expected/rollback.out
+++ b/regression/expected/rollback.out
@@ -26,7 +26,7 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
--- During manual rollback we will be able to get username and datname of the query that was rolled back.
+-- During manual rollback we will be able to get username of the query that was rolled back.
 BEGIN;
 INSERT INTO t VALUES (2);
 ROLLBACK;
@@ -45,7 +45,7 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
--- If transaction is rolled back due an error, we won't be able to get username and datname of the query that was rolled back.
+-- If transaction is rolled back due an error, we won't be able to get username of the query that was rolled back.
 BEGIN;
 INSERT INTO t VALUES (1);
 ERROR:  duplicate key value violates unique constraint "t_pkey"
@@ -56,7 +56,7 @@ SELECT query, username, datname FROM pg_stat_monitor ORDER BY query COLLATE "C";
 --------------------------------+----------+--------------------
  BEGIN                          | u        | contrib_regression
  INSERT INTO t VALUES (1);      | u        | contrib_regression
- ROLLBACK                       |          | 
+ ROLLBACK                       |          | contrib_regression
  SELECT pg_stat_monitor_reset() | u        | contrib_regression
 (4 rows)
 

--- a/regression/expected/security_definer.out
+++ b/regression/expected/security_definer.out
@@ -1,0 +1,139 @@
+CREATE USER su WITH SUPERUSER;
+SET ROLE su;
+CREATE EXTENSION pg_stat_monitor;
+SET pg_stat_monitor.pgsm_track = 'all';
+CREATE USER owner_role;
+CREATE USER caller_role;
+GRANT ALL ON SCHEMA public TO owner_role;
+SET ROLE owner_role;
+CREATE TABLE owner_table (a int);
+INSERT INTO owner_table VALUES (1);
+CREATE FUNCTION owner_secdef_func() RETURNS bigint AS $$
+BEGIN
+    RETURN (SELECT count(*) FROM owner_table);
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+CREATE FUNCTION owner_secdef_ddl_func() RETURNS void AS $$
+BEGIN
+    EXECUTE 'CREATE TABLE owner_ddl_table (a int)';
+    EXECUTE 'DROP TABLE owner_ddl_table';
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+CREATE FUNCTION owner_secdef_appname_func() RETURNS void AS $$
+BEGIN
+    PERFORM set_config('application_name', 'secdef_app', false);
+    PERFORM 2 + 2;
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+GRANT EXECUTE ON FUNCTION owner_secdef_func() TO caller_role;
+GRANT EXECUTE ON FUNCTION owner_secdef_ddl_func() TO caller_role;
+GRANT EXECUTE ON FUNCTION owner_secdef_appname_func() TO caller_role;
+SET ROLE su;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SET ROLE caller_role;
+SELECT owner_secdef_func();
+ owner_secdef_func 
+-------------------
+                 1
+(1 row)
+
+SET ROLE su;
+-- The outer call must be attributed to the caller, while the query executed
+-- inside the SECURITY DEFINER function body must be attributed to the
+-- function owner, since that is whose privileges it runs under.
+SELECT username, top_query, query FROM pg_stat_monitor
+  WHERE query NOT LIKE '%pg_stat_monitor%'
+  ORDER BY username, query COLLATE "C";
+  username   |          top_query          |               query                
+-------------+-----------------------------+------------------------------------
+ caller_role |                             | SELECT owner_secdef_func()
+ caller_role |                             | SET ROLE su
+ owner_role  | SELECT owner_secdef_func(); | (SELECT count(*) FROM owner_table)
+ su          |                             | SET ROLE caller_role
+(4 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SET ROLE caller_role;
+SELECT owner_secdef_ddl_func();
+ owner_secdef_ddl_func 
+-----------------------
+ 
+(1 row)
+
+SET ROLE su;
+-- DDL executed inside a SECURITY DEFINER function must still be
+-- attributed to the function owner, not the caller.
+SELECT username, top_query, query FROM pg_stat_monitor
+  WHERE query NOT LIKE '%pg_stat_monitor%'
+  ORDER BY username, query COLLATE "C";
+  username   |            top_query            |                query                 
+-------------+---------------------------------+--------------------------------------
+ caller_role |                                 | SELECT owner_secdef_ddl_func()
+ caller_role |                                 | SET ROLE su
+ owner_role  | SELECT owner_secdef_ddl_func(); | CREATE TABLE owner_ddl_table (a int)
+ owner_role  | SELECT owner_secdef_ddl_func(); | DROP TABLE owner_ddl_table
+ su          |                                 | SET ROLE caller_role
+(5 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SET ROLE caller_role;
+SET application_name = 'caller_app';
+SELECT owner_secdef_appname_func();
+ owner_secdef_appname_func 
+---------------------------
+ 
+(1 row)
+
+RESET application_name;
+SET ROLE su;
+-- application_name may be changed from inside a SECURITY DEFINER function;
+-- queries run after that change must be attributed to the new name.
+SELECT application_name, query FROM pg_stat_monitor
+  WHERE query NOT LIKE '%pg_stat_monitor%'
+  ORDER BY application_name, query COLLATE "C";
+      application_name       |                           query                            
+-----------------------------+------------------------------------------------------------
+ caller_app                  | SELECT owner_secdef_appname_func()
+ caller_app                  | SELECT set_config('application_name', 'secdef_app', false)
+ pg_regress/security_definer | SET ROLE caller_role
+ pg_regress/security_definer | SET ROLE su
+ pg_regress/security_definer | SET application_name = 'caller_app'
+ secdef_app                  | RESET application_name
+ secdef_app                  | SELECT 2 + 2
+(7 rows)
+
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
+SET ROLE owner_role;
+DROP FUNCTION owner_secdef_func();
+DROP FUNCTION owner_secdef_ddl_func();
+DROP FUNCTION owner_secdef_appname_func();
+DROP TABLE owner_table;
+SET ROLE su;
+DROP OWNED BY caller_role;
+DROP USER caller_role;
+DROP OWNED BY owner_role;
+DROP USER owner_role;
+DROP EXTENSION pg_stat_monitor;
+SET ROLE NONE;
+DROP OWNED BY su;
+DROP USER su;

--- a/regression/sql/rollback.sql
+++ b/regression/sql/rollback.sql
@@ -13,7 +13,7 @@ COMMIT;
 SELECT query, username, datname FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset();
 
--- During manual rollback we will be able to get username and datname of the query that was rolled back.
+-- During manual rollback we will be able to get username of the query that was rolled back.
 BEGIN;
 INSERT INTO t VALUES (2);
 ROLLBACK;
@@ -21,7 +21,7 @@ ROLLBACK;
 SELECT query, username, datname FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset();
 
--- If transaction is rolled back due an error, we won't be able to get username and datname of the query that was rolled back.
+-- If transaction is rolled back due an error, we won't be able to get username of the query that was rolled back.
 BEGIN;
 INSERT INTO t VALUES (1);
 ROLLBACK;

--- a/regression/sql/security_definer.sql
+++ b/regression/sql/security_definer.sql
@@ -1,0 +1,102 @@
+CREATE USER su WITH SUPERUSER;
+
+SET ROLE su;
+CREATE EXTENSION pg_stat_monitor;
+SET pg_stat_monitor.pgsm_track = 'all';
+
+CREATE USER owner_role;
+CREATE USER caller_role;
+
+GRANT ALL ON SCHEMA public TO owner_role;
+
+SET ROLE owner_role;
+CREATE TABLE owner_table (a int);
+INSERT INTO owner_table VALUES (1);
+
+CREATE FUNCTION owner_secdef_func() RETURNS bigint AS $$
+BEGIN
+    RETURN (SELECT count(*) FROM owner_table);
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE FUNCTION owner_secdef_ddl_func() RETURNS void AS $$
+BEGIN
+    EXECUTE 'CREATE TABLE owner_ddl_table (a int)';
+    EXECUTE 'DROP TABLE owner_ddl_table';
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE FUNCTION owner_secdef_appname_func() RETURNS void AS $$
+BEGIN
+    PERFORM set_config('application_name', 'secdef_app', false);
+    PERFORM 2 + 2;
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION owner_secdef_func() TO caller_role;
+GRANT EXECUTE ON FUNCTION owner_secdef_ddl_func() TO caller_role;
+GRANT EXECUTE ON FUNCTION owner_secdef_appname_func() TO caller_role;
+
+SET ROLE su;
+SELECT pg_stat_monitor_reset();
+
+SET ROLE caller_role;
+SELECT owner_secdef_func();
+
+SET ROLE su;
+
+-- The outer call must be attributed to the caller, while the query executed
+-- inside the SECURITY DEFINER function body must be attributed to the
+-- function owner, since that is whose privileges it runs under.
+SELECT username, top_query, query FROM pg_stat_monitor
+  WHERE query NOT LIKE '%pg_stat_monitor%'
+  ORDER BY username, query COLLATE "C";
+
+SELECT pg_stat_monitor_reset();
+
+SET ROLE caller_role;
+SELECT owner_secdef_ddl_func();
+
+SET ROLE su;
+
+-- DDL executed inside a SECURITY DEFINER function must still be
+-- attributed to the function owner, not the caller.
+SELECT username, top_query, query FROM pg_stat_monitor
+  WHERE query NOT LIKE '%pg_stat_monitor%'
+  ORDER BY username, query COLLATE "C";
+
+SELECT pg_stat_monitor_reset();
+
+SET ROLE caller_role;
+SET application_name = 'caller_app';
+SELECT owner_secdef_appname_func();
+RESET application_name;
+
+SET ROLE su;
+
+-- application_name may be changed from inside a SECURITY DEFINER function;
+-- queries run after that change must be attributed to the new name.
+SELECT application_name, query FROM pg_stat_monitor
+  WHERE query NOT LIKE '%pg_stat_monitor%'
+  ORDER BY application_name, query COLLATE "C";
+
+SELECT pg_stat_monitor_reset();
+
+SET ROLE owner_role;
+DROP FUNCTION owner_secdef_func();
+DROP FUNCTION owner_secdef_ddl_func();
+DROP FUNCTION owner_secdef_appname_func();
+DROP TABLE owner_table;
+
+SET ROLE su;
+DROP OWNED BY caller_role;
+DROP USER caller_role;
+DROP OWNED BY owner_role;
+DROP USER owner_role;
+
+DROP EXTENSION pg_stat_monitor;
+
+SET ROLE NONE;
+
+DROP OWNED BY su;
+DROP USER su;

--- a/src/hash_query.h
+++ b/src/hash_query.h
@@ -29,7 +29,6 @@
 #define REL_LST				10
 /* schema + dot + relname + view indication + string terminator */
 #define REL_LEN				(NAMEDATALEN + 1 + NAMEDATALEN + 1 + 1)
-#define APPLICATIONNAME_LEN	NAMEDATALEN
 #define COMMENTS_LEN		256
 #define PLAN_TEXT_LEN		1024
 #define SQLCODE_LEN			20
@@ -71,7 +70,7 @@ typedef struct QueryInfo
 	dsa_pointer parent_query;
 	int64		type;			/* type of query, options are query, info,
 								 * warning, error, fatal */
-	char		application_name[APPLICATIONNAME_LEN];
+	char		application_name[NAMEDATALEN];
 	char		comments[COMMENTS_LEN];
 	char		relations[REL_LST][REL_LEN];	/* List of relation involved
 												 * in the query */

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -113,8 +113,6 @@ static struct
 static int	hist_bucket_count_user;
 static int	hist_bucket_count_total;
 
-static uint32 pgsm_client_ip = PGSM_INVALID_IP;
-
 /* The array to store outer layer query id */
 static int64 *nested_queryids;
 static char **nested_query_txts;
@@ -126,8 +124,9 @@ static int	num_relations;		/* Number of relation in the query */
 static bool system_init = false;
 static struct rusage rusage_start;
 
-/* Application name and length; set each time when an stats is created locally */
-static char app_name[APPLICATIONNAME_LEN];
+/* Cached per-backend information */
+static char datname[NAMEDATALEN];
+static uint32 client_ip = PGSM_INVALID_IP;
 
 /* Query buffer, store queries' text. */
 static char *pgsm_explain(QueryDesc *queryDesc);
@@ -191,7 +190,7 @@ PG_FUNCTION_INFO_V1(pg_stat_monitor_decode_error_level);
 PG_FUNCTION_INFO_V1(pg_stat_monitor_get_cmd_type);
 
 static uint pg_get_client_addr(void);
-static int	pg_get_application_name(char *name, int buff_size);
+static void pgsm_set_cached_info(void);
 static Datum intarray_get_datum(const int32 *arr, int len);
 
 static int64 pgsm_hash_string(const char *str, int len);
@@ -206,12 +205,26 @@ typedef struct pgsmQueryStats
 								 * pgsmEntry */
 	int64		pgsm_query_id;	/* pgsm generate normalized query hash */
 	char	   *query;			/* query text, palloc'd in local context */
-	char		datname[NAMEDATALEN];	/* database name */
+	char		appname[NAMEDATALEN];	/* application name */
 	char		username[NAMEDATALEN];	/* user name */
 	Counters	counters;		/* the statistics for this query */
 } pgsmQueryStats;
 
+/*
+ * Structure to store information about the current statement execution.
+ * This data may change during the execution of the query and for statistics
+ * we need to know this data at the time when the statement execution started.
+ */
+typedef struct pgsmQueryExecInfo
+{
+	Oid			userid;
+	char		appname[NAMEDATALEN];
+	char		username[NAMEDATALEN];
+} pgsmQueryExecInfo;
+
+static void pgsm_fill_query_exec_info(pgsmQueryExecInfo *info);
 static pgsmQueryStats *pgsm_create_query_stats(int64 queryid, const PlanInfo *plan_info);
+static pgsmQueryStats *pgsm_create_stats_with_query_exec_info(const pgsmQueryExecInfo *info, int64 queryid, const PlanInfo *plan_info);
 static void pgsm_add_query_stats(pgsmQueryStats *stats, const char *query_text, int query_len);
 static void pgsm_delete_query_stats(uint64 queryid);
 static pgsmQueryStats *pgsm_get_query_stats(int64 queryid, const PlanInfo *plan_info, const char *query_text, CmdType cmd_type);
@@ -1013,9 +1026,17 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		BufferUsage bufusage_start = pgBufferUsage;
 		WalUsage	walusage;
 		WalUsage	walusage_start = pgWalUsage;
-		pgsmQueryStats *stats = pgsm_create_query_stats(queryId, NULL);
+		pgsmQueryStats *stats;
+		pgsmQueryExecInfo info;
 
 		getrusage(RUSAGE_SELF, &rusage_start);
+
+		/*
+		 * Create a query execution info before utility statement execution
+		 * because statement may change the data itself and for statistics we
+		 * need to know this data at the statement execution start time.
+		 */
+		pgsm_fill_query_exec_info(&info);
 
 		INSTR_TIME_SET_CURRENT(start);
 		nesting_level++;
@@ -1042,6 +1063,8 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 			PG_RE_THROW();
 		}
 		PG_END_TRY();
+
+		stats = pgsm_create_stats_with_query_exec_info(&info, queryId, NULL);
 
 		/*
 		 * CAUTION: do not access the *pstmt data structure again below here.
@@ -1168,21 +1191,58 @@ pgsm_hash_string(const char *str, int len)
 }
 
 /*
- * The caller should allocate max_len memory to name including terminating null.
- * The function returns the length of the string.
+ * Set backend-level cached information.
  */
-static int
-pg_get_application_name(char *name, int buff_size)
+static void
+pgsm_set_cached_info(void)
 {
-	int			len;
+	if (client_ip == PGSM_INVALID_IP)
+		client_ip = pg_get_client_addr();
+
+	if (IsTransactionState() && datname[0] == '\0')
+	{
+		char	   *name = get_database_name(MyDatabaseId);
+
+		if (name)
+		{
+			strlcpy(datname, name, NAMEDATALEN);
+			pfree(name);
+		}
+	}
+}
+
+/*
+ * Fill the query execution info with the current statement execution data.
+ * Some data may be changed by statement execution itself, but for
+ * statistics we need this data state at the statement execution start time.
+ */
+static void
+pgsm_fill_query_exec_info(pgsmQueryExecInfo *info)
+{
+	int			sec_ctx;
+
+	/*
+	 * Get the user ID. Let's use this instead of GetUserID as this won't
+	 * throw an assertion in case of an error.
+	 */
+	GetUserIdAndSecContext(&info->userid, &sec_ctx);
 
 	if (application_name && *application_name)
-		len = strlcpy(name, application_name, buff_size);
+		strlcpy(info->appname, application_name, NAMEDATALEN);
 	else
-		len = strlcpy(name, "unknown", buff_size);
+		strlcpy(info->appname, "unknown", NAMEDATALEN);
 
-	/* Return length so that others don't have to calculate */
-	return len < buff_size ? len : buff_size - 1;
+	info->username[0] = '\0';
+	if (IsTransactionState())
+	{
+		char	   *username = GetUserNameFromId(info->userid, true);
+
+		if (username)
+		{
+			strlcpy(info->username, username, NAMEDATALEN);
+			pfree(username);
+		}
+	}
 }
 
 static uint
@@ -1452,63 +1512,44 @@ pgsm_store_error(const char *query, const ErrorData *edata)
 static pgsmQueryStats *
 pgsm_create_query_stats(int64 queryid, const PlanInfo *plan_info)
 {
+	pgsmQueryExecInfo info;
+
+	pgsm_fill_query_exec_info(&info);
+
+	return pgsm_create_stats_with_query_exec_info(&info, queryid, plan_info);
+}
+
+static pgsmQueryStats *
+pgsm_create_stats_with_query_exec_info(const pgsmQueryExecInfo *info, int64 queryid, const PlanInfo *plan_info)
+{
 	pgsmQueryStats *stats;
-	int			sec_ctx;
 	MemoryContext oldctx;
+
+	pgsm_set_cached_info();
 
 	/* Create an stats in the pgsm memory context */
 	oldctx = MemoryContextSwitchTo(PgsmMemoryContext);
 	stats = palloc0_object(pgsmQueryStats);
 
-	/*
-	 * Get the user ID. Let's use this instead of GetUserID as this won't
-	 * throw an assertion in case of an error.
-	 */
-	GetUserIdAndSecContext((Oid *) &stats->key.userid, &sec_ctx);
-
 	if (pgsm_track_application_names)
 	{
-		int			len = pg_get_application_name(app_name, APPLICATIONNAME_LEN);
-
-		stats->key.appid = pgsm_hash_string(app_name, len);
+		stats->key.appid = pgsm_hash_string(info->appname, strlen(info->appname));
 	}
-
-	/* Fetch client address only once */
-	if (pgsm_client_ip == PGSM_INVALID_IP)
-		pgsm_client_ip = pg_get_client_addr();
-
-	stats->key.ip = pgsm_client_ip;
-
-	/* PlanID, if there is one */
+	stats->key.ip = client_ip;
 	stats->key.planid = plan_info ? plan_info->planid : 0;
-
-	/* Set remaining data */
 	stats->key.dbid = MyDatabaseId;
 	stats->key.queryid = queryid;
 	stats->key.parentid = 0;
+	stats->key.userid = info->userid;
+
+	strlcpy(stats->appname, info->appname, NAMEDATALEN);
+	strlcpy(stats->username, info->username, NAMEDATALEN);
 
 #if PG_VERSION_NUM >= 170000
 	stats->key.toplevel = (nesting_level == 0);
 #else
 	stats->key.toplevel = (nesting_level + plan_nested_level == 0);
 #endif
-
-	if (IsTransactionState())
-	{
-		char	   *datname = get_database_name(stats->key.dbid);
-		char	   *username = GetUserNameFromId(stats->key.userid, true);
-
-		if (datname)
-		{
-			strlcpy(stats->datname, datname, sizeof(stats->datname));
-			pfree(datname);
-		}
-		if (username)
-		{
-			strlcpy(stats->username, username, sizeof(stats->username));
-			pfree(username);
-		}
-	}
 
 	MemoryContextSwitchTo(oldctx);
 
@@ -1752,7 +1793,7 @@ pgsm_store(const pgsmQueryStats *stats)
 		entry->counters.info.cmd_type = stats->counters.info.cmd_type;
 		entry->counters.info.parent_query = InvalidDsaPointer;
 
-		strlcpy(entry->datname, stats->datname, sizeof(entry->datname));
+		strlcpy(entry->datname, datname, sizeof(entry->datname));
 		strlcpy(entry->username, stats->username, sizeof(entry->username));
 	}
 
@@ -1780,8 +1821,8 @@ pgsm_store(const pgsmQueryStats *stats)
 	if (pgsm_extract_comments && comments[0] && !entry->counters.info.comments[0])
 		strlcpy(entry->counters.info.comments, comments, COMMENTS_LEN);
 
-	if (pgsm_track_application_names && app_name[0] != '\0' && !entry->counters.info.application_name[0])
-		strlcpy(entry->counters.info.application_name, app_name, APPLICATIONNAME_LEN);
+	if (pgsm_track_application_names && stats->appname[0] != '\0' && !entry->counters.info.application_name[0])
+		strlcpy(entry->counters.info.application_name, stats->appname, NAMEDATALEN);
 
 	entry->counters.info.num_relations = num_relations;
 	for (int i = 0; i < num_relations; i++)


### PR DESCRIPTION
PG-2557

There are two reasons for that change:

1. As a preparation for memory management rework we should move all allocations under utility statement processing as it may reset transaction context that we plan to use as a parent for local PGSM memory context.
2. Some data may be collected only before utility statement execution as statement itself may change this data. Because of that make snapshot before executing statement and later use it for stats item creation.

