### PR TITLE
Remove unused field minmax_stats_since

### DIFF
--- a/src/hash_query.c
+++ b/src/hash_query.c
@@ -239,7 +239,6 @@ hash_entry_alloc(pgsmSharedState *pgsm, const pgsmHashKey *key)
 		entry->query = InvalidDsaPointer;
 		entry->counters.info.parent_query = InvalidDsaPointer;
 		entry->stats_since = GetCurrentTimestamp();
-		entry->minmax_stats_since = entry->stats_since;
 
 		/* set the appropriate initial usage count */
 		/* re-initialize the mutex each time ... we assume no one using it */

--- a/src/hash_query.h
+++ b/src/hash_query.h
@@ -186,7 +186,6 @@ typedef struct pgsmEntry
 	char		username[NAMEDATALEN];	/* user name */
 	Counters	counters;		/* the statistics for this query */
 	TimestampTz stats_since;	/* timestamp of entry allocation */
-	TimestampTz minmax_stats_since; /* timestamp of last min/max values reset */
 	slock_t		mutex;			/* protects the counters only */
 	dsa_pointer query;			/* query text location within query buffer */
 } pgsmEntry;

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -2482,7 +2482,8 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 		{
 			/* at column number 71 */
 			values[i++] = TimestampTzGetDatum(entry->stats_since);
-			values[i++] = TimestampTzGetDatum(entry->minmax_stats_since);
+			/* exists for compatibility with pg_stat_statements */
+			values[i++] = TimestampTzGetDatum(entry->stats_since);
 		}
 
 		/* toplevel at column number 73 */


### PR DESCRIPTION
The struct field is only there for compatibility with pg_stat_statements and always has the same value as stats_since in our code. If we implement more granular resetting of stats this might change but for now save a handful of bytes of memory.

PG-0
