### PR TITLE
PG-2623 Utility statement normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Do not acquire LWLock under spinlock
 - Race condition where we could leak memory for the parent query
 - `plans` now counts only actual planner invocations instead of every execution: utility statements and executions that reuse a cached plan no longer bump the counter
+- Normalize the query text of utility statements ([PG-2623](https://perconadev.atlassian.net/browse/PG-2623))
 
 ## [2.3.2] - 2026-03-02
 

--- a/regression/expected/cursors.out
+++ b/regression/expected/cursors.out
@@ -18,10 +18,10 @@ CLOSE cursor_stats_1;
 DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT 2;
 CLOSE cursor_stats_1;
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                        query                         
--------+------+------------------------------------------------------
+ calls | rows |                         query                         
+-------+------+-------------------------------------------------------
      2 |    0 | CLOSE cursor_stats_1
-     2 |    0 | DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT 1
+     2 |    0 | DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT $1
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (3 rows)
 
@@ -51,16 +51,16 @@ CLOSE cursor_stats_1;
 CLOSE cursor_stats_2;
 COMMIT;
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                        query                         
--------+------+------------------------------------------------------
+ calls | rows |                         query                         
+-------+------+-------------------------------------------------------
      1 |    0 | BEGIN
      1 |    0 | CLOSE cursor_stats_1
      1 |    0 | CLOSE cursor_stats_2
      1 |    0 | COMMIT
-     1 |    0 | DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT 2
-     1 |    0 | DECLARE cursor_stats_2 CURSOR WITH HOLD FOR SELECT 3
-     1 |    1 | FETCH 1 IN cursor_stats_1
-     1 |    1 | FETCH 1 IN cursor_stats_2
+     1 |    0 | DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT $1
+     1 |    0 | DECLARE cursor_stats_2 CURSOR WITH HOLD FOR SELECT $1
+     1 |    1 | FETCH $1 IN cursor_stats_1
+     1 |    1 | FETCH $1 IN cursor_stats_2
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (9 rows)
 
@@ -187,12 +187,12 @@ FETCH BACKWARD ALL pgsm_cursor;
 
 COMMIT;
 SELECT calls, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls |                               query                               
--------+-------------------------------------------------------------------
+ calls |                               query                                
+-------+--------------------------------------------------------------------
      1 | BEGIN
      1 | COMMIT
-     1 | DECLARE pgsm_cursor CURSOR FOR SELECT FROM generate_series(1, 10)
-     3 | FETCH ABSOLUTE 1 pgsm_cursor
+     1 | DECLARE pgsm_cursor CURSOR FOR SELECT FROM generate_series($1, $2)
+     3 | FETCH ABSOLUTE $1 pgsm_cursor
      1 | FETCH ALL pgsm_cursor
      1 | FETCH BACKWARD ALL pgsm_cursor
      4 | FETCH BACKWARD pgsm_cursor
@@ -202,7 +202,7 @@ SELECT calls, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
      1 | FETCH LAST pgsm_cursor
      1 | FETCH NEXT pgsm_cursor
      1 | FETCH PRIOR pgsm_cursor
-     3 | FETCH RELATIVE 1 pgsm_cursor
+     3 | FETCH RELATIVE $1 pgsm_cursor
      4 | FETCH pgsm_cursor
      1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (16 rows)

--- a/regression/expected/cursors_1.out
+++ b/regression/expected/cursors_1.out
@@ -18,10 +18,10 @@ CLOSE cursor_stats_1;
 DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT 2;
 CLOSE cursor_stats_1;
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                        query                         
--------+------+------------------------------------------------------
+ calls | rows |                         query                         
+-------+------+-------------------------------------------------------
      2 |    0 | CLOSE cursor_stats_1
-     2 |    0 | DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT 1
+     2 |    0 | DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT $1
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (3 rows)
 
@@ -51,14 +51,14 @@ CLOSE cursor_stats_1;
 CLOSE cursor_stats_2;
 COMMIT;
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                        query                         
--------+------+------------------------------------------------------
+ calls | rows |                         query                         
+-------+------+-------------------------------------------------------
      1 |    0 | BEGIN
      1 |    0 | CLOSE cursor_stats_1
      1 |    0 | CLOSE cursor_stats_2
      1 |    0 | COMMIT
-     1 |    0 | DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT 2
-     1 |    0 | DECLARE cursor_stats_2 CURSOR WITH HOLD FOR SELECT 3
+     1 |    0 | DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT $1
+     1 |    0 | DECLARE cursor_stats_2 CURSOR WITH HOLD FOR SELECT $1
      1 |    1 | FETCH 1 IN cursor_stats_1
      1 |    1 | FETCH 1 IN cursor_stats_2
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
@@ -187,11 +187,11 @@ FETCH BACKWARD ALL pgsm_cursor;
 
 COMMIT;
 SELECT calls, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls |                               query                               
--------+-------------------------------------------------------------------
+ calls |                               query                                
+-------+--------------------------------------------------------------------
      1 | BEGIN
      1 | COMMIT
-     1 | DECLARE pgsm_cursor CURSOR FOR SELECT FROM generate_series(1, 10)
+     1 | DECLARE pgsm_cursor CURSOR FOR SELECT FROM generate_series($1, $2)
      2 | FETCH -1 pgsm_cursor
      2 | FETCH 2 pgsm_cursor
      1 | FETCH ABSOLUTE 2 pgsm_cursor

--- a/regression/expected/level_tracking.out
+++ b/regression/expected/level_tracking.out
@@ -60,24 +60,24 @@ END
 $$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
     ORDER BY query COLLATE "C", toplevel;
- toplevel | calls |                 query                  
-----------+-------+----------------------------------------
+ toplevel | calls |                query                
+----------+-------+-------------------------------------
  f        |     1 | DELETE FROM stats_track_tab
  t        |     1 | DELETE FROM stats_track_tab
- t        |     1 | DO $$                                 +
-          |       | BEGIN                                 +
-          |       |     -- this is a SELECT               +
-          |       |     PERFORM 'hello world'::text;      +
-          |       | END                                   +
+ t        |     1 | DO $$                              +
+          |       | BEGIN                              +
+          |       |     -- this is a SELECT            +
+          |       |     PERFORM 'hello world'::text;   +
+          |       | END                                +
           |       | $$
- t        |     1 | DO $$                                 +
-          |       | BEGIN                                 +
-          |       |     DELETE FROM stats_track_tab;      +
-          |       | END                                   +
+ t        |     1 | DO $$                              +
+          |       | BEGIN                              +
+          |       |     DELETE FROM stats_track_tab;   +
+          |       | END                                +
           |       | $$
  f        |     1 | SELECT $1::text
  t        |     1 | SELECT pg_stat_monitor_reset()
- t        |     1 | SET pg_stat_monitor.pgsm_track = 'all'
+ t        |     1 | SET pg_stat_monitor.pgsm_track = $1
 (7 rows)
 
 -- Procedure with multiple utility statements.
@@ -223,34 +223,34 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                query                                
 ----------+-------+---------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2)
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
  f        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table);
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  f        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2));
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1));
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id      +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
           |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id      +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id);
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id       +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2;
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES ($1);
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (23 rows)
 
@@ -349,22 +349,22 @@ EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                              query                               
-----------+-------+------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2)
+ toplevel | calls |                               query                                
+----------+-------+--------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                  +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id    +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                           +
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                    +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id     +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                             +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (12 rows)
 
@@ -424,16 +424,16 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                                        query                                                        
 ----------+-------+---------------------------------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3); EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3)
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4)
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3); EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4)
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4; EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1; EXPLAIN (COSTS OFF) SELECT 1, 2;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4
  f        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4; EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT 1; EXPLAIN (COSTS OFF) SELECT $1, $2;
  t        |     1 | SELECT pg_stat_monitor_reset()
@@ -514,24 +514,24 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                                                              query                                                               
 ----------+-------+----------------------------------------------------------------------------------------------------------------------------------
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab; EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1;
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab; EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1;
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ($1), ($2)
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (1), (2);
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ($1), ($2);
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (1), (2)
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab; EXPLAIN (COSTS OFF) (TABLE test_table);
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab; EXPLAIN (COSTS OFF) (TABLE test_table);
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2; EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1;
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1; EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1;
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES ($1); EXPLAIN (COSTS OFF) (VALUES (1, 2));
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES (1); EXPLAIN (COSTS OFF) (VALUES ($1, $2));
  t        |     1 | SELECT pg_stat_monitor_reset()
 (21 rows)
@@ -568,19 +568,19 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                             query                                              
 ----------+-------+------------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id                                 +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
           |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id                                 +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id); EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5;
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                                  +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
           |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                                  +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id); EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5
  t        |     1 | SELECT pg_stat_monitor_reset()
 (5 rows)
 
@@ -719,26 +719,26 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                                              query                                                               
 ----------+-------+----------------------------------------------------------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3)
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
+ t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1), (2));
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab USING (SELECT id FROM generate_series(1, 10) id) ON x = id                       +
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab USING (SELECT id FROM generate_series($1, $2) id) ON x = id                      +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                                                           +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (19 rows)
 
