### PR TITLE
Fix plans counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@
 - Make sure that for prepared statements utility statement exec info read at the executor start hook, where data is not yet modified by query itself
 - Do not acquire LWLock under spinlock
 - Race condition where we could leak memory for the parent query
+- `plans` now counts only actual planner invocations instead of every execution: utility statements and executions that reuse a cached plan no longer bump the counter

--- a/regression/expected/level_tracking.out
+++ b/regression/expected/level_tracking.out
@@ -1603,7 +1603,7 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
  toplevel | calls | rows | plans |             query              
 ----------+-------+------+-------+--------------------------------
  f        |     2 |    2 |     2 | SELECT i + $2 LIMIT $3
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
  t        |     2 |    2 |     2 | SELECT plus_three($1)
 (3 rows)
 
@@ -1634,9 +1634,9 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls | rows | plans |                        query                        
 ----------+-------+------+-------+-----------------------------------------------------
- f        |     2 |    2 |     2 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
- t        |     2 |    2 |     2 | INSERT INTO test_trigger VALUES ($1, $2)
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ f        |     2 |    2 |     0 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
+ t        |     2 |    2 |     0 | INSERT INTO test_trigger VALUES ($1, $2)
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
 DROP TRIGGER audit_after_trigger ON test_trigger;

--- a/regression/expected/level_tracking_1.out
+++ b/regression/expected/level_tracking_1.out
@@ -1598,7 +1598,7 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
  toplevel | calls | rows | plans |             query              
 ----------+-------+------+-------+--------------------------------
  f        |     2 |    2 |     2 | SELECT i + $2 LIMIT $3
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
  t        |     2 |    2 |     2 | SELECT plus_three($1)
 (3 rows)
 
@@ -1629,9 +1629,9 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls | rows | plans |                        query                        
 ----------+-------+------+-------+-----------------------------------------------------
- f        |     2 |    2 |     2 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
- t        |     2 |    2 |     2 | INSERT INTO test_trigger VALUES ($1, $2)
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ f        |     2 |    2 |     0 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
+ t        |     2 |    2 |     0 | INSERT INTO test_trigger VALUES ($1, $2)
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
 DROP TRIGGER audit_after_trigger ON test_trigger;

--- a/regression/expected/level_tracking_2.out
+++ b/regression/expected/level_tracking_2.out
@@ -1601,7 +1601,7 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
  toplevel | calls | rows | plans |             query              
 ----------+-------+------+-------+--------------------------------
  f        |     2 |    2 |     2 | SELECT i + $2 LIMIT $3
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
  t        |     2 |    2 |     2 | SELECT plus_three($1)
 (3 rows)
 
@@ -1632,9 +1632,9 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls | rows | plans |                        query                        
 ----------+-------+------+-------+-----------------------------------------------------
- f        |     2 |    2 |     2 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
- t        |     2 |    2 |     2 | INSERT INTO test_trigger VALUES ($1, $2)
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ f        |     2 |    2 |     0 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
+ t        |     2 |    2 |     0 | INSERT INTO test_trigger VALUES ($1, $2)
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
 DROP TRIGGER audit_after_trigger ON test_trigger;

--- a/regression/expected/level_tracking_3.out
+++ b/regression/expected/level_tracking_3.out
@@ -1584,7 +1584,7 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
  toplevel | calls | rows | plans |             query              
 ----------+-------+------+-------+--------------------------------
  f        |     2 |    2 |     2 | SELECT i + $2 LIMIT $3
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
  t        |     2 |    2 |     2 | SELECT plus_three($1)
 (3 rows)
 
@@ -1615,9 +1615,9 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls | rows | plans |                        query                        
 ----------+-------+------+-------+-----------------------------------------------------
- f        |     2 |    2 |     2 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
- t        |     2 |    2 |     2 | INSERT INTO test_trigger VALUES ($1, $2)
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ f        |     2 |    2 |     0 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
+ t        |     2 |    2 |     0 | INSERT INTO test_trigger VALUES ($1, $2)
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
 DROP TRIGGER audit_after_trigger ON test_trigger;

