### PR TITLE
Fix stats for queries executed via prepared statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@
 - Potential buffer overread in comment extraction ([PG-2540](https://perconadev.atlassian.net/browse/PG-2540))
 - Do not access `PlannedStmt` after we call `standard_ProcessUtility()` ([PG-2486](https://perconadev.atlassian.net/browse/PG-2486))
 - Various improvements to the stability of our test suite
+- Make sure that for prepared statements utility statement exec info read at the executor start hook, where data is not yet modified by query itself

--- a/regression/expected/application_name_unique.out
+++ b/regression/expected/application_name_unique.out
@@ -35,4 +35,41 @@ SELECT pg_stat_monitor_reset();
  
 (1 row)
 
+-- Check for prepared statements
+-- Use generic plan to avoid re-parsing and planner call
+SET plan_cache_mode = force_generic_plan;
+PREPARE p AS SELECT set_config('application_name', 'selfset', false);
+EXECUTE p;
+ set_config 
+------------
+ selfset
+(1 row)
+
+SET application_name = 'another_name';
+EXECUTE p;
+ set_config 
+------------
+ selfset
+(1 row)
+
+-- Prepared statements should not have application_name 'selfset'
+SELECT query, application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
+                                 query                                 | application_name 
+-----------------------------------------------------------------------+------------------
+ PREPARE p AS SELECT set_config('application_name', 'selfset', false); | another_name
+ PREPARE p AS SELECT set_config('application_name', 'selfset', false); | psql
+ SELECT pg_stat_monitor_reset()                                        | psql
+ SET application_name = 'another_name'                                 | selfset
+ SET plan_cache_mode = force_generic_plan                              | psql
+(5 rows)
+
+DEALLOCATE p;
+RESET application_name;
+RESET plan_cache_mode;
+SELECT pg_stat_monitor_reset();
+ pg_stat_monitor_reset 
+-----------------------
+ 
+(1 row)
+
 DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/application_name_unique.sql
+++ b/regression/sql/application_name_unique.sql
@@ -6,4 +6,23 @@ SET application_name = 'psql';
 SELECT 1 AS num;
 SELECT query, application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
 SELECT pg_stat_monitor_reset();
+
+-- Check for prepared statements
+
+-- Use generic plan to avoid re-parsing and planner call
+SET plan_cache_mode = force_generic_plan;
+PREPARE p AS SELECT set_config('application_name', 'selfset', false);
+
+EXECUTE p;
+SET application_name = 'another_name';
+EXECUTE p;
+
+-- Prepared statements should not have application_name 'selfset'
+SELECT query, application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
+
+DEALLOCATE p;
+RESET application_name;
+RESET plan_cache_mode;
+SELECT pg_stat_monitor_reset();
+
 DROP EXTENSION pg_stat_monitor;

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -546,6 +546,14 @@ pgsm_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		queryDesc->plannedstmt->queryId != INT64CONST(0))
 	{
 		/*
+		 * Make sure a local stats entry exists before the query runs, so its
+		 * snapshot of the execution info (application_name, user) reflects
+		 * the state at statement start.
+		 */
+		(void) pgsm_get_query_stats(queryDesc->plannedstmt->queryId, 0,
+									queryDesc->sourceText, queryDesc->operation);
+
+		/*
 		 * Set up to track total elapsed time in ExecutorRun.  Make sure the
 		 * space is allocated in the per-query context so it will go away at
 		 * ExecutorEnd.


### PR DESCRIPTION
If prepared statement was created in one transaction and executed in another it may produce entry with incorrect data if query itself changes application name or user. So to fix this we just need to be sure that stas item exists in executor start hook, were no mutations we done yet.

PG-0

### Description
<!--- Describe your changes in detail -->


### Links
<!--- Please provide links to any related PRs in this or other repositories --->