@@ -815,26 +815,26 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                           query                                           
 ----------+-------+-------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3))
  f        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3));
- t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT 4) (SELECT 1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2))
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2));
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                     +
+          |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                            +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                     +
           |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                            +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id);
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3;
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2;
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3;
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) MERGE INTO stats_track_tab                      +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                             +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) UPDATE stats_track_tab SET x = 1 WHERE x = 1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (15 rows)
 
@@ -909,18 +909,18 @@ EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                         query                                         
-----------+-------+---------------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT 4) (SELECT 1, 2))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) MERGE INTO stats_track_tab                  +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                         +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                +
+ toplevel | calls |                                          query                                           
+----------+-------+------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                    +
+          |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                           +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                   +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) UPDATE stats_track_tab SET x = 1 WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3
  t        |     1 | SELECT pg_stat_monitor_reset()
 (8 rows)
 
@@ -953,8 +953,8 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
           |       |   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab
  f        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)           +
           |       |   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab;
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1
  f        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1;
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT 100
  t        |     1 | SELECT pg_stat_monitor_reset()
 (5 rows)
 
@@ -981,11 +981,11 @@ EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                     query                                     
-----------+-------+-------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)           +
+ toplevel | calls |                                    query                                     
+----------+-------+------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)          +
           |       |   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT 100
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
@@ -1004,7 +1004,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                       query                        
 ----------+-------+----------------------------------------------------
  t        |     1 | CREATE MATERIALIZED VIEW pgsm_materialized_view AS+
-          |       |   SELECT * FROM generate_series(1, 5) AS id
+          |       |   SELECT * FROM generate_series($1, $2) AS id
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 
@@ -1023,7 +1023,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                        query                         
 ----------+-------+------------------------------------------------------
  t        |     1 | CREATE MATERIALIZED VIEW pgsm_materialized_view_2 AS+
-          |       |   SELECT * FROM generate_series(1, 5) AS id
+          |       |   SELECT * FROM generate_series($1, $2) AS id
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 
@@ -1076,8 +1076,8 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                              query                              
 ----------+-------+-----------------------------------------------------------------
+ t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_1 AS SELECT $1
  f        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_1 AS SELECT $1;
- t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_1 AS SELECT 1
  t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_2 AS EXECUTE test_prepare_pgsm
  f        |     1 | PREPARE test_prepare_pgsm AS SELECT generate_series($1, $2)
  t        |     1 | SELECT pg_stat_monitor_reset()
@@ -1097,7 +1097,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                              query                              
 ----------+-------+-----------------------------------------------------------------
- t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_3 AS SELECT 1
+ t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_3 AS SELECT $1
  t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_4 AS EXECUTE test_prepare_pgsm
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
@@ -1120,8 +1120,8 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                   query                                    
 ----------+-------+----------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT $1
  f        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT $1;
- t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
@@ -1141,9 +1141,9 @@ EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                  query                                   
-----------+-------+--------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1
+ toplevel | calls |                                   query                                   
+----------+-------+---------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT $1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 

--- a/regression/expected/level_tracking_1.out
+++ b/regression/expected/level_tracking_1.out
@@ -223,34 +223,34 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                query                                
 ----------+-------+---------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2)
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
  f        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table);
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  f        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2));
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1));
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id      +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
           |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id      +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id);
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id       +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2;
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES ($1);
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (23 rows)
 
@@ -349,22 +349,22 @@ EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                              query                               
-----------+-------+------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2)
+ toplevel | calls |                               query                                
+----------+-------+--------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                  +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id    +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                           +
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                    +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id     +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                             +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (12 rows)
 
@@ -424,16 +424,16 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                                        query                                                        
 ----------+-------+---------------------------------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3); EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3)
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4)
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3); EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4)
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4; EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1; EXPLAIN (COSTS OFF) SELECT 1, 2;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4
  f        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4; EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT 1; EXPLAIN (COSTS OFF) SELECT $1, $2;
  t        |     1 | SELECT pg_stat_monitor_reset()
@@ -514,24 +514,24 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                                                              query                                                               
 ----------+-------+----------------------------------------------------------------------------------------------------------------------------------
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab; EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1;
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab; EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1;
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ($1), ($2)
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (1), (2);
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ($1), ($2);
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (1), (2)
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab; EXPLAIN (COSTS OFF) (TABLE test_table);
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab; EXPLAIN (COSTS OFF) (TABLE test_table);
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2; EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1;
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1; EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1;
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES ($1); EXPLAIN (COSTS OFF) (VALUES (1, 2));
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES (1); EXPLAIN (COSTS OFF) (VALUES ($1, $2));
  t        |     1 | SELECT pg_stat_monitor_reset()
 (21 rows)
@@ -568,19 +568,19 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                             query                                              
 ----------+-------+------------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id                                 +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
           |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id                                 +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id); EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5;
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                                  +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
           |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                                  +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id); EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5
  t        |     1 | SELECT pg_stat_monitor_reset()
 (5 rows)
 
@@ -719,26 +719,26 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                                              query                                                               
 ----------+-------+----------------------------------------------------------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3)
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
+ t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1), (2));
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab USING (SELECT id FROM generate_series(1, 10) id) ON x = id                       +
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab USING (SELECT id FROM generate_series($1, $2) id) ON x = id                      +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                                                           +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (19 rows)
 
@@ -815,26 +815,26 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                           query                                           
 ----------+-------+-------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3))
  f        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3));
- t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT 4) (SELECT 1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2))
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2));
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                     +
+          |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                            +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                     +
           |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                            +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id);
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3;
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2;
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3;
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) MERGE INTO stats_track_tab                      +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                             +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) UPDATE stats_track_tab SET x = 1 WHERE x = 1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (15 rows)
 
@@ -909,18 +909,18 @@ EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                         query                                         
-----------+-------+---------------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT 4) (SELECT 1, 2))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) MERGE INTO stats_track_tab                  +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                         +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                +
+ toplevel | calls |                                          query                                           
+----------+-------+------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                    +
+          |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                           +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                   +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) UPDATE stats_track_tab SET x = 1 WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3
  t        |     1 | SELECT pg_stat_monitor_reset()
 (8 rows)
 
@@ -951,8 +951,8 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
 ----------+-------+-------------------------------------------------------------------------------
  t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)           +
           |       |   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1
  f        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1;
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT 100
  t        |     1 | SELECT pg_stat_monitor_reset()
 (4 rows)
 
@@ -979,11 +979,11 @@ EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                     query                                     
-----------+-------+-------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)           +
+ toplevel | calls |                                    query                                     
+----------+-------+------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)          +
           |       |   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT 100
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
@@ -1002,7 +1002,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                       query                        
 ----------+-------+----------------------------------------------------
  t        |     1 | CREATE MATERIALIZED VIEW pgsm_materialized_view AS+
-          |       |   SELECT * FROM generate_series(1, 5) AS id
+          |       |   SELECT * FROM generate_series($1, $2) AS id
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 
@@ -1021,7 +1021,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                        query                         
 ----------+-------+------------------------------------------------------
  t        |     1 | CREATE MATERIALIZED VIEW pgsm_materialized_view_2 AS+
-          |       |   SELECT * FROM generate_series(1, 5) AS id
+          |       |   SELECT * FROM generate_series($1, $2) AS id
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 
@@ -1074,7 +1074,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                              query                              
 ----------+-------+-----------------------------------------------------------------
- t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_1 AS SELECT 1
+ t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_1 AS SELECT $1
  t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_2 AS EXECUTE test_prepare_pgsm
  f        |     1 | PREPARE test_prepare_pgsm AS SELECT generate_series($1, $2)
  t        |     1 | SELECT pg_stat_monitor_reset()
@@ -1094,7 +1094,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                              query                              
 ----------+-------+-----------------------------------------------------------------
- t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_3 AS SELECT 1
+ t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_3 AS SELECT $1
  t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_4 AS EXECUTE test_prepare_pgsm
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
@@ -1115,9 +1115,9 @@ EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                  query                                   
-----------+-------+--------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1
+ toplevel | calls |                                   query                                   
+----------+-------+---------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT $1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 
@@ -1137,9 +1137,9 @@ EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                  query                                   
-----------+-------+--------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1
+ toplevel | calls |                                   query                                   
+----------+-------+---------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT $1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 

--- a/regression/expected/level_tracking_2.out
+++ b/regression/expected/level_tracking_2.out
@@ -60,24 +60,24 @@ END
 $$;
 SELECT toplevel, calls, query FROM pg_stat_monitor
     ORDER BY query COLLATE "C", toplevel;
- toplevel | calls |                 query                  
-----------+-------+----------------------------------------
+ toplevel | calls |                query                
+----------+-------+-------------------------------------
  f        |     1 | DELETE FROM stats_track_tab
  t        |     1 | DELETE FROM stats_track_tab
- t        |     1 | DO $$                                 +
-          |       | BEGIN                                 +
-          |       |     -- this is a SELECT               +
-          |       |     PERFORM 'hello world'::text;      +
-          |       | END                                   +
+ t        |     1 | DO $$                              +
+          |       | BEGIN                              +
+          |       |     -- this is a SELECT            +
+          |       |     PERFORM 'hello world'::text;   +
+          |       | END                                +
           |       | $$
