### PR TITLE
PG-2602 Deprecate pgsm_track_application_names parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Set unit for `pg_stat_monitor.pgsm_query_max_len` to bytes
 - Do not leave the `pgsm_create_view()` function after running `CREATE EXTENSION`
 - Specifying `USE_PGXS` is no longer necessary when building with make
+- Deprecate the `pgsm_track_application_names` parameter, application name now tracked always ([PG-2602](https://perconadev.atlassian.net/browse/PG-2602))
 
 ### Removed
 

--- a/regression/expected/application_name.out
+++ b/regression/expected/application_name.out
@@ -24,32 +24,9 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
-SELECT 1 AS num;
- num 
------
-   1
-(1 row)
-
+-- The parameter is deprecated and has no effect, but setting it must still
+-- emit a deprecation warning.
 SET pg_stat_monitor.pgsm_track_application_names = off;
-SELECT 1 AS num;
- num 
------
-   1
-(1 row)
-
-SELECT query, application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
-                         query                          |      application_name       
---------------------------------------------------------+-----------------------------
- SELECT 1 AS num                                        | pg_regress/application_name
- SELECT 1 AS num                                        | 
- SELECT pg_stat_monitor_reset()                         | pg_regress/application_name
- SET pg_stat_monitor.pgsm_track_application_names = off | 
-(4 rows)
-
-SELECT pg_stat_monitor_reset();
- pg_stat_monitor_reset 
------------------------
- 
-(1 row)
-
+WARNING:  pg_stat_monitor.pgsm_track_application_names is deprecated and has no effect
+DETAIL:  Application names are always tracked.
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/application_name.sql
+++ b/regression/sql/application_name.sql
@@ -5,10 +5,8 @@ SELECT 1 AS num;
 SELECT query, application_name FROM pg_stat_monitor ORDER BY query COLLATE "C";
 SELECT pg_stat_monitor_reset();
 
-SELECT 1 AS num;
+-- The parameter is deprecated and has no effect, but setting it must still
+-- emit a deprecation warning.
 SET pg_stat_monitor.pgsm_track_application_names = off;
-SELECT 1 AS num;
-SELECT query, application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
-SELECT pg_stat_monitor_reset();
 
 DROP EXTENSION pg_stat_monitor;

--- a/src/guc.c
+++ b/src/guc.c
@@ -34,7 +34,7 @@ bool		pgsm_enable_query_plan;
 bool		pgsm_enable_overflow;
 bool		pgsm_normalized_query;
 bool		pgsm_track_utility;
-bool		pgsm_track_application_names;
+static bool pgsm_track_application_names;	/* deprecated */
 bool		pgsm_enable_pgsm_query_id;
 int			pgsm_track = PGSM_TRACK_TOP;
 
@@ -49,6 +49,9 @@ static const struct config_enum_entry track_options[] =
 /* Check hooks to ensure histogram_min < histogram_max */
 static bool check_histogram_min(double *newval, void **extra, GucSource source);
 static bool check_histogram_max(double *newval, void **extra, GucSource source);
+
+/* Check hook warning that a deprecated parameter has no effect */
+static bool check_track_application_names(bool *newval, void **extra, GucSource source);
 
 /*
  * Define (or redefine) custom GUC variables.
@@ -181,13 +184,13 @@ init_guc(void)
 		);
 
 	DefineCustomBoolVariable("pg_stat_monitor.pgsm_track_application_names",	/* name */
-							 "Enable/Disable application names tracking.",	/* short_desc */
+							 "Deprecated, has no effect. Application names are always tracked.",	/* short_desc */
 							 NULL,	/* long_desc */
 							 &pgsm_track_application_names, /* value address */
 							 true,	/* boot value */
 							 PGC_USERSET,	/* context */
 							 0, /* flags */
-							 NULL,	/* check_hook */
+							 check_track_application_names, /* check_hook */
 							 NULL,	/* assign_hook */
 							 NULL	/* show_hook */
 		);
@@ -292,4 +295,16 @@ static bool
 check_histogram_max(double *newval, void **extra, GucSource source)
 {
 	return *newval >= (pgsm_histogram_min + 1.0);
+}
+
+static bool
+check_track_application_names(bool *newval, void **extra, GucSource source)
+{
+	if (source >= PGC_S_FILE)
+		ereport(WARNING,
+				(errcode(ERRCODE_WARNING_DEPRECATED_FEATURE),
+				 errmsg("pg_stat_monitor.pgsm_track_application_names is deprecated and has no effect"),
+				 errdetail("Application names are always tracked.")));
+
+	return true;
 }

--- a/src/guc.h
+++ b/src/guc.h
@@ -41,7 +41,6 @@ extern bool pgsm_enable_query_plan;
 extern bool pgsm_enable_overflow;
 extern bool pgsm_normalized_query;
 extern bool pgsm_track_utility;
-extern bool pgsm_track_application_names;
 extern bool pgsm_enable_pgsm_query_id;
 extern int	pgsm_track;
 

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1563,10 +1563,7 @@ pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int6
 	stats->subxid = IsTransactionState() ? GetCurrentSubTransactionId()
 		: InvalidSubTransactionId;
 
-	if (pgsm_track_application_names)
-	{
-		stats->key.appid = pgsm_hash_string(info->appname, strlen(info->appname));
-	}
+	stats->key.appid = pgsm_hash_string(info->appname, strlen(info->appname));
 	stats->key.ip = client_ip;
 	stats->key.planid = planid;
 	stats->key.dbid = MyDatabaseId;
@@ -1838,7 +1835,7 @@ pgsm_store(const pgsmQueryStats *stats)
 	if (pgsm_extract_comments && comments[0] && !entry->counters.info.comments[0])
 		strlcpy(entry->counters.info.comments, comments, COMMENTS_LEN);
 
-	if (pgsm_track_application_names && stats->appname[0] != '\0' && !entry->counters.info.application_name[0])
+	if (stats->appname[0] != '\0' && !entry->counters.info.application_name[0])
 		strlcpy(entry->counters.info.application_name, stats->appname, NAMEDATALEN);
 
 	entry->counters.info.num_relations = num_relations;


### PR DESCRIPTION
PG-2602

This parameter was introduced to address performance issues caused by application name tracking. Code parts that were causing these issues were removed in b0ebcc8, so this parameter has no sense anymore.



