### PR TITLE
PG-2229 Rework memory management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@
 
 - Do not leave the `pgsm_create_view()` function after running `CREATE EXTENSION`
 - Read utility statement exec info before executing this statement ([PG-2557](https://perconadev.atlassian.net/browse/PG-2557))
+
+### Fixed
+
+- Fix memory leak by scoping local memory context to the current transaction ([PG-2229](https://perconadev.atlassian.net/browse/PG-2229))

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -225,9 +225,8 @@ typedef struct pgsmQueryExecInfo
 
 static MemoryContext pgsm_memory_context(void);
 static void pgsm_fill_query_exec_info(pgsmQueryExecInfo *info);
-static pgsmQueryStats *pgsm_create_query_stats(int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type);
+static pgsmQueryStats *pgsm_add_query_stats(int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, int query_len, CmdType cmd_type);
 static void pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type);
-static void pgsm_add_query_stats(pgsmQueryStats *stats, const char *query_text, int query_len);
 static void pgsm_delete_query_stats(uint64 queryid);
 static pgsmQueryStats *pgsm_get_query_stats(int64 queryid, int64 planid, const char *query_text, CmdType cmd_type);
 static int64 get_pgsm_query_id_hash(const char *norm_query, int len);
@@ -415,7 +414,6 @@ pgsm_shmem_request(void)
 static void
 pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, JumbleState *jstate)
 {
-	pgsmQueryStats *stats;
 	const char *query_text;
 	int			query_len;
 	const char *hash_text;
@@ -495,10 +493,9 @@ pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, JumbleState *
 	 * bucket value. The correct bucket value will be needed then to search
 	 * the hash table, or create the appropriate entry.
 	 */
-	stats = pgsm_create_query_stats(query->queryId, 0,
-									get_pgsm_query_id_hash(hash_text, hash_text_len),
-									store_text, query->commandType);
-	pgsm_add_query_stats(stats, store_text, store_text_len);
+	pgsm_add_query_stats(query->queryId, 0,
+						 get_pgsm_query_id_hash(hash_text, hash_text_len),
+						 store_text, store_text_len, query->commandType);
 
 	Assert(list_length(lentries) <= max_nesting_level);
 
@@ -1502,23 +1499,26 @@ pgsm_memory_context(void)
 }
 
 /*
- * Function to create a new pgsmQueryStats structure.
+ * Function to add a new pgsmQueryStats structure to the backend-local list.
  */
 static pgsmQueryStats *
-pgsm_create_query_stats(int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type)
+pgsm_add_query_stats(int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, int query_len, CmdType cmd_type)
 {
 	pgsmQueryStats *stats;
 	pgsmQueryExecInfo info;
 	MemoryContext oldctx;
+	char	   *store_text;
 
 	pgsm_fill_query_exec_info(&info);
 
-	/* Create the stats in the pgsm memory context */
+	/* Create the stats and own the query text in the pgsm memory context */
 	oldctx = MemoryContextSwitchTo(pgsm_memory_context());
 	stats = palloc0_object(pgsmQueryStats);
-	MemoryContextSwitchTo(oldctx);
+	store_text = pnstrdup(query_text, query_len);
 
-	pgsm_fill_query_stats(stats, &info, queryid, planid, pgsm_query_id, query_text, cmd_type);
+	pgsm_fill_query_stats(stats, &info, queryid, planid, pgsm_query_id, store_text, cmd_type);
+	lentries = lappend(lentries, stats);
+	MemoryContextSwitchTo(oldctx);
 
 	return stats;
 }
@@ -1557,19 +1557,6 @@ pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int6
 #else
 	stats->key.toplevel = (nesting_level + plan_nested_level == 0);
 #endif
-}
-
-/*
- * Function to add a new pgsmQueryStats structure to the local list.
- */
-static void
-pgsm_add_query_stats(pgsmQueryStats *stats, const char *query_text, int query_len)
-{
-	MemoryContext oldctx = MemoryContextSwitchTo(pgsm_memory_context());
-
-	stats->query = pnstrdup(query_text, query_len);
-	lentries = lappend(lentries, stats);
-	MemoryContextSwitchTo(oldctx);
 }
 
 /*
@@ -1641,10 +1628,9 @@ pgsm_get_query_stats(int64 queryid, int64 planid, const char *query_text, CmdTyp
 	}
 
 	query_len = strlen(query_text);
-	stats = pgsm_create_query_stats(queryid, planid,
-									get_pgsm_query_id_hash(query_text, query_len),
-									query_text, cmd_type);
-	pgsm_add_query_stats(stats, query_text, query_len);
+	stats = pgsm_add_query_stats(queryid, planid,
+								 get_pgsm_query_id_hash(query_text, query_len),
+								 query_text, query_len, cmd_type);
 
 	return stats;
 }

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -225,11 +225,11 @@ typedef struct pgsmQueryExecInfo
 
 static MemoryContext pgsm_memory_context(void);
 static void pgsm_fill_query_exec_info(pgsmQueryExecInfo *info);
-static pgsmQueryStats *pgsm_create_query_stats(int64 queryid, const PlanInfo *plan_info);
-static void pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, const PlanInfo *plan_info);
+static pgsmQueryStats *pgsm_create_query_stats(int64 queryid, int64 planid);
+static void pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, int64 planid);
 static void pgsm_add_query_stats(pgsmQueryStats *stats, const char *query_text, int query_len);
 static void pgsm_delete_query_stats(uint64 queryid);
-static pgsmQueryStats *pgsm_get_query_stats(int64 queryid, const PlanInfo *plan_info, const char *query_text, CmdType cmd_type);
+static pgsmQueryStats *pgsm_get_query_stats(int64 queryid, int64 planid, const char *query_text, CmdType cmd_type);
 static int64 get_pgsm_query_id_hash(const char *norm_query, int len);
 
 static void pgsm_cleanup_callback(void *arg);
@@ -481,7 +481,7 @@ pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, JumbleState *
 	 * bucket value. The correct bucket value will be needed then to search
 	 * the hash table, or create the appropriate entry.
 	 */
-	stats = pgsm_create_query_stats(query->queryId, NULL);
+	stats = pgsm_create_query_stats(query->queryId, 0);
 
 	/*
 	 * Update other member that are not counters, so that we don't have to
@@ -747,7 +747,7 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 		SysInfo		sys_info;
 		int64		planid = plan_ptr ? plan_ptr->planid : 0;
 
-		stats = pgsm_get_query_stats(queryId, plan_ptr, queryDesc->sourceText, queryDesc->operation);
+		stats = pgsm_get_query_stats(queryId, planid, queryDesc->sourceText, queryDesc->operation);
 
 		if (stats->key.planid == 0 && planid != 0)
 			stats->key.planid = planid;
@@ -846,7 +846,7 @@ pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, Par
 		walusage_start = pgWalUsage;
 		INSTR_TIME_SET_CURRENT(start);
 
-		stats = pgsm_get_query_stats(queryId, NULL, query_string, parse->commandType);
+		stats = pgsm_get_query_stats(queryId, 0, query_string, parse->commandType);
 
 #if PG_VERSION_NUM >= 170000
 		nesting_level++;
@@ -1073,7 +1073,7 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 
 		query_text = CleanQuerytext(queryString, &location, &query_len);
 
-		pgsm_fill_query_stats(&stats, &info, queryId, NULL);
+		pgsm_fill_query_stats(&stats, &info, queryId, 0);
 
 		/* Make it null terminated */
 		stats.query = pnstrdup(query_text, query_len);
@@ -1465,7 +1465,7 @@ pgsm_store_error(const char *query, const ErrorData *edata)
 	queryid = pgsm_hash_string(query, len);
 
 	pgsm_fill_query_exec_info(&info);
-	pgsm_fill_query_stats(&stats, &info, queryid, NULL);
+	pgsm_fill_query_stats(&stats, &info, queryid, 0);
 
 	/*
 	 * Do not allocate new memory for query text as it will be copied to the
@@ -1517,7 +1517,7 @@ pgsm_memory_context(void)
  * Function to create a new pgsmQueryStats structure.
  */
 static pgsmQueryStats *
-pgsm_create_query_stats(int64 queryid, const PlanInfo *plan_info)
+pgsm_create_query_stats(int64 queryid, int64 planid)
 {
 	pgsmQueryStats *stats;
 	pgsmQueryExecInfo info;
@@ -1530,7 +1530,7 @@ pgsm_create_query_stats(int64 queryid, const PlanInfo *plan_info)
 	stats = palloc0_object(pgsmQueryStats);
 	MemoryContextSwitchTo(oldctx);
 
-	pgsm_fill_query_stats(stats, &info, queryid, plan_info);
+	pgsm_fill_query_stats(stats, &info, queryid, planid);
 
 	return stats;
 }
@@ -1539,7 +1539,7 @@ pgsm_create_query_stats(int64 queryid, const PlanInfo *plan_info)
  * Populate non-counter fields of a pgsmQueryStats.
  */
 static void
-pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, const PlanInfo *plan_info)
+pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, int64 planid)
 {
 	pgsm_set_cached_info();
 
@@ -1551,7 +1551,7 @@ pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int6
 		stats->key.appid = pgsm_hash_string(info->appname, strlen(info->appname));
 	}
 	stats->key.ip = client_ip;
