### PR TITLE
Remove special handling for zero query ID hash

### DIFF
--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -485,13 +485,6 @@ pgsm_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 	}
 
 	/*
-	 * If we are unlucky enough to get a hash of zero, use 1 instead, to
-	 * prevent confusion with the utility-statement case.
-	 */
-	if (query->queryId == INT64CONST(0))
-		query->queryId = INT64CONST(1);
-
-	/*
 	 * Let's save the normalized query so that we can save the data without in
 	 * hash later on without the need of jstate which wouldn't be available.
 	 */


### PR DESCRIPTION
Since PostgreSQL 14 query jumbling can no longer result in a query ID of zero so we no longer need to handle that case.

See commit 5fd9dfa5f50e4906c35133a414ebec5b6d518493

PG-0