### PR TITLE
Do not leave pgsm_create_view() after CREATE EXTENSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,8 @@
 ### Added
 
 - Support for `EXEC_BACKEND` builds ([PG-2547](https://perconadev.atlassian.net/browse/PG-2547))
+
+
+### Changed
+
+- Do not leave the `pgsm_create_view()` function after running `CREATE EXTENSION`

--- a/pg_stat_monitor--2.3--next.sql
+++ b/pg_stat_monitor--2.3--next.sql
@@ -41,30 +41,24 @@ FROM stat
 WHERE queryid = _quryid AND bucket = _bucket
 $$;
 
+DROP FUNCTION pgsm_create_view();
 DROP FUNCTION pgsm_create_13_view();
 DROP VIEW pg_stat_monitor;
 
-CREATE OR REPLACE FUNCTION pgsm_create_view()
-RETURNS int
-LANGUAGE plpgsql
-AS $$
+DO $$
 DECLARE
     version int := current_setting('server_version_num');
 BEGIN
     IF version >= 180000 THEN
-        RETURN pgsm_create_18_view();
+        PERFORM pgsm_create_18_view();
     ELSEIF version >= 170000 THEN
-        RETURN pgsm_create_17_view();
+        PERFORM pgsm_create_17_view();
     ELSEIF version >= 150000 THEN
-        RETURN pgsm_create_15_view();
+        PERFORM pgsm_create_15_view();
     ELSEIF version >= 140000 THEN
-        RETURN pgsm_create_14_view();
+        PERFORM pgsm_create_14_view();
     END IF;
-    RETURN 0;
 END;
 $$;
-
-SELECT pgsm_create_view();
-REVOKE ALL ON FUNCTION pgsm_create_view FROM PUBLIC;
 
 GRANT SELECT ON pg_stat_monitor TO PUBLIC;

--- a/regression/expected/functions.out
+++ b/regression/expected/functions.out
@@ -24,9 +24,8 @@ SELECT routine_schema, routine_name, routine_type, data_type FROM information_sc
  public         | pgsm_create_15_view      | FUNCTION     | integer
  public         | pgsm_create_17_view      | FUNCTION     | integer
  public         | pgsm_create_18_view      | FUNCTION     | integer
- public         | pgsm_create_view         | FUNCTION     | integer
  public         | range                    | FUNCTION     | ARRAY
-(13 rows)
+(12 rows)
 
 SET ROLE u1;
 SELECT routine_schema, routine_name, routine_type, data_type FROM information_schema.routines WHERE routine_schema = 'public' ORDER BY routine_name COLLATE "C";


### PR DESCRIPTION
This function has no use to any user and just pollutes the catalog and public namespace for no reason. A DO block is simpler and does not leave anything behind.

PG-0