- t        |     1 | DO $$                                 +
-          |       | BEGIN                                 +
-          |       |     DELETE FROM stats_track_tab;      +
-          |       | END                                   +
+ t        |     1 | DO $$                              +
+          |       | BEGIN                              +
+          |       |     DELETE FROM stats_track_tab;   +
+          |       | END                                +
           |       | $$
  f        |     1 | SELECT $1::text
  t        |     1 | SELECT pg_stat_monitor_reset()
- t        |     1 | SET pg_stat_monitor.pgsm_track = 'all'
+ t        |     1 | SET pg_stat_monitor.pgsm_track = $1
 (7 rows)
 
 -- Procedure with multiple utility statements.
@@ -223,34 +223,34 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                query                                
 ----------+-------+---------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2)
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
  f        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table);
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  f        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2));
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1));
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id      +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
           |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id      +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id);
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id       +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2;
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES ($1);
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (23 rows)
 
@@ -349,22 +349,22 @@ EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                              query                               
-----------+-------+------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2)
+ toplevel | calls |                               query                                
+----------+-------+--------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                  +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id    +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                           +
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                    +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id     +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                             +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (12 rows)
 
@@ -424,16 +424,16 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                                        query                                                        
 ----------+-------+---------------------------------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3); EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3)
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4)
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3); EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4)
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4; EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1; EXPLAIN (COSTS OFF) SELECT 1, 2;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4
  f        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4; EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT 1; EXPLAIN (COSTS OFF) SELECT $1, $2;
  t        |     1 | SELECT pg_stat_monitor_reset()
@@ -514,24 +514,24 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                                                              query                                                               
 ----------+-------+----------------------------------------------------------------------------------------------------------------------------------
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab; EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1;
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab; EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1;
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ($1), ($2)
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (1), (2);
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ($1), ($2);
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (1), (2)
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab; EXPLAIN (COSTS OFF) (TABLE test_table);
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab; EXPLAIN (COSTS OFF) (TABLE test_table);
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2; EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1;
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1; EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1;
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES ($1); EXPLAIN (COSTS OFF) (VALUES (1, 2));
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES (1); EXPLAIN (COSTS OFF) (VALUES ($1, $2));
  t        |     1 | SELECT pg_stat_monitor_reset()
 (21 rows)
@@ -568,19 +568,19 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                             query                                              
 ----------+-------+------------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id                                 +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
           |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id                                 +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id); EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5;
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                                  +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
           |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                                  +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id); EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5
  t        |     1 | SELECT pg_stat_monitor_reset()
 (5 rows)
 
@@ -719,26 +719,26 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                                              query                                                               
 ----------+-------+----------------------------------------------------------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3)
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
+ t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1), (2));
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab USING (SELECT id FROM generate_series(1, 10) id) ON x = id                       +
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab USING (SELECT id FROM generate_series($1, $2) id) ON x = id                      +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                                                           +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (19 rows)
 
@@ -815,26 +815,26 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                           query                                           
 ----------+-------+-------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3))
  f        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3));
- t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT 4) (SELECT 1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2))
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2));
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                     +
+          |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                            +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                     +
           |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                            +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id);
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3;
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2;
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3;
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) MERGE INTO stats_track_tab                      +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                             +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) UPDATE stats_track_tab SET x = 1 WHERE x = 1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (15 rows)
 
@@ -909,18 +909,18 @@ EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                         query                                         
-----------+-------+---------------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT 4) (SELECT 1, 2))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) MERGE INTO stats_track_tab                  +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                         +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                +
+ toplevel | calls |                                          query                                           
+----------+-------+------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                    +
+          |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                           +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                   +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) UPDATE stats_track_tab SET x = 1 WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3
  t        |     1 | SELECT pg_stat_monitor_reset()
 (8 rows)
 
@@ -953,8 +953,8 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
           |       |   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab
  f        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)           +
           |       |   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab;
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1
  f        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1;
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT 100
  t        |     1 | SELECT pg_stat_monitor_reset()
 (5 rows)
 
@@ -981,11 +981,11 @@ EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                     query                                     
-----------+-------+-------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)           +
+ toplevel | calls |                                    query                                     
+----------+-------+------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)          +
           |       |   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT 100
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
@@ -1004,7 +1004,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                       query                        
 ----------+-------+----------------------------------------------------
  t        |     1 | CREATE MATERIALIZED VIEW pgsm_materialized_view AS+
-          |       |   SELECT * FROM generate_series(1, 5) AS id
+          |       |   SELECT * FROM generate_series($1, $2) AS id
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 
@@ -1023,7 +1023,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                        query                         
 ----------+-------+------------------------------------------------------
  t        |     1 | CREATE MATERIALIZED VIEW pgsm_materialized_view_2 AS+
-          |       |   SELECT * FROM generate_series(1, 5) AS id
+          |       |   SELECT * FROM generate_series($1, $2) AS id
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 
@@ -1076,8 +1076,8 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                              query                              
 ----------+-------+-----------------------------------------------------------------
+ t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_1 AS SELECT $1
  f        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_1 AS SELECT $1;
- t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_1 AS SELECT 1
  t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_2 AS EXECUTE test_prepare_pgsm
  f        |     1 | PREPARE test_prepare_pgsm AS SELECT generate_series($1, $2)
  t        |     1 | SELECT pg_stat_monitor_reset()
@@ -1097,7 +1097,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                              query                              
 ----------+-------+-----------------------------------------------------------------
- t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_3 AS SELECT 1
+ t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_3 AS SELECT $1
  t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_4 AS EXECUTE test_prepare_pgsm
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
@@ -1120,8 +1120,8 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                   query                                    
 ----------+-------+----------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT $1
  f        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT $1;
- t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
@@ -1141,9 +1141,9 @@ EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                  query                                   
-----------+-------+--------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1
+ toplevel | calls |                                   query                                   
+----------+-------+---------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT $1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 
@@ -1173,7 +1173,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  t        |     1 | COMMIT
  t        |     1 | DECLARE FOOCUR CURSOR FOR SELECT * FROM stats_track_tab
  f        |     1 | DECLARE FOOCUR CURSOR FOR SELECT * FROM stats_track_tab;
- t        |     1 | FETCH FORWARD 1 FROM foocur
+ t        |     1 | FETCH FORWARD $1 FROM foocur
  t        |     1 | SELECT pg_stat_monitor_reset()
 (7 rows)
 
@@ -1202,7 +1202,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  t        |     1 | CLOSE foocur
  t        |     1 | COMMIT
  t        |     1 | DECLARE FOOCUR CURSOR FOR SELECT * FROM stats_track_tab
- t        |     1 | FETCH FORWARD 1 FROM foocur
+ t        |     1 | FETCH FORWARD $1 FROM foocur
  t        |     1 | SELECT pg_stat_monitor_reset()
 (6 rows)
 

--- a/regression/expected/level_tracking_3.out
+++ b/regression/expected/level_tracking_3.out
@@ -223,34 +223,34 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                query                                
 ----------+-------+---------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2)
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
  f        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table);
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  f        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2));
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1));
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id      +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
           |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id      +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id);
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                     +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id       +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                              +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2;
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES ($1);
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (23 rows)
 
@@ -349,22 +349,22 @@ EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                              query                               
-----------+-------+------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2)
+ toplevel | calls |                               query                                
+----------+-------+--------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                  +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id    +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                           +
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                    +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id     +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                             +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1 UNION SELECT $2
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (12 rows)
 
@@ -424,16 +424,16 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                                        query                                                        
 ----------+-------+---------------------------------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3); EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3)
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4)
  f        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3); EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4);
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4)
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4; EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT $1; EXPLAIN (COSTS OFF) SELECT 1, 2;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4
  f        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4; EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6;
  f        |     1 | EXPLAIN (COSTS OFF) SELECT 1; EXPLAIN (COSTS OFF) SELECT $1, $2;
  t        |     1 | SELECT pg_stat_monitor_reset()
@@ -514,24 +514,24 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                                                              query                                                               
 ----------+-------+----------------------------------------------------------------------------------------------------------------------------------
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab; EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1;
  f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab; EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1;
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ($1), ($2)
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (1), (2);
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
  f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ($1), ($2);
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (1), (2)
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab; EXPLAIN (COSTS OFF) (TABLE test_table);
  f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab; EXPLAIN (COSTS OFF) (TABLE test_table);
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2; EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1;
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
  f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1; EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1;
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES ($1); EXPLAIN (COSTS OFF) (VALUES (1, 2));
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
  f        |     1 | EXPLAIN (COSTS OFF) VALUES (1); EXPLAIN (COSTS OFF) (VALUES ($1, $2));
  t        |     1 | SELECT pg_stat_monitor_reset()
 (21 rows)
@@ -568,19 +568,19 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                             query                                              
 ----------+-------+------------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
