### PR TITLE
Fix race condition where we can leak the parent query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@
 - Various improvements to the stability of our test suite
 - Make sure that for prepared statements utility statement exec info read at the executor start hook, where data is not yet modified by query itself
 - Do not acquire LWLock under spinlock
+- Race condition where we could leak memory for the parent query

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -1902,7 +1902,6 @@ pgsm_store(const pgsmQueryStats *stats)
 
 		entry->pgsm_query_id = stats->pgsm_query_id;
 		entry->counters.info.cmd_type = stats->counters.info.cmd_type;
-		entry->counters.info.parent_query = InvalidDsaPointer;
 
 		strlcpy(entry->datname, datname, sizeof(entry->datname));
 		strlcpy(entry->username, stats->username, sizeof(entry->username));


### PR DESCRIPTION
If two backends try to create a new entry with a parent query at the same time we could leak shared memory due to us mistakenly resetting the parent query field to `InvalidDsaPointer` when we should not do so. We already do it when creating a new entry in the hash table so we do not need to do it again and risk leaking memory.

PG-0