-	stats->key.planid = plan_info ? plan_info->planid : 0;
+	stats->key.planid = planid;
 	stats->key.dbid = MyDatabaseId;
 	stats->key.queryid = queryid;
 	stats->key.parentid = 0;
@@ -1624,7 +1624,7 @@ pgsm_delete_query_stats(uint64 queryid)
  * Function to get a pgsmQueryStats structure from the local list.
  */
 static pgsmQueryStats *
-pgsm_get_query_stats(int64 queryid, const PlanInfo *plan_info, const char *query_text, CmdType cmd_type)
+pgsm_get_query_stats(int64 queryid, int64 planid, const char *query_text, CmdType cmd_type)
 {
 	pgsmQueryStats *stats;
 	int			query_len;
@@ -1648,7 +1648,7 @@ pgsm_get_query_stats(int64 queryid, const PlanInfo *plan_info, const char *query
 		}
 	}
 
-	stats = pgsm_create_query_stats(queryid, plan_info);
+	stats = pgsm_create_query_stats(queryid, planid);
 
 	/*
 	 * Update other member that are not counters, so that we don't have to

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -225,8 +225,8 @@ typedef struct pgsmQueryExecInfo
 
 static MemoryContext pgsm_memory_context(void);
 static void pgsm_fill_query_exec_info(pgsmQueryExecInfo *info);
-static pgsmQueryStats *pgsm_create_query_stats(int64 queryid, int64 planid);
-static void pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, int64 planid);
+static pgsmQueryStats *pgsm_create_query_stats(int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type);
+static void pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type);
 static void pgsm_add_query_stats(pgsmQueryStats *stats, const char *query_text, int query_len);
 static void pgsm_delete_query_stats(uint64 queryid);
 static pgsmQueryStats *pgsm_get_query_stats(int64 queryid, int64 planid, const char *query_text, CmdType cmd_type);
@@ -417,10 +417,14 @@ pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, JumbleState *
 {
 	pgsmQueryStats *stats;
 	const char *query_text;
+	int			query_len;
+	const char *hash_text;
+	int			hash_text_len;
+	const char *store_text;
+	int			store_text_len;
 	char	   *norm_query = NULL;
 	int			norm_query_len;
 	int			location;
-	int			query_len;
 
 	/* Safety check... */
 	if (!IsSystemInitialized())