+          |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id                                 +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
           |       |   USING (SELECT id FROM generate_series($1, $2) id) ON x = id                                 +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id); EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5;
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                                  +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                                +
           |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                                  +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                         +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id); EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5;
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5
  t        |     1 | SELECT pg_stat_monitor_reset()
 (5 rows)
 
@@ -719,26 +719,26 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                                              query                                                               
 ----------+-------+----------------------------------------------------------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3)
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5
- t        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3)
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3) UNION SELECT $4, $5, $6
+ t        |     1 | EXPLAIN (COSTS OFF) (SELECT $1, $2, $3, $4)
  t        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table)
- t        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) (VALUES ($1, $2))
  t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))
+ t        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (($1))
  t        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1), (2));
- t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab USING (SELECT id FROM generate_series(1, 10) id) ON x = id                       +
+ t        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab USING (SELECT id FROM generate_series($1, $2) id) ON x = id                      +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                                                           +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4
- t        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2 UNION SELECT $3, $4
+ t        |     1 | EXPLAIN (COSTS OFF) SELECT $1, $2, $3, $4, $5
  t        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1
- t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1
- t        |     1 | EXPLAIN (COSTS OFF) VALUES (1)
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1
+ t        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = $1 WHERE x = $2
+ t        |     1 | EXPLAIN (COSTS OFF) VALUES ($1)
  t        |     1 | SELECT pg_stat_monitor_reset()
 (19 rows)
 
@@ -815,26 +815,26 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                                           query                                           
 ----------+-------+-------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3))
  f        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3));
- t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT 4) (SELECT 1, 2))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab;
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2))
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2));
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                     +
+          |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                            +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                     +
           |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                            +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id);
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3;
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2;
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3
  f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3;
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) MERGE INTO stats_track_tab                      +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                             +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
-          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) UPDATE stats_track_tab SET x = 1 WHERE x = 1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (15 rows)
 
@@ -909,18 +909,18 @@ EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                         query                                         
-----------+-------+---------------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT 4) (SELECT 1, 2))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) DELETE FROM stats_track_tab
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) INSERT INTO stats_track_tab VALUES ((1))
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) MERGE INTO stats_track_tab                  +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                         +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                +
+ toplevel | calls |                                          query                                           
+----------+-------+------------------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT $1) (SELECT $2, $3))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) DELETE FROM stats_track_tab
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) INSERT INTO stats_track_tab VALUES (($2))
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) MERGE INTO stats_track_tab                    +
+          |       |   USING (SELECT id FROM generate_series($2, $3) id) ON x = id                           +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                   +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id)
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1 UNION SELECT 2
- t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) UPDATE stats_track_tab SET x = 1 WHERE x = 1
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) SELECT $2 UNION SELECT $3
+ t        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT $1) UPDATE stats_track_tab SET x = $2 WHERE x = $3
  t        |     1 | SELECT pg_stat_monitor_reset()
 (8 rows)
 
@@ -951,8 +951,8 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
 ----------+-------+-------------------------------------------------------------------------------
  t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)           +
           |       |   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1
  f        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1;
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT 100
  t        |     1 | SELECT pg_stat_monitor_reset()
 (4 rows)
 
@@ -979,11 +979,11 @@ EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                     query                                     
-----------+-------+-------------------------------------------------------------------------------
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)           +
+ toplevel | calls |                                    query                                     
+----------+-------+------------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)          +
           |       |   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab
- t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT 100
+ t        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT $1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
 
@@ -1002,7 +1002,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                       query                        
 ----------+-------+----------------------------------------------------
  t        |     1 | CREATE MATERIALIZED VIEW pgsm_materialized_view AS+
-          |       |   SELECT * FROM generate_series(1, 5) AS id
+          |       |   SELECT * FROM generate_series($1, $2) AS id
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 
@@ -1021,7 +1021,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
  toplevel | calls |                        query                         
 ----------+-------+------------------------------------------------------
  t        |     1 | CREATE MATERIALIZED VIEW pgsm_materialized_view_2 AS+
-          |       |   SELECT * FROM generate_series(1, 5) AS id
+          |       |   SELECT * FROM generate_series($1, $2) AS id
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 
@@ -1074,7 +1074,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                              query                              
 ----------+-------+-----------------------------------------------------------------
- t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_1 AS SELECT 1
+ t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_1 AS SELECT $1
  t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_2 AS EXECUTE test_prepare_pgsm
  f        |     1 | PREPARE test_prepare_pgsm AS SELECT generate_series($1, $2)
  t        |     1 | SELECT pg_stat_monitor_reset()
@@ -1094,7 +1094,7 @@ SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
  toplevel | calls |                              query                              
 ----------+-------+-----------------------------------------------------------------
- t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_3 AS SELECT 1
+ t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_3 AS SELECT $1
  t        |     1 | CREATE TEMPORARY TABLE pgsm_ctas_4 AS EXECUTE test_prepare_pgsm
  t        |     1 | SELECT pg_stat_monitor_reset()
 (3 rows)
@@ -1115,9 +1115,9 @@ EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                  query                                   
-----------+-------+--------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1
+ toplevel | calls |                                   query                                   
+----------+-------+---------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT $1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 
@@ -1137,9 +1137,9 @@ EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1;
 
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C";
- toplevel | calls |                                  query                                   
-----------+-------+--------------------------------------------------------------------------
- t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT 1
+ toplevel | calls |                                   query                                   
+----------+-------+---------------------------------------------------------------------------
+ t        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgsm_explain_ctas AS SELECT $1
  t        |     1 | SELECT pg_stat_monitor_reset()
 (2 rows)
 

--- a/regression/expected/pgsm_query_id.out
+++ b/regression/expected/pgsm_query_id.out
@@ -95,11 +95,11 @@ SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_q
  db2                | 1988437669671417938 | SELECT * FROM t1                                    |     1
  db1                | 5193804135051352284 | SELECT $1 + $2                                      |     1
  db2                | 5193804135051352284 | SELECT $1 + $2                                      |     1
- db2                | 6220142855706866455 | set pg_stat_monitor.pgsm_enable_pgsm_query_id = on  |     1
+ db2                | 8581192202768104099 | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     1
  db1                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
  db2                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
  db2                |                     | SELECT * FROM t3                                    |     1
- db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     1
+ db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = on  |     1
 (12 rows)
 
 SELECT pg_stat_monitor_reset();

--- a/regression/expected/pgsm_query_id_1.out
+++ b/regression/expected/pgsm_query_id_1.out
@@ -93,11 +93,11 @@ SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_q
  db1                | 1897482803466821995 | SELECT * /* x */ FROM t2                            |     4
  db1                | 1988437669671417938 | SELECT * FROM t1                                    |     1
  db2                | 1988437669671417938 | SELECT * FROM t1                                    |     1
- db2                | 6220142855706866455 | set pg_stat_monitor.pgsm_enable_pgsm_query_id = on  |     1
+ db2                | 8581192202768104099 | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     1
  db1                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
  db2                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
  db2                |                     | SELECT * FROM t3                                    |     1
- db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     1
+ db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = on  |     1
 (10 rows)
 
 SELECT pg_stat_monitor_reset();

--- a/regression/expected/pgsm_query_id_2.out
+++ b/regression/expected/pgsm_query_id_2.out
@@ -93,10 +93,10 @@ SELECT datname, pgsm_query_id, query, calls FROM pg_stat_monitor ORDER BY pgsm_q
  db1                | 1897482803466821995 | SELECT * /* x */ FROM t2                            |     4
  db1                | 1988437669671417938 | SELECT * FROM t1                                    |     1
  db2                | 1988437669671417938 | SELECT * FROM t1                                    |     1
+ db2                | 2230366555432676772 | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     2
  db1                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
  db2                | 8828613017640075704 | SELECT *, add(1, 2) FROM t1                         |     1
  db2                |                     | SELECT * FROM t3                                    |     1
- db2                |                     | set pg_stat_monitor.pgsm_enable_pgsm_query_id = off |     2
 (9 rows)
 
 SELECT pg_stat_monitor_reset();

--- a/regression/expected/plancache_1.out
+++ b/regression/expected/plancache_1.out
@@ -54,7 +54,7 @@ SELECT calls, generic_plan_calls, custom_plan_calls, query FROM pg_stat_monitor
 -------+--------------------+-------------------+-------------------------------------------------
      2 |                  1 |                 1 | PREPARE p1 AS SELECT $1 AS a;
      1 |                  0 |                 0 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
-     2 |                  0 |                 0 | SET plan_cache_mode TO force_generic_plan
+     2 |                  0 |                 0 | SET plan_cache_mode TO $1
 (3 rows)
 
 DEALLOCATE p1;
@@ -101,7 +101,7 @@ SELECT calls, generic_plan_calls, custom_plan_calls, toplevel, query FROM pg_sta
      2 |                  0 |                 0 | t        | EXPLAIN (COSTS OFF) EXECUTE p1(1)
      4 |                  2 |                 2 | f        | PREPARE p1 AS SELECT $1;
      1 |                  0 |                 0 | t        | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