--- a/regression/expected/level_tracking_4.out
+++ b/regression/expected/level_tracking_4.out
@@ -1374,7 +1374,7 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
  toplevel | calls | rows | plans |             query              
 ----------+-------+------+-------+--------------------------------
  f        |     2 |    2 |     2 | SELECT i + $2 LIMIT $3
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
  t        |     2 |    2 |     2 | SELECT plus_three($1)
 (3 rows)
 
@@ -1405,9 +1405,9 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls | rows | plans |                        query                        
 ----------+-------+------+-------+-----------------------------------------------------
- f        |     2 |    2 |     2 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
- t        |     2 |    2 |     2 | INSERT INTO test_trigger VALUES ($1, $2)
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ f        |     2 |    2 |     0 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
+ t        |     2 |    2 |     0 | INSERT INTO test_trigger VALUES ($1, $2)
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
 DROP TRIGGER audit_after_trigger ON test_trigger;

--- a/regression/expected/level_tracking_5.out
+++ b/regression/expected/level_tracking_5.out
@@ -1472,7 +1472,7 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
  toplevel | calls | rows | plans |             query              
 ----------+-------+------+-------+--------------------------------
  f        |     2 |    2 |     2 | SELECT i + $2 LIMIT $3
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
  t        |     2 |    2 |     2 | SELECT plus_three($1)
 (3 rows)
 
@@ -1503,9 +1503,9 @@ SELECT toplevel, calls, rows, plans, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls | rows | plans |                        query                        
 ----------+-------+------+-------+-----------------------------------------------------
- f        |     2 |    2 |     2 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
- t        |     2 |    2 |     2 | INSERT INTO test_trigger VALUES ($1, $2)
- t        |     1 |    1 |     1 | SELECT pg_stat_monitor_reset()
+ f        |     2 |    2 |     0 | INSERT INTO audit_table VALUES ($15, TG_OP, NEW.id)
+ t        |     2 |    2 |     0 | INSERT INTO test_trigger VALUES ($1, $2)
+ t        |     1 |    1 |     0 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
 DROP TRIGGER audit_after_trigger ON test_trigger;

--- a/regression/expected/planning.out
+++ b/regression/expected/planning.out
@@ -63,8 +63,8 @@ SELECT plans, calls, rows, query FROM pg_stat_monitor
     WHERE query NOT LIKE 'PREPARE%' ORDER BY query COLLATE "C";
  plans | calls | rows |                      query                      
 -------+-------+------+-------------------------------------------------
-     1 |     1 |    0 | ALTER TABLE stats_plan_test ADD COLUMN x int
-     1 |     1 |    0 | CREATE TABLE stats_plan_test ()
+     0 |     1 |    0 | ALTER TABLE stats_plan_test ADD COLUMN x int
+     0 |     1 |    0 | CREATE TABLE stats_plan_test ()
      3 |     3 |    3 | SELECT $1
      1 |     1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (4 rows)
@@ -78,9 +78,41 @@ SELECT plans >= 2 AND plans <= calls AS plans_ok, calls, rows, query FROM pg_sta
  t        |     4 |    4 | PREPARE prep1 AS SELECT COUNT(*) FROM stats_plan_test;
 (1 row)
 
+--
+-- Cached plans are not counted
+--
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SET plan_cache_mode TO force_generic_plan;
+PREPARE prep2 AS SELECT 42;
+EXECUTE prep2;
+ ?column? 
+----------
+       42
+(1 row)
+
+EXECUTE prep2;
+ ?column? 
+----------
+       42
+(1 row)
+
+RESET plan_cache_mode;
+SELECT plans, calls FROM pg_stat_monitor WHERE query LIKE 'PREPARE prep2%'
+    ORDER BY query COLLATE "C";
+ plans | calls 
+-------+-------
+     1 |     2
+(1 row)
+
 -- Cleanup
 DROP TABLE stats_plan_test;
 DEALLOCATE prep1;