@@ -476,36 +480,25 @@ pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, JumbleState *
 	}
 
 	/*
+	 * pgsm_query_id always groups by the normalized form when we have one.
+	 * But what gets stored as query text depends on the pgsm_normalized_query
+	 * GUC.
+	 */
+	hash_text = norm_query ? norm_query : query_text;
+	hash_text_len = norm_query ? norm_query_len : query_len;
+	store_text = pgsm_normalized_query ? hash_text : query_text;
+	store_text_len = pgsm_normalized_query ? hash_text_len : query_len;
+
+	/*
 	 * At this point, we don't know which bucket this query will land in, so
 	 * passing 0. The store function MUST later update it based on the current
 	 * bucket value. The correct bucket value will be needed then to search
 	 * the hash table, or create the appropriate entry.
 	 */
-	stats = pgsm_create_query_stats(query->queryId, 0);
-
-	/*
-	 * Update other member that are not counters, so that we don't have to
-	 * worry about these.
-	 */
-	stats->pgsm_query_id = get_pgsm_query_id_hash(norm_query ? norm_query : query_text, norm_query_len);
-	stats->counters.info.cmd_type = query->commandType;
-
-	/*
-	 * Add the query text and stats to the local list.
-	 *
-	 * Preserve the normalized query if needed and we got a valid one.
-	 * Otherwise, store the actual query so that we don't have to check what
-	 * query to store when saving into the hash.
-	 *
-	 * In case of query_text, request the function to duplicate it so that it
-	 * is put in the relevant memory context.
-	 */
-	if (pgsm_normalized_query && norm_query)
-		pgsm_add_query_stats(stats, norm_query, norm_query_len);
-	else
-	{
-		pgsm_add_query_stats(stats, query_text, query_len);
-	}
+	stats = pgsm_create_query_stats(query->queryId, 0,
+									get_pgsm_query_id_hash(hash_text, hash_text_len),
+									store_text, query->commandType);
+	pgsm_add_query_stats(stats, store_text, store_text_len);
 
 	Assert(list_length(lentries) <= max_nesting_level);
 