-     2 |                  0 |                 0 | t        | SET plan_cache_mode TO force_generic_plan
+     2 |                  0 |                 0 | t        | SET plan_cache_mode TO $1
 (5 rows)
 
 RESET pg_stat_monitor.pgsm_track;
@@ -134,10 +134,10 @@ SELECT calls, generic_plan_calls, custom_plan_calls, toplevel, query FROM pg_sta
     ORDER BY query COLLATE "C";
  calls | generic_plan_calls | custom_plan_calls | toplevel |                      query                      
 -------+--------------------+-------------------+----------+-------------------------------------------------
-     2 |                  0 |                 0 | t        | CALL select_one_proc(1)
+     2 |                  0 |                 0 | t        | CALL select_one_proc($1)
      1 |                  0 |                 0 | t        | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
      2 |                  0 |                 0 | t        | SELECT select_one_func($1)
-     2 |                  0 |                 0 | t        | SET plan_cache_mode TO force_generic_plan
+     2 |                  0 |                 0 | t        | SET plan_cache_mode TO $1
 (4 rows)
 
 --
@@ -182,12 +182,12 @@ SELECT calls, generic_plan_calls, custom_plan_calls, toplevel, query FROM pg_sta
     ORDER BY query COLLATE "C", toplevel;
  calls | generic_plan_calls | custom_plan_calls | toplevel |                                             query                                              
 -------+--------------------+-------------------+----------+------------------------------------------------------------------------------------------------
-     2 |                  0 |                 0 | t        | CALL select_one_proc(1)
+     2 |                  0 |                 0 | t        | CALL select_one_proc($1)
+     2 |                  0 |                 0 | t        | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT select_one_func($1)
      4 |                  0 |                 0 | f        | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT select_one_func($1);
-     2 |                  0 |                 0 | t        | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT select_one_func(1)
-     2 |                  0 |                 0 | t        | EXPLAIN (COSTS OFF) SELECT select_one_func(1)
+     2 |                  0 |                 0 | t        | EXPLAIN (COSTS OFF) SELECT select_one_func($1)
      1 |                  0 |                 0 | t        | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
-     2 |                  0 |                 0 | t        | SET plan_cache_mode TO force_generic_plan
+     2 |                  0 |                 0 | t        | SET plan_cache_mode TO $1
 (6 rows)
 
 RESET pg_stat_monitor.pgsm_track;

--- a/regression/expected/utility.out
+++ b/regression/expected/utility.out
@@ -110,7 +110,7 @@ SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
      1 |    0 | CREATE FOREIGN TABLE foreign_stats (a int) SERVER server_stats
      1 |    0 | CREATE FUNCTION func_stats(a text DEFAULT 'a_data', b text DEFAULT lower('b_data'))+
        |      |     RETURNS text AS $$ SELECT $1::text || '_' || $2::text; $$ LANGUAGE SQL         +
-       |      |     SET work_mem = '256kB'
+       |      |     SET work_mem = $1
      1 |    0 | CREATE FUNCTION trigger_func_stats () RETURNS trigger LANGUAGE plpgsql             +
        |      |     AS $$ BEGIN return OLD; end; $$
      1 |    0 | CREATE INDEX pt_stats2_index ON ONLY pt_stats2 (a)
@@ -212,9 +212,9 @@ SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
  calls | rows |                      query                      
 -------+------+-------------------------------------------------
      2 |    0 | BEGIN
-     1 |    0 | COMMIT PREPARED 'stat_trans1'
-     2 |    0 | PREPARE TRANSACTION 'stat_trans1'
-     1 |    0 | ROLLBACK PREPARED 'stat_trans2'
+     1 |    0 | COMMIT PREPARED $1
+     2 |    0 | PREPARE TRANSACTION $1
+     1 |    0 | ROLLBACK PREPARED $1
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (5 rows)
 
@@ -243,9 +243,9 @@ SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 -------+------+-------------------------------------------------
      1 |    0 | BEGIN
      1 |    0 | COMMIT
-     3 |    0 | RELEASE sp3
-     4 |    0 | ROLLBACK TO sp4
-     4 |    0 | SAVEPOINT sp1
+     3 |    0 | RELEASE $1
+     4 |    0 | ROLLBACK TO $1
+     4 |    0 | SAVEPOINT $1
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (6 rows)
 
@@ -284,10 +284,10 @@ EXPLAIN (costs off) SELECT a FROM generate_series(1,10) AS tab(a) WHERE a = 7;
 (2 rows)
 
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                                     query                                     
--------+------+-------------------------------------------------------------------------------
-     2 |    0 | EXPLAIN (costs off) SELECT 1
-     2 |    0 | EXPLAIN (costs off) SELECT a FROM generate_series(1,10) AS tab(a) WHERE a = 3
+ calls | rows |                                      query                                      
+-------+------+---------------------------------------------------------------------------------
+     2 |    0 | EXPLAIN (costs off) SELECT $1
+     2 |    0 | EXPLAIN (costs off) SELECT a FROM generate_series($1,$2) AS tab(a) WHERE a = $3
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (3 rows)
 
@@ -352,11 +352,11 @@ CALL in_out(2, 1, 2);
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
  calls | rows |                      query                      
 -------+------+-------------------------------------------------
-     2 |    0 | CALL in_out(1, NULL, 1)
-     1 |    0 | CALL overload('A')
-     1 |    0 | CALL overload(1)
-     2 |    0 | CALL sum_one(3)
-     2 |    0 | CALL sum_two(1,1)
+     2 |    0 | CALL in_out($1, $2, $3)
+     1 |    0 | CALL overload($1)
+     1 |    0 | CALL overload($1)
+     2 |    0 | CALL sum_one($1)
+     2 |    0 | CALL sum_two($1,$2)
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (6 rows)
 
@@ -420,12 +420,12 @@ CREATE TABLE ctas_stats_2 AS
         FROM generate_series(1, 5) AS tab(a) WHERE a < 4 AND a > 1;
 DROP TABLE ctas_stats_2;
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                                query                                
--------+------+---------------------------------------------------------------------
-     2 |    2 | CREATE TABLE ctas_stats_1 AS SELECT 1 AS a
-     2 |    4 | CREATE TABLE ctas_stats_2 AS                                       +
-       |      |     SELECT a AS col1, 2::int AS col2                               +
-       |      |         FROM generate_series(1, 10) AS tab(a) WHERE a < 5 AND a > 2
+ calls | rows |                                 query                                  
+-------+------+------------------------------------------------------------------------
+     2 |    2 | CREATE TABLE ctas_stats_1 AS SELECT $1 AS a
+     2 |    4 | CREATE TABLE ctas_stats_2 AS                                          +
+       |      |     SELECT a AS col1, $1::int AS col2                                 +
+       |      |         FROM generate_series($2, $3) AS tab(a) WHERE a < $4 AND a > $5
      2 |    0 | DROP TABLE ctas_stats_1
      2 |    0 | DROP TABLE ctas_stats_2
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
@@ -448,11 +448,11 @@ CREATE MATERIALIZED VIEW matview_stats_1 AS
         FROM generate_series(1, 5) AS tab(a) WHERE a < 4 AND a > 3;
 DROP MATERIALIZED VIEW matview_stats_1;
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                                query                                
--------+------+---------------------------------------------------------------------
-     2 |    2 | CREATE MATERIALIZED VIEW matview_stats_1 AS                        +
-       |      |     SELECT a AS col1, 2::int AS col2                               +
-       |      |         FROM generate_series(1, 10) AS tab(a) WHERE a < 5 AND a > 2
+ calls | rows |                                 query                                  
+-------+------+------------------------------------------------------------------------
+     2 |    2 | CREATE MATERIALIZED VIEW matview_stats_1 AS                           +
+       |      |     SELECT a AS col1, $1::int AS col2                                 +
+       |      |         FROM generate_series($2, $3) AS tab(a) WHERE a < $4 AND a > $5
      2 |    0 | DROP MATERIALIZED VIEW matview_stats_1
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (3 rows)
@@ -623,14 +623,14 @@ SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
      1 |    0 | RESET enable_seqscan
      1 |    0 | RESET work_mem
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
-     1 |    0 | SET LOCAL SESSION AUTHORIZATION 'regress_stat_set_1'
-     1 |    0 | SET LOCAL SESSION AUTHORIZATION 'regress_stat_set_2'
+     1 |    0 | SET LOCAL SESSION AUTHORIZATION $1
+     1 |    0 | SET LOCAL SESSION AUTHORIZATION $1
      1 |    0 | SET LOCAL SESSION AUTHORIZATION DEFAULT
-     2 |    0 | SET LOCAL work_mem = '128kB'
+     2 |    0 | SET LOCAL work_mem = $1
      2 |    0 | SET LOCAL work_mem = DEFAULT
      1 |    0 | SET LOCAL work_mem FROM CURRENT
-     1 |    0 | SET SESSION AUTHORIZATION 'regress_stat_set_1'
-     1 |    0 | SET SESSION AUTHORIZATION 'regress_stat_set_2'
+     1 |    0 | SET SESSION AUTHORIZATION $1
+     1 |    0 | SET SESSION AUTHORIZATION $1
      1 |    0 | SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY
      1 |    0 | SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY, READ ONLY
      1 |    0 | SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY, READ WRITE
