### PR TITLE
Use /tmp as unix socket directory in the CI

### DIFF
--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -5,11 +5,13 @@ set -e
 SCRIPT_DIR=$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)
 PG_BIN_DIR=$(pg_config --bindir)
 
-cd "$SCRIPT_DIR/../../"
+cd "$SCRIPT_DIR/../.."
+
+export PGHOST=/tmp
 
 # The two-phase transaction cases of the "utility" test need
 # max_prepared_transactions to be nonzero.
-OPTS='-c shared_preload_libraries=pg_stat_monitor -c max_prepared_transactions=5'
+OPTS="-k $PGHOST -c shared_preload_libraries=pg_stat_monitor -c max_prepared_transactions=5"
 
 if [ "$1" = sanitize ]; then
     OPTS+=' -c max_stack_depth=8MB'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,7 @@ env:
   OS: ${{ inputs.os }}
   CC: ${{ inputs.compiler }}
   BUILD_TYPE: ${{ inputs.build_type }}
+  PGPORT: 6432
 
 jobs:
   build:
@@ -71,14 +72,6 @@ jobs:
 
       - name: Build pg_stat_monitor
         run: src/.github/scripts/build.sh ${{ env.BUILD_TYPE }}
-
-      - name: Set permissions
-        if: startsWith(inputs.os, 'ubuntu-') && env.PG_PACKAGE != 'source'
-        run: sudo chown -R runner:runner /var/run/postgresql
-
-      - name: Stop existing PostgreSQL instances
-        if: startsWith(inputs.os, 'ubuntu-') && env.PG_PACKAGE != 'source'
-        run: sudo service postgresql stop
 
       - name: Run tests
         run: src/.github/scripts/test.sh ${{ env.BUILD_TYPE }}


### PR DESCRIPTION
Since the Ubuntu packages uses `/run/postgresql` as the unix socket directory by default and that directory is owned by the `postgres` user we used to change owner of `/run/postgresql` but instead we can just use `/tmp` and simplify our setup.

This way we do not even have to kill the default instance of PostgreSQL.

PG-0