### PR TITLE
Stop including nodes.h

### DIFF
--- a/src/hash_query.h
+++ b/src/hash_query.h
@@ -19,7 +19,6 @@
 #include <postgres.h>
 
 #include <executor/instrument.h>
-#include <nodes/nodes.h>
 #include <storage/lwlock.h>
 #include <storage/spin.h>
 #include <utils/dsa.h>


### PR DESCRIPTION
We no longer use anything from `nodes.h` in our project so we do not need to include it.

PG-0