+DEALLOCATE prep2;
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
  t 
 ---

--- a/regression/sql/planning.sql
+++ b/regression/sql/planning.sql
@@ -28,8 +28,21 @@ SELECT plans, calls, rows, query FROM pg_stat_monitor
 SELECT plans >= 2 AND plans <= calls AS plans_ok, calls, rows, query FROM pg_stat_monitor
     WHERE query LIKE 'PREPARE%' ORDER BY query COLLATE "C";
 
+--
+-- Cached plans are not counted
+--
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SET plan_cache_mode TO force_generic_plan;
+PREPARE prep2 AS SELECT 42;
+EXECUTE prep2;
+EXECUTE prep2;
+RESET plan_cache_mode;
+SELECT plans, calls FROM pg_stat_monitor WHERE query LIKE 'PREPARE prep2%'
+    ORDER BY query COLLATE "C";
+
 -- Cleanup
 DROP TABLE stats_plan_test;
 DEALLOCATE prep1;
+DEALLOCATE prep2;
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 DROP EXTENSION pg_stat_monitor;

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -978,6 +978,7 @@ pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, Par
 
 		/* The plan details are captured when the query finishes */
 		if (stats)
+		{
 			pgsm_update_counters(&stats->counters,	/* counters */
 								 NULL,	/* PlanInfo */
 								 NULL,	/* SysInfo */
@@ -990,6 +991,10 @@ pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, Par
 								 0, /* parallel_workers_to_launch */
 								 0, /* parallel_workers_launched */
 								 0);	/* plan_origin */
+
+			/* Record the planning event itself. */
+			stats->counters.plancalls.calls++;
+		}
 	}
 	else
 	{
@@ -1455,26 +1460,29 @@ pgsm_merge_counters(Counters *dst, const Counters *src)
 {
 	int			index;
 
-	/* plan stats: fold src as a single sample */
-	dst->plancalls.calls += 1;
-	dst->plantime.total_time += src->plantime.total_time;
-	if (dst->plancalls.calls == 1)
+	if (src->plancalls.calls > 0)
 	{
-		dst->plantime.min_time = src->plantime.total_time;
-		dst->plantime.max_time = src->plantime.total_time;
-		dst->plantime.mean_time = src->plantime.total_time;
-	}
-	else
-	{
-		double		old_mean = dst->plantime.mean_time;
-
-		dst->plantime.mean_time += (src->plantime.total_time - old_mean) / dst->plancalls.calls;
-		dst->plantime.sum_var_time += (src->plantime.total_time - old_mean) * (src->plantime.total_time - dst->plantime.mean_time);
-
-		if (dst->plantime.min_time > src->plantime.total_time)
+		dst->plantime.total_time += src->plantime.total_time;
+		if (dst->plancalls.calls == 0)
+		{
+			dst->plancalls.calls = src->plancalls.calls;
 			dst->plantime.min_time = src->plantime.total_time;
-		if (dst->plantime.max_time < src->plantime.total_time)
 			dst->plantime.max_time = src->plantime.total_time;
+			dst->plantime.mean_time = src->plantime.total_time;
+		}
+		else
+		{
+			double		old_mean = dst->plantime.mean_time;
+
+			dst->plancalls.calls += src->plancalls.calls;
+			dst->plantime.mean_time += (src->plantime.total_time - old_mean) / dst->plancalls.calls;
+			dst->plantime.sum_var_time += (src->plantime.total_time - old_mean) * (src->plantime.total_time - dst->plantime.mean_time);
+
+			if (dst->plantime.min_time > src->plantime.total_time)
+				dst->plantime.min_time = src->plantime.total_time;
+			if (dst->plantime.max_time < src->plantime.total_time)
+				dst->plantime.max_time = src->plantime.total_time;
+		}
 	}
 
 	/* exec stats: fold src as a single sample */


### PR DESCRIPTION
plans counter was incremented unconditionally, even when there was no plan at all (utility statements). Fix it so it will reflect how many times planning events happened. Also this fixes associated timers.