@@ -644,8 +644,8 @@ SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
      1 |    0 | SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
      1 |    0 | SET XML OPTION CONTENT
      1 |    0 | SET XML OPTION DOCUMENT
-     2 |    0 | SET enable_seqscan = off
-     5 |    0 | SET work_mem = '1MB'
+     2 |    0 | SET enable_seqscan = $1
+     5 |    0 | SET work_mem = $1
      2 |    0 | SET work_mem = DEFAULT
      1 |    0 | SET work_mem FROM CURRENT
 (34 rows)
@@ -700,19 +700,19 @@ FETCH FORWARD ALL pgsm_cursor;
 
 COMMIT;
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                                   query                                    
--------+------+----------------------------------------------------------------------------
+ calls | rows |                                  query                                  
+-------+------+-------------------------------------------------------------------------
      1 |    0 | BEGIN
      1 |    0 | COMMIT
      1 |    3 | COPY pgsm_ctas (a, b) FROM STDIN
      1 |   13 | CREATE MATERIALIZED VIEW pgsm_matv AS SELECT * FROM pgsm_ctas
-     1 |   10 | CREATE TABLE pgsm_ctas AS SELECT a, 'ctas' b FROM generate_series(1, 10) a
+     1 |   10 | CREATE TABLE pgsm_ctas AS SELECT a, $1 b FROM generate_series($2, $3) a
      1 |    0 | DECLARE pgsm_cursor CURSOR FOR SELECT * FROM pgsm_matv
-     1 |    5 | FETCH FORWARD 5 pgsm_cursor
+     1 |    5 | FETCH FORWARD $1 pgsm_cursor
      1 |    7 | FETCH FORWARD ALL pgsm_cursor
      1 |    1 | FETCH NEXT pgsm_cursor
      1 |   13 | REFRESH MATERIALIZED VIEW pgsm_matv
-     1 |   10 | SELECT generate_series(1, 10) c INTO pgsm_select_into
+     1 |   10 | SELECT generate_series($1, $2) c INTO pgsm_select_into
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (12 rows)
 
@@ -734,7 +734,7 @@ SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 -------+------+-------------------------------------------------
      1 |    0 | RESET ALL
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
-     2 |    0 | SET SCHEMA 'foo'
+     2 |    0 | SET SCHEMA $1
 (3 rows)
 
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;

--- a/regression/expected/utility_2.out
+++ b/regression/expected/utility_2.out
@@ -292,10 +292,10 @@ EXPLAIN (costs off) SELECT a FROM generate_series(1,10) AS tab(a) WHERE a = 7;
 (2 rows)
 
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                                     query                                     
--------+------+-------------------------------------------------------------------------------
-     2 |    0 | EXPLAIN (costs off) SELECT 1
-     2 |    0 | EXPLAIN (costs off) SELECT a FROM generate_series(1,10) AS tab(a) WHERE a = 3
+ calls | rows |                                      query                                      
+-------+------+---------------------------------------------------------------------------------
+     2 |    0 | EXPLAIN (costs off) SELECT $1
+     2 |    0 | EXPLAIN (costs off) SELECT a FROM generate_series($1,$2) AS tab(a) WHERE a = $3
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (3 rows)
 
@@ -431,12 +431,12 @@ CREATE TABLE ctas_stats_2 AS
         FROM generate_series(1, 5) AS tab(a) WHERE a < 4 AND a > 1;
 DROP TABLE ctas_stats_2;
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                                query                                
--------+------+---------------------------------------------------------------------
-     2 |    2 | CREATE TABLE ctas_stats_1 AS SELECT 1 AS a
-     2 |    4 | CREATE TABLE ctas_stats_2 AS                                       +
-       |      |     SELECT a AS col1, 2::int AS col2                               +
-       |      |         FROM generate_series(1, 10) AS tab(a) WHERE a < 5 AND a > 2
+ calls | rows |                                 query                                  
+-------+------+------------------------------------------------------------------------
+     2 |    2 | CREATE TABLE ctas_stats_1 AS SELECT $1 AS a
+     2 |    4 | CREATE TABLE ctas_stats_2 AS                                          +
+       |      |     SELECT a AS col1, $1::int AS col2                                 +
+       |      |         FROM generate_series($2, $3) AS tab(a) WHERE a < $4 AND a > $5
      2 |    0 | DROP TABLE ctas_stats_1
      2 |    0 | DROP TABLE ctas_stats_2
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
@@ -459,11 +459,11 @@ CREATE MATERIALIZED VIEW matview_stats_1 AS
         FROM generate_series(1, 5) AS tab(a) WHERE a < 4 AND a > 3;
 DROP MATERIALIZED VIEW matview_stats_1;
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                                query                                
--------+------+---------------------------------------------------------------------
-     2 |    2 | CREATE MATERIALIZED VIEW matview_stats_1 AS                        +
-       |      |     SELECT a AS col1, 2::int AS col2                               +
-       |      |         FROM generate_series(1, 10) AS tab(a) WHERE a < 5 AND a > 2
+ calls | rows |                                 query                                  
+-------+------+------------------------------------------------------------------------
+     2 |    2 | CREATE MATERIALIZED VIEW matview_stats_1 AS                           +
+       |      |     SELECT a AS col1, $1::int AS col2                                 +
+       |      |         FROM generate_series($2, $3) AS tab(a) WHERE a < $4 AND a > $5
      2 |    0 | DROP MATERIALIZED VIEW matview_stats_1
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (3 rows)
@@ -716,19 +716,19 @@ FETCH FORWARD ALL pgsm_cursor;
 
 COMMIT;
 SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
- calls | rows |                                   query                                    
--------+------+----------------------------------------------------------------------------
+ calls | rows |                                  query                                  
+-------+------+-------------------------------------------------------------------------
      1 |    0 | BEGIN
      1 |    0 | COMMIT
      1 |    3 | COPY pgsm_ctas (a, b) FROM STDIN
      1 |   13 | CREATE MATERIALIZED VIEW pgsm_matv AS SELECT * FROM pgsm_ctas
-     1 |   10 | CREATE TABLE pgsm_ctas AS SELECT a, 'ctas' b FROM generate_series(1, 10) a
+     1 |   10 | CREATE TABLE pgsm_ctas AS SELECT a, $1 b FROM generate_series($2, $3) a
      1 |    0 | DECLARE pgsm_cursor CURSOR FOR SELECT * FROM pgsm_matv
      1 |    5 | FETCH FORWARD 5 pgsm_cursor
      1 |    7 | FETCH FORWARD ALL pgsm_cursor
      1 |    1 | FETCH NEXT pgsm_cursor
      1 |   13 | REFRESH MATERIALIZED VIEW pgsm_matv
-     1 |   10 | SELECT generate_series(1, 10) c INTO pgsm_select_into
+     1 |   10 | SELECT generate_series($1, $2) c INTO pgsm_select_into
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
 (12 rows)
 

--- a/regression/expected/utility_5.out
+++ b/regression/expected/utility_5.out
@@ -110,7 +110,7 @@ SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
      1 |    0 | CREATE FOREIGN TABLE foreign_stats (a int) SERVER server_stats
      1 |    0 | CREATE FUNCTION func_stats(a text DEFAULT 'a_data', b text DEFAULT lower('b_data'))+
        |      |     RETURNS text AS $$ SELECT $1::text || '_' || $2::text; $$ LANGUAGE SQL         +
-       |      |     SET work_mem = '256kB'
+       |      |     SET work_mem = $1
      1 |    0 | CREATE FUNCTION trigger_func_stats () RETURNS trigger LANGUAGE plpgsql             +
        |      |     AS $$ BEGIN return OLD; end; $$
      1 |    0 | CREATE INDEX pt_stats2_index ON ONLY pt_stats2 (a)
@@ -623,21 +623,18 @@ SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
      1 |    0 | RESET enable_seqscan
      1 |    0 | RESET work_mem
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
-     1 |    0 | SET LOCAL SESSION AUTHORIZATION 'regress_stat_set_1'
-     1 |    0 | SET LOCAL SESSION AUTHORIZATION 'regress_stat_set_2'
+     1 |    0 | SET LOCAL SESSION AUTHORIZATION $1
+     1 |    0 | SET LOCAL SESSION AUTHORIZATION $1
      1 |    0 | SET LOCAL SESSION AUTHORIZATION DEFAULT
-     1 |    0 | SET LOCAL work_mem = '128kB'
-     1 |    0 | SET LOCAL work_mem = '256kB'
+     2 |    0 | SET LOCAL work_mem = $1
      2 |    0 | SET LOCAL work_mem = DEFAULT
      1 |    0 | SET LOCAL work_mem FROM CURRENT
-     1 |    0 | SET SESSION AUTHORIZATION 'regress_stat_set_1'
-     1 |    0 | SET SESSION AUTHORIZATION 'regress_stat_set_2'
+     1 |    0 | SET SESSION AUTHORIZATION $1
+     1 |    0 | SET SESSION AUTHORIZATION $1
      1 |    0 | SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY
      1 |    0 | SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY, READ ONLY
      1 |    0 | SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY, READ WRITE
      1 |    0 | SET SESSION SESSION AUTHORIZATION DEFAULT