@@ -991,6 +984,7 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		!IsA(parsetree, DeallocateStmt))
 	{
 		const char *query_text;
+		char	   *store_text;
 		int			location = pstmt->stmt_location;
 		int			query_len = pstmt->stmt_len;
 		int			cmd_type = pstmt->commandType;
@@ -1073,12 +1067,12 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 
 		query_text = CleanQuerytext(queryString, &location, &query_len);
 
-		pgsm_fill_query_stats(&stats, &info, queryId, 0);
-
 		/* Make it null terminated */
-		stats.query = pnstrdup(query_text, query_len);
-		stats.pgsm_query_id = get_pgsm_query_id_hash(query_text, query_len);
-		stats.counters.info.cmd_type = cmd_type;
+		store_text = pnstrdup(query_text, query_len);
+
+		pgsm_fill_query_stats(&stats, &info, queryId, 0,
+							  get_pgsm_query_id_hash(query_text, query_len),
+							  store_text, cmd_type);
 
 		/* The plan details are captured when the query finishes */
 		pgsm_update_counters(&stats.counters,	/* counters */
@@ -1095,7 +1089,7 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 
 		pgsm_store(&stats);
 
-		pfree(stats.query);
+		pfree(store_text);
 	}
 	else
 	{
@@ -1459,20 +1453,14 @@ pgsm_store_error(const char *query, const ErrorData *edata)
 {
 	pgsmQueryStats stats = {0};
 	pgsmQueryExecInfo info;
-	int64		queryid;
 	int			len = strlen(query);
 
-	queryid = pgsm_hash_string(query, len);
-
 	pgsm_fill_query_exec_info(&info);
-	pgsm_fill_query_stats(&stats, &info, queryid, 0);
-
-	/*
-	 * Do not allocate new memory for query text as it will be copied to the
-	 * shared memory in pgsm_store().
-	 */
-	stats.query = unconstify(char *, query);
-	stats.pgsm_query_id = get_pgsm_query_id_hash(query, len);
+	pgsm_fill_query_stats(&stats, &info,
+						  pgsm_hash_string(query, len),
+						  0,
+						  get_pgsm_query_id_hash(query, len),
+						  query, CMD_UNKNOWN);
 
 	stats.counters.error.elevel = edata->elevel;
 	strlcpy(stats.counters.error.message, edata->message, ERROR_MESSAGE_LEN);
@@ -1517,7 +1505,7 @@ pgsm_memory_context(void)
  * Function to create a new pgsmQueryStats structure.
  */
 static pgsmQueryStats *
-pgsm_create_query_stats(int64 queryid, int64 planid)
+pgsm_create_query_stats(int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type)
 {
 	pgsmQueryStats *stats;
 	pgsmQueryExecInfo info;
@@ -1530,7 +1518,7 @@ pgsm_create_query_stats(int64 queryid, int64 planid)
 	stats = palloc0_object(pgsmQueryStats);
 	MemoryContextSwitchTo(oldctx);
 
-	pgsm_fill_query_stats(stats, &info, queryid, planid);
+	pgsm_fill_query_stats(stats, &info, queryid, planid, pgsm_query_id, query_text, cmd_type);
 
 	return stats;
 }
@@ -1539,7 +1527,7 @@ pgsm_create_query_stats(int64 queryid, int64 planid)
  * Populate non-counter fields of a pgsmQueryStats.
  */
 static void
-pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, int64 planid)
+pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type)
 {
 	pgsm_set_cached_info();
 
@@ -1556,6 +1544,10 @@ pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int6
 	stats->key.queryid = queryid;
 	stats->key.parentid = 0;
 	stats->key.userid = info->userid;
+
+	stats->pgsm_query_id = pgsm_query_id;
+	stats->counters.info.cmd_type = cmd_type;
+	stats->query = unconstify(char *, query_text);
 
 	strlcpy(stats->appname, info->appname, NAMEDATALEN);
 	strlcpy(stats->username, info->username, NAMEDATALEN);
@@ -1648,15 +1640,10 @@ pgsm_get_query_stats(int64 queryid, int64 planid, const char *query_text, CmdTyp
 		}
 	}
 
-	stats = pgsm_create_query_stats(queryid, planid);
-
-	/*
-	 * Update other member that are not counters, so that we don't have to
-	 * worry about these.
-	 */
 	query_len = strlen(query_text);
-	stats->pgsm_query_id = get_pgsm_query_id_hash(query_text, query_len);
-	stats->counters.info.cmd_type = cmd_type;
+	stats = pgsm_create_query_stats(queryid, planid,
+									get_pgsm_query_id_hash(query_text, query_len),
+									query_text, cmd_type);
 	pgsm_add_query_stats(stats, query_text, query_len);
 
 	return stats;

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -204,6 +204,7 @@ typedef struct pgsmQueryStats
 	pgsmHashKey key;			/* key used to find/create the shared
 								 * pgsmEntry */
 	int64		pgsm_query_id;	/* pgsm generate normalized query hash */
+	SubTransactionId subxid;	/* subtransaction the query belongs to */
 	char	   *query;			/* query text, palloc'd in local context */
 	char		appname[NAMEDATALEN];	/* application name */
 	char		username[NAMEDATALEN];	/* user name */
@@ -222,15 +223,18 @@ typedef struct pgsmQueryExecInfo
 	char		username[NAMEDATALEN];
 } pgsmQueryExecInfo;
 
