### PR TITLE
Clean up comments

### DIFF
--- a/src/hash_query.c
+++ b/src/hash_query.c
@@ -184,11 +184,9 @@ pgsm_attach_shmem(void)
 	pgsmStateLocal.dsa = dsa_attach_in_place(pgsmStateLocal.shared_pgsmState->raw_dsa_area,
 											 NULL);
 
-	/*
-	 * pin the attached area to keep the area attached until end of session or
-	 * explicit detach.
-	 */
+	/* Keep area attached until end of session */
 	dsa_pin_mapping(pgsmStateLocal.dsa);
+
 	MemoryContextSwitchTo(oldcontext);
 }
 

--- a/src/hash_query.c
+++ b/src/hash_query.c
@@ -177,7 +177,7 @@ pgsm_attach_shmem(void)
 
 	/*
 	 * We want the dsa to remain valid throughout the lifecycle of this
-	 * process. so switch to TopMemoryContext before attaching
+	 * process so switch to TopMemoryContext before attaching.
 	 */
 	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
 

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1274,7 +1274,7 @@ pgsm_update_counters(Counters *counters,
 					 int parallel_workers_launched)
 {
 	/*
-	 * Only the update totals here, min/max/mean will be computed in
+	 * Only update the totals here, min/max/mean will be computed in
 	 * pgsm_merge_counters.
 	 */
 	counters->plantime.total_time += plan_total_time;

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1597,6 +1597,7 @@ pgsm_delete_query_stats(uint64 queryid)
 	if (lentries == NIL)
 		return;
 
+	/* Look at end of list first */
 	stats = (pgsmQueryStats *) llast(lentries);
 	if (stats->key.queryid == queryid)
 	{
@@ -1605,12 +1606,6 @@ pgsm_delete_query_stats(uint64 queryid)
 		pfree(stats);
 		return;
 	}
-
-	/*
-	 * The rest of the code is just paranoia. In theory this list is a stack,
-	 * and we always want to remove the last item. Similarly, in the getter
-	 * method we are always looking for the last item.
-	 */
 
 	foreach(lc, lentries)
 	{

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1700,13 +1700,6 @@ pgsm_subxact_callback(SubXactEvent event, SubTransactionId mySubid,
 
 /*
  * Store some statistics for a statement.
- *
- * If queryId is 0 then this is a utility statement and we should compute
- * a suitable queryId internally.
- *
- * If jstate is not NULL then we're trying to create an entry for which
- * we have no statistics as yet; we just want to record the normalized
- * query string.  total_time, rows, bufusage are ignored in this case.
  */
 static void
 pgsm_store(const pgsmQueryStats *stats)


### PR DESCRIPTION
Various improvements of comments:

- Fix typos
- Remove an outdated part of a comment
- Clarify comments in `pgsm_delete_query_stats()`
- Clarify a comment about attaching to DSA

PG-0