-     1 |    0 | SET SESSION work_mem = '300kB'
-     1 |    0 | SET SESSION work_mem = '400kB'
      1 |    0 | SET TIME ZONE 'America/New_York'
      1 |    0 | SET TIME ZONE 'Asia/Tokyo'
      1 |    0 | SET TIME ZONE 'CST7CDT,M4.1.0,M10.5.0'
@@ -647,13 +644,11 @@ SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
      1 |    0 | SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
      1 |    0 | SET XML OPTION CONTENT
      1 |    0 | SET XML OPTION DOCUMENT
-     1 |    0 | SET enable_seqscan = off
-     1 |    0 | SET enable_seqscan = on
-     2 |    0 | SET work_mem = '1MB'
-     1 |    0 | SET work_mem = '2MB'
+     2 |    0 | SET enable_seqscan = $1
+     5 |    0 | SET work_mem = $1
      2 |    0 | SET work_mem = DEFAULT
      1 |    0 | SET work_mem FROM CURRENT
-(39 rows)
+(34 rows)
 
 DROP ROLE regress_stat_set_1;
 DROP ROLE regress_stat_set_2;
@@ -739,9 +734,8 @@ SELECT calls, rows, query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 -------+------+-------------------------------------------------
      1 |    0 | RESET ALL
      1 |    1 | SELECT pg_stat_monitor_reset() IS NOT NULL AS t
-     1 |    0 | SET SCHEMA 'foo'
-     1 |    0 | SET SCHEMA 'public'
-(4 rows)
+     2 |    0 | SET SCHEMA $1
+(3 rows)
 
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
  t 

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -478,10 +478,17 @@ pgsm_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 	 */
 	if (query->utilityStmt)
 	{
-		if (pgsm_track_utility && IsA(query->utilityStmt, ExecuteStmt))
-			query->queryId = INT64CONST(0);
+		/* See pgsm_ProcessUtility for more details regarding this skip logic */
+		if (!pgsm_track_utility ||
+			IsA(query->utilityStmt, PrepareStmt) ||
+			IsA(query->utilityStmt, DeallocateStmt))
+			return;
 
-		return;
+		if (IsA(query->utilityStmt, ExecuteStmt))
+		{
+			query->queryId = INT64CONST(0);
+			return;
+		}
 	}
 
 	/*
@@ -504,6 +511,16 @@ pgsm_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 											   location,	/* query location */
 											   &norm_query_len);
 	}
+
+	/*
+	 * This is optimization. The only thing that we need here for utility
+	 * statements is normalized query. If we don't have it, we can skip entry
+	 * creation. It will be created in pgsm_ProcessUtility() if needed.
+	 */
+	if (query->utilityStmt && norm_query == NULL)
+		return;
+
+	Assert(query->queryId != INT64CONST(0));
 
 	/*
 	 * pgsm_query_id always groups by the normalized form when we have one.
@@ -1101,8 +1118,6 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		!IsA(parsetree, PrepareStmt) &&
 		!IsA(parsetree, DeallocateStmt))
 	{
-		const char *query_text;
-		char	   *store_text;
 		int			location = pstmt->stmt_location;
 		int			query_len = pstmt->stmt_len;
 		int			cmd_type = pstmt->commandType;
@@ -1112,21 +1127,47 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		struct rusage rusage_end;
 		SysInfo		sys_info;
 		BufferUsage bufusage;
-		BufferUsage bufusage_start = pgBufferUsage;
+		BufferUsage bufusage_start;
 		WalUsage	walusage;
-		WalUsage	walusage_start = pgWalUsage;
+		WalUsage	walusage_start;
 		pgsmQueryStats stats = {0};
-		pgsmQueryExecInfo info;
-
-		getrusage(RUSAGE_SELF, &rusage_start);
+		pgsmQueryStats *stashed;
 
 		/*
-		 * Create a query execution info before utility statement execution
-		 * because statement may change the data itself and for statistics we
-		 * need to know this data at the statement execution start time.
+		 * If there is an entry for the query in the list, use it as it has
+		 * normalized query text. We have to copy entry to the stack here as
+		 * statement execution may cleanup memory context that stores entries
+		 * list.
 		 */
-		pgsm_fill_query_exec_info(&info);
+		stashed = pgsm_find_query_stats(queryId);
+		if (stashed != NULL)
+		{
+			stats = *stashed;
+			stats.query = pstrdup(stashed->query);
+			pgsm_delete_query_stats(queryId);
+		}
+		else
+		{
+			pgsmQueryExecInfo info;
+			const char *query_text;
 
+			/*
+			 * Create the entry before utility statement execution because the
+			 * statement may change the execution info itself and for statistics
+			 * we need to know this data at the statement execution start time.
+			 */
+			pgsm_fill_query_exec_info(&info);
+			query_text = CleanQuerytext(queryString, &location, &query_len);
+
+			pgsm_fill_query_stats(&stats, &info, queryId, 0,
+								  get_pgsm_query_id_hash(query_text, query_len),
+								  pnstrdup(query_text, query_len),	/* null terminated */
+								  cmd_type);
+		}
+
+		getrusage(RUSAGE_SELF, &rusage_start);
+		bufusage_start = pgBufferUsage;
+		walusage_start = pgWalUsage;
 		INSTR_TIME_SET_CURRENT(start);
 		nesting_level++;
 
@@ -1183,15 +1224,6 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		memset(&bufusage, 0, sizeof(BufferUsage));
 		BufferUsageAccumDiff(&bufusage, &pgBufferUsage, &bufusage_start);
 
-		query_text = CleanQuerytext(queryString, &location, &query_len);
-
-		/* Make it null terminated */
-		store_text = pnstrdup(query_text, query_len);
-
-		pgsm_fill_query_stats(&stats, &info, queryId, 0,
-							  get_pgsm_query_id_hash(query_text, query_len),
-							  store_text, cmd_type);
-
 		/* The plan details are captured when the query finishes */
 		pgsm_update_counters(&stats.counters,	/* counters */
 							 NULL,	/* PlanInfo */
@@ -1208,7 +1240,7 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 
 		pgsm_store(&stats);
 
-		pfree(store_text);
+		pfree(stats.query);
 	}
 	else
 	{

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -234,22 +234,9 @@ typedef struct pgsmQueryStats
 	Counters	counters;		/* the statistics for this query */
 } pgsmQueryStats;
 
-/*
- * Structure to store information about the current statement execution.
- * This data may change during the execution of the query and for statistics
- * we need to know this data at the time when the statement execution started.
- */
-typedef struct pgsmQueryExecInfo
-{
-	Oid			userid;
-	char		appname[NAMEDATALEN];
-	char		username[NAMEDATALEN];
-} pgsmQueryExecInfo;
-
 static MemoryContext pgsm_memory_context(void);
-static void pgsm_fill_query_exec_info(pgsmQueryExecInfo *info);
 static pgsmQueryStats *pgsm_add_query_stats(int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, int query_len, CmdType cmd_type);
-static void pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type);
+static void pgsm_fill_query_stats(pgsmQueryStats *stats, int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type);
 static pgsmQueryStats *pgsm_find_query_stats(int64 queryid);
 static void pgsm_delete_query_stats(uint64 queryid);
 static int64 get_pgsm_query_id_hash(const char *norm_query, int len);
@@ -1148,18 +1135,10 @@ pgsm_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		}
 		else
 		{
-			pgsmQueryExecInfo info;
-			const char *query_text;
+			const char *query_text = CleanQuerytext(queryString, &location,
+													&query_len);
 
-			/*
-			 * Create the entry before utility statement execution because the
-			 * statement may change the execution info itself and for statistics
-			 * we need to know this data at the statement execution start time.
-			 */
-			pgsm_fill_query_exec_info(&info);
-			query_text = CleanQuerytext(queryString, &location, &query_len);
-
-			pgsm_fill_query_stats(&stats, &info, queryId, 0,
+			pgsm_fill_query_stats(&stats, queryId, 0,
 								  get_pgsm_query_id_hash(query_text, query_len),
 								  pnstrdup(query_text, query_len),	/* null terminated */
 								  cmd_type);
@@ -1324,40 +1303,6 @@ pgsm_set_cached_info(void)
 		{
 			strlcpy(datname, name, NAMEDATALEN);
 			pfree(name);
-		}
-	}
-}
-
-/*
- * Fill the query execution info with the current statement execution data.
- * Some data may be changed by statement execution itself, but for
- * statistics we need this data state at the statement execution start time.
- */
-static void
-pgsm_fill_query_exec_info(pgsmQueryExecInfo *info)
-{
-	int			sec_ctx;
-
-	/*
-	 * Get the user ID. Let's use this instead of GetUserID as this won't
-	 * throw an assertion in case of an error.
-	 */
-	GetUserIdAndSecContext(&info->userid, &sec_ctx);
-
-	if (application_name)
-		strlcpy(info->appname, application_name, NAMEDATALEN);
-	else
-		strlcpy(info->appname, "", NAMEDATALEN);
-
-	info->username[0] = '\0';
-	if (IsTransactionState())
-	{
-		char	   *username = GetUserNameFromId(info->userid, true);
-
-		if (username)
-		{
-			strlcpy(info->username, username, NAMEDATALEN);
-			pfree(username);
 		}
 	}
 }