+static MemoryContext pgsm_memory_context(void);
 static void pgsm_fill_query_exec_info(pgsmQueryExecInfo *info);
 static pgsmQueryStats *pgsm_create_query_stats(int64 queryid, const PlanInfo *plan_info);
-static pgsmQueryStats *pgsm_create_stats_with_query_exec_info(const pgsmQueryExecInfo *info, int64 queryid, const PlanInfo *plan_info);
+static void pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, const PlanInfo *plan_info);
 static void pgsm_add_query_stats(pgsmQueryStats *stats, const char *query_text, int query_len);
 static void pgsm_delete_query_stats(uint64 queryid);
 static pgsmQueryStats *pgsm_get_query_stats(int64 queryid, const PlanInfo *plan_info, const char *query_text, CmdType cmd_type);
 static int64 get_pgsm_query_id_hash(const char *norm_query, int len);
 
 static void pgsm_cleanup_callback(void *arg);
+static void pgsm_subxact_callback(SubXactEvent event, SubTransactionId mySubid,
+								  SubTransactionId parentSubid, void *arg);
 static void pgsm_store_error(const char *query, const ErrorData *edata);
 
 /*---- Local variables ----*/
@@ -239,7 +243,6 @@ static MemoryContextCallback mem_cxt_reset_callback =
 	.func = pgsm_cleanup_callback,
 	.arg = NULL
 };
