### PR TITLE
Replace impossible case in switch with Assert(false)

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -2087,9 +2087,7 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 			expected_columns = PG_STAT_MONITOR_COLS_NEXT;
 			break;
 		default:
-			ereport(ERROR,
-					errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					errmsg("[pg_stat_monitor] pg_stat_monitor_internal: Unknown API version"));
+			Assert(false);
 	}
 
 	/* Disallow old api usage */


### PR DESCRIPTION
This case cannot be hit since the switch is exhaustive so replace it with an `Assert(false)`.

PG-0