@@ -1619,11 +1564,9 @@ static void
 pgsm_store_error(const char *query, const ErrorData *edata)
 {
 	pgsmQueryStats stats = {0};
-	pgsmQueryExecInfo info;
 	int			len = strlen(query);
 
-	pgsm_fill_query_exec_info(&info);
-	pgsm_fill_query_stats(&stats, &info,
+	pgsm_fill_query_stats(&stats,
 						  pgsm_hash_string(query, len),
 						  0,
 						  get_pgsm_query_id_hash(query, len),
@@ -1675,18 +1618,15 @@ static pgsmQueryStats *
 pgsm_add_query_stats(int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, int query_len, CmdType cmd_type)
 {
 	pgsmQueryStats *stats;
-	pgsmQueryExecInfo info;
 	MemoryContext oldctx;
-	char	   *store_text;
-
-	pgsm_fill_query_exec_info(&info);
 
 	/* Create the stats and own the query text in the pgsm memory context */
 	oldctx = MemoryContextSwitchTo(pgsm_memory_context());
 	stats = palloc0_object(pgsmQueryStats);
-	store_text = pnstrdup(query_text, query_len);
 
-	pgsm_fill_query_stats(stats, &info, queryid, planid, pgsm_query_id, store_text, cmd_type);
+	pgsm_fill_query_stats(stats, queryid, planid, pgsm_query_id,
+						  pnstrdup(query_text, query_len),	/* null terminated */
+						  cmd_type);
 	lentries = lappend(lentries, stats);
 	MemoryContextSwitchTo(oldctx);
 
@@ -1697,27 +1637,48 @@ pgsm_add_query_stats(int64 queryid, int64 planid, int64 pgsm_query_id, const cha
  * Populate non-counter fields of a pgsmQueryStats.
  */
 static void
-pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type)
+pgsm_fill_query_stats(pgsmQueryStats *stats, int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type)
 {
+	int			sec_ctx;
+
 	pgsm_set_cached_info();
+
+	/*
+	 * Get the user ID. Let's use this instead of GetUserID as this won't
+	 * throw an assertion in case of an error.
+	 */
+	GetUserIdAndSecContext(&stats->key.userid, &sec_ctx);
+
+	if (application_name)
+		strlcpy(stats->appname, application_name, NAMEDATALEN);
+	else
+		stats->appname[0] = '\0';
+
+	stats->username[0] = '\0';
+	if (IsTransactionState())
+	{
+		char	   *username = GetUserNameFromId(stats->key.userid, true);
+
+		if (username)
+		{
+			strlcpy(stats->username, username, NAMEDATALEN);
+			pfree(username);
+		}
+	}
 
 	stats->subxid = IsTransactionState() ? GetCurrentSubTransactionId()
 		: InvalidSubTransactionId;
 
-	stats->key.appid = pgsm_hash_string(info->appname, strlen(info->appname));
+	stats->key.appid = pgsm_hash_string(stats->appname, strlen(stats->appname));
 	stats->key.ip = client_ip;
 	stats->key.planid = planid;
 	stats->key.dbid = MyDatabaseId;
 	stats->key.queryid = queryid;
 	stats->key.parentid = 0;
-	stats->key.userid = info->userid;
 
 	stats->pgsm_query_id = pgsm_query_id;
 	stats->counters.info.cmd_type = cmd_type;
 	stats->query = unconstify(char *, query_text);
-
-	strlcpy(stats->appname, info->appname, NAMEDATALEN);
-	strlcpy(stats->username, info->username, NAMEDATALEN);
 
 #if PG_VERSION_NUM >= 170000
 	stats->key.toplevel = (nesting_level == 0);

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -250,8 +250,8 @@ static MemoryContext pgsm_memory_context(void);
 static void pgsm_fill_query_exec_info(pgsmQueryExecInfo *info);
 static pgsmQueryStats *pgsm_add_query_stats(int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, int query_len, CmdType cmd_type);
 static void pgsm_fill_query_stats(pgsmQueryStats *stats, const pgsmQueryExecInfo *info, int64 queryid, int64 planid, int64 pgsm_query_id, const char *query_text, CmdType cmd_type);
+static pgsmQueryStats *pgsm_find_query_stats(int64 queryid);
 static void pgsm_delete_query_stats(uint64 queryid);
-static pgsmQueryStats *pgsm_get_query_stats(int64 queryid, int64 planid, const char *query_text, CmdType cmd_type);
 static int64 get_pgsm_query_id_hash(const char *norm_query, int len);
 
 static void pgsm_cleanup_callback(void *arg);
@@ -569,8 +569,15 @@ pgsm_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		 * snapshot of the execution info (application_name, user) reflects
 		 * the state at statement start.
 		 */
-		(void) pgsm_get_query_stats(queryDesc->plannedstmt->queryId, 0,
-									queryDesc->sourceText, queryDesc->operation);
+		if (pgsm_find_query_stats(queryDesc->plannedstmt->queryId) == NULL)
+		{
+			int			query_len = strlen(queryDesc->sourceText);
+
+			pgsm_add_query_stats(queryDesc->plannedstmt->queryId, 0,
+								 get_pgsm_query_id_hash(queryDesc->sourceText, query_len),
+								 queryDesc->sourceText, query_len,
+								 queryDesc->operation);
+		}
 
 #if PG_VERSION_NUM < 190000
 
@@ -722,7 +729,16 @@ pgsm_ExecutorEnd(QueryDesc *queryDesc)
 		SysInfo		sys_info;
 		int64		planid = plan_ptr ? plan_ptr->planid : 0;
 
-		stats = pgsm_get_query_stats(queryId, planid, queryDesc->sourceText, queryDesc->operation);
+		stats = pgsm_find_query_stats(queryId);
+		if (stats == NULL)
+		{
+			int			query_len = strlen(queryDesc->sourceText);
+
+			stats = pgsm_add_query_stats(queryId, planid,
+										 get_pgsm_query_id_hash(queryDesc->sourceText, query_len),
+										 queryDesc->sourceText, query_len,
+										 queryDesc->operation);
+		}
 
 		if (stats->key.planid == 0 && planid != 0)
 			stats->key.planid = planid;
@@ -914,7 +930,16 @@ pgsm_planner_hook(Query *parse, const char *query_string, int cursorOptions, Par
 		walusage_start = pgWalUsage;
 		INSTR_TIME_SET_CURRENT(start);
 
-		stats = pgsm_get_query_stats(queryId, 0, query_string, parse->commandType);
+		stats = pgsm_find_query_stats(queryId);
+		if (stats == NULL)
+		{
+			int			query_len = strlen(query_string);
+
+			stats = pgsm_add_query_stats(queryId, 0,
+										 get_pgsm_query_id_hash(query_string, query_len),
+										 query_string, query_len,
+										 parse->commandType);
+		}
 
 #if PG_VERSION_NUM >= 170000
 		nesting_level++;
@@ -1705,39 +1730,31 @@ pgsm_delete_query_stats(uint64 queryid)
 }
 
 /*
- * Function to get a pgsmQueryStats structure from the local list.
+ * Find query stats by query id.
+ * Returns NULL if not found.
  */
 static pgsmQueryStats *
-pgsm_get_query_stats(int64 queryid, int64 planid, const char *query_text, CmdType cmd_type)
+pgsm_find_query_stats(int64 queryid)
 {
 	pgsmQueryStats *stats;
-	int			query_len;
+	ListCell   *lc;
 
-	Assert(query_text != NULL);
+	if (lentries == NIL)
+		return NULL;
 
-	if (lentries != NIL)
+	/* First bet is on the last item */
+	stats = (pgsmQueryStats *) llast(lentries);
+	if (stats->key.queryid == queryid)
+		return stats;
+
+	foreach(lc, lentries)
 	{
-		ListCell   *lc;
-
-		/* First bet is on the last item */
-		stats = (pgsmQueryStats *) llast(lentries);
+		stats = lfirst(lc);
 		if (stats->key.queryid == queryid)
 			return stats;
-
-		foreach(lc, lentries)
-		{
-			stats = lfirst(lc);
-			if (stats->key.queryid == queryid)
-				return stats;
-		}
 	}
 
-	query_len = strlen(query_text);
-	stats = pgsm_add_query_stats(queryid, planid,
-								 get_pgsm_query_id_hash(query_text, query_len),
-								 query_text, query_len, cmd_type);
-
-	return stats;
+	return NULL;
 }
 
 static void


### PR DESCRIPTION
PG-2623

### Description
<!--- Describe your changes in detail -->
To have normalized query text for utility statements we have to pre-save it in post parse hook. (pretty much the same as for ordinary queries). Because some utility statements may cleanup our memory context we have to copy query stats entry to stack.

### Links
<!--- Please provide links to any related PRs in this or other repositories --->