-static bool callback_setup = false;
 
 static void pgsm_update_counters(Counters *counters,
 								 const PlanInfo *plan_info,
@@ -341,6 +344,8 @@ _PG_init(void)
 	prev_emit_log_hook = emit_log_hook;
 	emit_log_hook = pgsm_emit_log_hook;
 
+	RegisterSubXactCallback(pgsm_subxact_callback, NULL);
+
 	/*
 	 * Use max_stack_depth as a very high and very rough estimate for maximum
 	 * query nesting.
@@ -348,10 +353,6 @@ _PG_init(void)
 	max_nesting_level = max_stack_depth;
 
 	oldctx = MemoryContextSwitchTo(TopMemoryContext);
-
-	PgsmMemoryContext = AllocSetContextCreate(TopMemoryContext,
-											  "pg_stat_monitor local store",
-											  ALLOCSET_DEFAULT_SIZES);
 
 	nested_queryids = palloc_array(int64, max_nesting_level);
 	nested_query_txts = palloc0_array(char *, max_nesting_level);
@@ -424,19 +425,6 @@ pgsm_post_parse_analyze_internal(ParseState *pstate, Query *query, JumbleState *
 	/* Safety check... */
 	if (!IsSystemInitialized())
 		return;
-
-	if (!callback_setup)
-	{
-		/*
-		 * If MessageContext is valid setup a callback to cleanup our local
-		 * stats list when the MessagContext gets reset
-		 */
-		if (MemoryContextIsValid(MessageContext))
-		{
-			MemoryContextRegisterResetCallback(MessageContext, &mem_cxt_reset_callback);
-			callback_setup = true;
-		}
-	}
 
 	if (!pgsm_enabled(nesting_level))
 		return;
@@ -757,11 +745,12 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 		pgsmQueryStats *stats;
 		struct rusage rusage_end;
 		SysInfo		sys_info;
+		int64		planid = plan_ptr ? plan_ptr->planid : 0;
 
 		stats = pgsm_get_query_stats(queryId, plan_ptr, queryDesc->sourceText, queryDesc->operation);
 
-		if (stats->key.planid == 0 && plan_ptr)
-			stats->key.planid = plan_ptr->planid;
+		if (stats->key.planid == 0 && planid != 0)
+			stats->key.planid = planid;
 
 		/*
 		 * Make sure stats accumulation is done.  (Note: it's okay if several
@@ -857,8 +846,7 @@ pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, Par
 		walusage_start = pgWalUsage;
 		INSTR_TIME_SET_CURRENT(start);
 
-		if (MemoryContextIsValid(MessageContext))
-			stats = pgsm_get_query_stats(queryId, NULL, query_string, parse->commandType);
+		stats = pgsm_get_query_stats(queryId, NULL, query_string, parse->commandType);
 
 #if PG_VERSION_NUM >= 170000
 		nesting_level++;
@@ -1015,7 +1003,7 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		BufferUsage bufusage_start = pgBufferUsage;
 		WalUsage	walusage;
 		WalUsage	walusage_start = pgWalUsage;
-		pgsmQueryStats *stats;
+		pgsmQueryStats stats = {0};
 		pgsmQueryExecInfo info;
 
 		getrusage(RUSAGE_SELF, &rusage_start);
@@ -1051,8 +1039,6 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		}
 		PG_END_TRY();
 
-		stats = pgsm_create_stats_with_query_exec_info(&info, queryId, NULL);
-
 		/*
 		 * CAUTION: do not access the *pstmt data structure again below here.
 		 * If it was a ROLLBACK or similar, that data structure may have been
@@ -1087,12 +1073,15 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 
 		query_text = CleanQuerytext(queryString, &location, &query_len);
 
-		stats->query = pnstrdup(query_text, query_len);
-		stats->pgsm_query_id = get_pgsm_query_id_hash(query_text, query_len);
-		stats->counters.info.cmd_type = cmd_type;
+		pgsm_fill_query_stats(&stats, &info, queryId, NULL);
+
+		/* Make it null terminated */
+		stats.query = pnstrdup(query_text, query_len);
+		stats.pgsm_query_id = get_pgsm_query_id_hash(query_text, query_len);
+		stats.counters.info.cmd_type = cmd_type;
 
 		/* The plan details are captured when the query finishes */
-		pgsm_update_counters(&stats->counters,	/* counters */
+		pgsm_update_counters(&stats.counters,	/* counters */
 							 NULL,	/* PlanInfo */
 							 &sys_info, /* SysInfo */
 							 0, /* plan_total_time */
@@ -1104,10 +1093,9 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 							 0, /* parallel_workers_to_launch */
 							 0);	/* parallel_workers_launched */
 
-		pgsm_store(stats);
+		pgsm_store(&stats);
 
-		pfree(stats->query);
-		pfree(stats);
+		pfree(stats.query);
 	}
 	else
 	{
@@ -1469,25 +1457,60 @@ pgsm_merge_counters(Counters *dst, const Counters *src)
 static void
 pgsm_store_error(const char *query, const ErrorData *edata)
 {
-	pgsmQueryStats *stats;
+	pgsmQueryStats stats = {0};
+	pgsmQueryExecInfo info;
 	int64		queryid;
 	int			len = strlen(query);
 
 	queryid = pgsm_hash_string(query, len);
 
-	stats = pgsm_create_query_stats(queryid, NULL);
-	stats->query = pnstrdup(query, len);
+	pgsm_fill_query_exec_info(&info);
+	pgsm_fill_query_stats(&stats, &info, queryid, NULL);
 
-	stats->pgsm_query_id = get_pgsm_query_id_hash(query, len);
+	/*
+	 * Do not allocate new memory for query text as it will be copied to the
+	 * shared memory in pgsm_store().
+	 */
+	stats.query = unconstify(char *, query);
+	stats.pgsm_query_id = get_pgsm_query_id_hash(query, len);
 
-	stats->counters.error.elevel = edata->elevel;
-	strlcpy(stats->counters.error.message, edata->message, ERROR_MESSAGE_LEN);
-	strlcpy(stats->counters.error.sqlcode, unpack_sql_state(edata->sqlerrcode), SQLCODE_LEN);
+	stats.counters.error.elevel = edata->elevel;
+	strlcpy(stats.counters.error.message, edata->message, ERROR_MESSAGE_LEN);
+	strlcpy(stats.counters.error.sqlcode, unpack_sql_state(edata->sqlerrcode), SQLCODE_LEN);
 
-	pgsm_store(stats);
+	pgsm_store(&stats);
+}
 
-	pfree(stats->query);
-	pfree(stats);
+/*
+ * Return pgsm local memory context.
+ *
+ * This context is used to store intermediate query statistics before it will be added
+ * to the buckets in shared memory.
+ */
+static MemoryContext
+pgsm_memory_context(void)
+{
+	Assert(IsTransactionState());
+
+	if (PgsmMemoryContext == NULL)
+	{
+		/*
+		 * We expect top transaction context to be available in any possible
+		 * scenario. CurrentMemoryContext here is just a failsafe mechanism,
+		 * it should never happen.
+		 */
+		MemoryContext parent = IsTransactionState() ? TopTransactionContext
+			: CurrentMemoryContext;
+
+		PgsmMemoryContext = AllocSetContextCreate(parent,
+												  "pg_stat_monitor local store",
+												  ALLOCSET_START_SMALL_SIZES);
+		MemoryContextRegisterResetCallback(PgsmMemoryContext,
+										   &mem_cxt_reset_callback);
+		lentries = NIL;
+	}
+
+	return PgsmMemoryContext;
 }
 
 /*
@@ -1496,24 +1519,32 @@ pgsm_store_error(const char *query, const ErrorData *edata)
 static pgsmQueryStats *
 pgsm_create_query_stats(int64 queryid, const PlanInfo *plan_info)
 {
+	pgsmQueryStats *stats;
 	pgsmQueryExecInfo info;
+	MemoryContext oldctx;
 
 	pgsm_fill_query_exec_info(&info);
 
-	return pgsm_create_stats_with_query_exec_info(&info, queryid, plan_info);
+	/* Create the stats in the pgsm memory context */
+	oldctx = MemoryContextSwitchTo(pgsm_memory_context());
+	stats = palloc0_object(pgsmQueryStats);
+	MemoryContextSwitchTo(oldctx);
+
+	pgsm_fill_query_stats(stats, &info, queryid, plan_info);
+
+	return stats;
 }
 
-static pgsmQueryStats *
-pgsm_create_stats_with_query_exec_info(const pgsmQueryExecInfo *info, int64 queryid, const PlanInfo *plan_info)
+/*
+ * Populate non-counter fields of a pgsmQueryStats.
+ */
+static void
+pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, const PlanInfo *plan_info)
 {
-	pgsmQueryStats *stats;
-	MemoryContext oldctx;
-
 	pgsm_set_cached_info();
 
-	/* Create an stats in the pgsm memory context */
-	oldctx = MemoryContextSwitchTo(PgsmMemoryContext);
-	stats = palloc0_object(pgsmQueryStats);
+	stats->subxid = IsTransactionState() ? GetCurrentSubTransactionId()
+		: InvalidSubTransactionId;
 
 	if (pgsm_track_application_names)
 	{
@@ -1534,10 +1565,6 @@ pgsm_create_stats_with_query_exec_info(const pgsmQueryExecInfo *info, int64 quer
 #else
 	stats->key.toplevel = (nesting_level + plan_nested_level == 0);
 #endif
-
-	MemoryContextSwitchTo(oldctx);
-
-	return stats;
 }
 
 /*
@@ -1546,8 +1573,7 @@ pgsm_create_stats_with_query_exec_info(const pgsmQueryExecInfo *info, int64 quer
 static void
 pgsm_add_query_stats(pgsmQueryStats *stats, const char *query_text, int query_len)
 {
-	/* Switch to pgsm memory context */
-	MemoryContext oldctx = MemoryContextSwitchTo(PgsmMemoryContext);
+	MemoryContext oldctx = MemoryContextSwitchTo(pgsm_memory_context());
 
 	stats->query = pnstrdup(query_text, query_len);
 	lentries = lappend(lentries, stats);
@@ -1639,11 +1665,38 @@ pgsm_get_query_stats(int64 queryid, const PlanInfo *plan_info, const char *query
 static void
 pgsm_cleanup_callback(void *arg)
 {
-	/* Reset the memory context holding the list */
-	MemoryContextReset(PgsmMemoryContext);
-
+	PgsmMemoryContext = NULL;
 	lentries = NIL;
-	callback_setup = false;
+}
+
+/*
+ * On subtransaction abort, discard any in-flight local stats that belong to the
+ * aborting subtransaction.
+ */
+static void
+pgsm_subxact_callback(SubXactEvent event, SubTransactionId mySubid,
+					  SubTransactionId parentSubid, void *arg)
+{
+	ListCell   *lc;
+
+	if (event != SUBXACT_EVENT_ABORT_SUB)
+		return;
+
+	foreach(lc, lentries)
+	{
+		pgsmQueryStats *stats = lfirst(lc);
+
+		/*
+		 * Prune entries stamped by the aborting subxact. Using >= is
+		 * defensive (cleanup everything that is not yet pruned)
+		 */
+		if (stats->subxid >= mySubid)
+		{
+			lentries = foreach_delete_current(lentries, lc);
+			pfree(stats->query);
+			pfree(stats);
+		}
+	}
 }
 
 /*

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1165,7 +1165,7 @@ pgsm_set_cached_info(void)
 	if (client_ip == PGSM_INVALID_IP)
 		client_ip = pg_get_client_addr();
 
-	if (IsTransactionState() && datname[0] == '\0')
+	if (datname[0] == '\0' && IsTransactionState())
 	{
 		char	   *name = get_database_name(MyDatabaseId);
 


### PR DESCRIPTION
PG-2229

Use TopTransactionContext as a parent for pgsm context. Create it lazy for each statement. If there were aborted subtransactions, cleanup local stats list for such entries, otherwise statistics may be compromised. For statement error scenario and utility statements we don't need cross-hook objects, so allocate stats object there on stack.

