### PR TITLE
Do not represent application name not set as "unknown"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Do not leave the `pgsm_create_view()` function after running `CREATE EXTENSION`
 - Specifying `USE_PGXS` is no longer necessary when building with make
 - Deprecate the `pgsm_track_application_names` parameter, application name now tracked always ([PG-2602](https://perconadev.atlassian.net/browse/PG-2602))
+- Show `NULL` instead of `'unknown'` when `application_name` is not set
 
 ### Removed
 

--- a/regression/expected/application_name.out
+++ b/regression/expected/application_name.out
@@ -11,12 +11,21 @@ SELECT 1 AS num;
    1
 (1 row)
 
-SELECT query, application_name FROM pg_stat_monitor ORDER BY query COLLATE "C";
-             query              |      application_name       
---------------------------------+-----------------------------
- SELECT 1 AS num                | pg_regress/application_name
- SELECT pg_stat_monitor_reset() | pg_regress/application_name
-(2 rows)
+SET application_name = '';
+SELECT 1 AS num;
+ num 
+-----
+   1
+(1 row)
+
+SELECT query, application_name, application_name IS NULL AS isnull FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
+             query              |      application_name       | isnull 
+--------------------------------+-----------------------------+--------
+ SELECT 1 AS num                | pg_regress/application_name | f
+ SELECT 1 AS num                |                             | t
+ SELECT pg_stat_monitor_reset() | pg_regress/application_name | f
+ SET application_name = ''      | pg_regress/application_name | f
+(4 rows)
 
 SELECT pg_stat_monitor_reset();
  pg_stat_monitor_reset 

--- a/regression/sql/application_name.sql
+++ b/regression/sql/application_name.sql
@@ -2,7 +2,9 @@ CREATE EXTENSION pg_stat_monitor;
 SELECT pg_stat_monitor_reset();
 
 SELECT 1 AS num;
-SELECT query, application_name FROM pg_stat_monitor ORDER BY query COLLATE "C";
+SET application_name = '';
+SELECT 1 AS num;
+SELECT query, application_name, application_name IS NULL AS isnull FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
 SELECT pg_stat_monitor_reset();
 
 -- The parameter is deprecated and has no effect, but setting it must still

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1219,10 +1219,10 @@ pgsm_fill_query_exec_info(pgsmQueryExecInfo *info)
 	 */
 	GetUserIdAndSecContext(&info->userid, &sec_ctx);
 
-	if (application_name && *application_name)
+	if (application_name)
 		strlcpy(info->appname, application_name, NAMEDATALEN);
 	else
-		strlcpy(info->appname, "unknown", NAMEDATALEN);
+		strlcpy(info->appname, "", NAMEDATALEN);
 
 	info->username[0] = '\0';
 	if (IsTransactionState())


### PR DESCRIPTION
Setting the application name to the empty string does not mean that it is unknown, it means that it is not set so store it as the empty string which our code outputs as NULL. Another option would have been to output the empty string, but treating it as NULL fits well with e.g. the behavior of jsonlog.

PG-0

