### PR TITLE
PG-2624 Hide sensitive data for users with no priveleges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,3 +77,4 @@
 - Fix performance issue in comment extraction in large queries ([PG-1674](https://perconadev.atlassian.net/browse/PG-1674))
 - Fix error levels in PostreSQL 17 ([PG-1313](https://perconadev.atlassian.net/browse/PG-1313))
 - Fix bug where `cmd_type` often was 0 ([PG-1621](https://perconadev.atlassian.net/browse/PG-1621))
+- Hide sensitive date for users who has no priveleges ([PG-2624](https://perconadev.atlassian.net/browse/PG-2624)).

--- a/regression/expected/privileges.out
+++ b/regression/expected/privileges.out
@@ -6,10 +6,21 @@
 CREATE EXTENSION pg_stat_monitor;
 SET pg_stat_monitor.pgsm_track_utility = off;
 SET pg_stat_monitor.pgsm_normalized_query = on;
+SET pg_stat_monitor.pgsm_track = 'all';
+SET pg_stat_monitor.pgsm_extract_comments = on;
+SET pg_stat_monitor.pgsm_enable_query_plan = on;
+CREATE FUNCTION regress_stats_nested(int) RETURNS int AS
+$$
+BEGIN
+    RETURN (SELECT $1 + 1);
+END
+$$ LANGUAGE plpgsql;
 CREATE ROLE regress_stats_superuser SUPERUSER;
 CREATE ROLE regress_stats_user1;
 CREATE ROLE regress_stats_user2;
+CREATE ROLE regress_stats_user3 NOINHERIT;
 GRANT pg_read_all_stats TO regress_stats_user2;
+GRANT pg_read_all_stats TO regress_stats_user3;
 SET ROLE regress_stats_superuser;
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
  t 
@@ -23,6 +34,12 @@ SELECT 1 AS "ONE";
    1
 (1 row)
 
+SELECT regress_stats_nested(1);
+ regress_stats_nested 
+----------------------
+                    2
+(1 row)
+
 SET ROLE regress_stats_user1;
 SELECT 1+1 AS "TWO";
  TWO 
@@ -30,66 +47,192 @@ SELECT 1+1 AS "TWO";
    2
 (1 row)
 
+SELECT regress_stats_nested(2) /* comment */;
+ regress_stats_nested 
+----------------------
+                    3
+(1 row)
+
+SELECT 1 / 0;
+ERROR:  division by zero
+--
+-- regress_stats_user1 has no privileges to read the query text of queries
+-- executed by others but can see statistics like calls and rows.
+--
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.top_query,
+       ss.message, ss.comments, ss.pgsm_query_id <> 0 AS pgsm_query_id_bool,
+       ss.planid <> 0 AS planid_bool,
+       ss.top_queryid <> 0 AS top_queryid_bool,
+       ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows
+    FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
+    ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
+         rolname         | queryid_bool |                     query                     |                   top_query                   |         message          |         comments         | pgsm_query_id_bool | planid_bool | top_queryid_bool | client_ip_bool | calls | rows 
+-------------------------+--------------+-----------------------------------------------+-----------------------------------------------+--------------------------+--------------------------+--------------------+-------------+------------------+----------------+-------+------
+ regress_stats_superuser |              | <insufficient privilege>                      | <insufficient privilege>                      | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    1
+ regress_stats_superuser |              | <insufficient privilege>                      | <insufficient privilege>                      | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    1
+ regress_stats_superuser |              | <insufficient privilege>                      | <insufficient privilege>                      | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    1
+ regress_stats_superuser |              | <insufficient privilege>                      | <insufficient privilege>                      | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    1
+ regress_stats_user1     | t            | (SELECT $1 + 1)                               | SELECT regress_stats_nested(2) /* comment */; |                          |                          | t                  | t           | t                | t              |     1 |    1
+ regress_stats_user1     | t            | SELECT $1+$2 AS "TWO"                         |                                               |                          |                          | t                  | t           |                  | t              |     1 |    1
+ regress_stats_user1     | t            | SELECT 1 / 0;                                 |                                               | division by zero         |                          | t                  |             |                  | t              |     1 |    0
+ regress_stats_user1     | t            | SELECT regress_stats_nested($1) /* comment */ |                                               |                          | /* comment */            | t                  | t           |                  | t              |     1 |    1
+(8 rows)
+
 --
 -- A superuser can read all columns of queries executed by others,
 -- including query text.
 --
 SET ROLE regress_stats_superuser;
-SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.calls, ss.rows
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.top_query,
+       ss.message, ss.comments, ss.pgsm_query_id <> 0 AS pgsm_query_id_bool,
+       ss.planid <> 0 AS planid_bool,
+       ss.top_queryid <> 0 AS top_queryid_bool,
+       ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows
     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
-         rolname         | queryid_bool |                      query                      | calls | rows 
--------------------------+--------------+-------------------------------------------------+-------+------
- regress_stats_superuser | t            | SELECT $1 AS "ONE"                              |     1 |    1
- regress_stats_superuser | t            | SELECT pg_stat_monitor_reset() IS NOT NULL AS t |     1 |    1
- regress_stats_user1     | t            | SELECT $1+$2 AS "TWO"                           |     1 |    1
-(3 rows)
-
---
--- regress_stats_user1 has no privileges to read the query text of queries
--- executed by others but can see statistics like calls and rows.
---
-SET ROLE regress_stats_user1;
-SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.calls, ss.rows
-    FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
-    ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
-         rolname         | queryid_bool |          query           | calls | rows 
--------------------------+--------------+--------------------------+-------+------
- regress_stats_superuser | t            | <insufficient privilege> |     1 |    1
- regress_stats_superuser | t            | <insufficient privilege> |     1 |    1
- regress_stats_superuser | t            | <insufficient privilege> |     1 |    3
- regress_stats_user1     | t            | SELECT $1+$2 AS "TWO"    |     1 |    1
-(4 rows)
+         rolname         | queryid_bool |                                     query                                     |                   top_query                   |     message      |   comments    | pgsm_query_id_bool | planid_bool | top_queryid_bool | client_ip_bool | calls | rows 
+-------------------------+--------------+-------------------------------------------------------------------------------+-----------------------------------------------+------------------+---------------+--------------------+-------------+------------------+----------------+-------+------
+ regress_stats_superuser | t            | (SELECT $1 + $2)                                                              | SELECT regress_stats_nested(1);               |                  |               | t                  | t           | t                | t              |     1 |    1
+ regress_stats_superuser | t            | SELECT $1 AS "ONE"                                                            |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_superuser | t            | SELECT pg_stat_monitor_reset() IS NOT NULL AS t                               |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_superuser | t            | SELECT regress_stats_nested($1)                                               |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_user1     | t            | (SELECT $1 + 1)                                                               | SELECT regress_stats_nested(2) /* comment */; |                  |               | t                  | t           | t                | t              |     1 |    1
+ regress_stats_user1     | t            | SELECT $1+$2 AS "TWO"                                                         |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_user1     | t            | SELECT 1 / 0;                                                                 |                                               | division by zero |               | t                  |             |                  | t              |     1 |    0
+ regress_stats_user1     | t            | SELECT r.rolname, ss.queryid <> $1 AS queryid_bool, ss.query, ss.top_query,  +|                                               |                  |               | t                  | t           |                  | t              |     1 |    8
+                         |              |        ss.message, ss.comments, ss.pgsm_query_id <> $2 AS pgsm_query_id_bool,+|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.planid <> $3 AS planid_bool,                                       +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.top_queryid <> $4 AS top_queryid_bool,                             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows         +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows               |                                               |                  |               |                    |             |                  |                |       | 
+ regress_stats_user1     | t            | SELECT regress_stats_nested($1) /* comment */                                 |                                               |                  | /* comment */ | t                  | t           |                  | t              |     1 |    1
+(9 rows)
 
 --
 -- regress_stats_user2, with pg_read_all_stats role privileges, can
 -- read all columns, including query text, of queries executed by others.
 --
 SET ROLE regress_stats_user2;
-SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.calls, ss.rows
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.top_query,
+       ss.message, ss.comments, ss.pgsm_query_id <> 0 AS pgsm_query_id_bool,
+       ss.planid <> 0 AS planid_bool,
+       ss.top_queryid <> 0 AS top_queryid_bool,
+       ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows
     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
-         rolname         | queryid_bool |                                      query                                      | calls | rows 
--------------------------+--------------+---------------------------------------------------------------------------------+-------+------
- regress_stats_superuser | t            | SELECT $1 AS "ONE"                                                              |     1 |    1
- regress_stats_superuser | t            | SELECT pg_stat_monitor_reset() IS NOT NULL AS t                                 |     1 |    1
- regress_stats_superuser | t            | SELECT r.rolname, ss.queryid <> $1 AS queryid_bool, ss.query, ss.calls, ss.rows+|     1 |    3
-                         |              |     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid               +|       | 
-                         |              |     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows                 |       | 
- regress_stats_user1     | t            | SELECT $1+$2 AS "TWO"                                                           |     1 |    1
- regress_stats_user1     | t            | SELECT r.rolname, ss.queryid <> $1 AS queryid_bool, ss.query, ss.calls, ss.rows+|     1 |    4
-                         |              |     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid               +|       | 
-                         |              |     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows                 |       | 
-(5 rows)
+         rolname         | queryid_bool |                                     query                                     |                   top_query                   |     message      |   comments    | pgsm_query_id_bool | planid_bool | top_queryid_bool | client_ip_bool | calls | rows 
+-------------------------+--------------+-------------------------------------------------------------------------------+-----------------------------------------------+------------------+---------------+--------------------+-------------+------------------+----------------+-------+------
+ regress_stats_superuser | t            | (SELECT $1 + $2)                                                              | SELECT regress_stats_nested(1);               |                  |               | t                  | t           | t                | t              |     1 |    1
+ regress_stats_superuser | t            | SELECT $1 AS "ONE"                                                            |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_superuser | t            | SELECT pg_stat_monitor_reset() IS NOT NULL AS t                               |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_superuser | t            | SELECT r.rolname, ss.queryid <> $1 AS queryid_bool, ss.query, ss.top_query,  +|                                               |                  |               | t                  | t           |                  | t              |     1 |    9
+                         |              |        ss.message, ss.comments, ss.pgsm_query_id <> $2 AS pgsm_query_id_bool,+|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.planid <> $3 AS planid_bool,                                       +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.top_queryid <> $4 AS top_queryid_bool,                             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows         +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows               |                                               |                  |               |                    |             |                  |                |       | 
+ regress_stats_superuser | t            | SELECT regress_stats_nested($1)                                               |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_user1     | t            | (SELECT $1 + 1)                                                               | SELECT regress_stats_nested(2) /* comment */; |                  |               | t                  | t           | t                | t              |     1 |    1
+ regress_stats_user1     | t            | SELECT $1+$2 AS "TWO"                                                         |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_user1     | t            | SELECT 1 / 0;                                                                 |                                               | division by zero |               | t                  |             |                  | t              |     1 |    0
+ regress_stats_user1     | t            | SELECT r.rolname, ss.queryid <> $1 AS queryid_bool, ss.query, ss.top_query,  +|                                               |                  |               | t                  | t           |                  | t              |     1 |    8
+                         |              |        ss.message, ss.comments, ss.pgsm_query_id <> $2 AS pgsm_query_id_bool,+|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.planid <> $3 AS planid_bool,                                       +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.top_queryid <> $4 AS top_queryid_bool,                             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows         +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows               |                                               |                  |               |                    |             |                  |                |       | 
+ regress_stats_user1     | t            | SELECT regress_stats_nested($1) /* comment */                                 |                                               |                  | /* comment */ | t                  | t           |                  | t              |     1 |    1
+(10 rows)
+
+--
+-- regress_stats_user3 is a member of pg_read_all_stats, but it is a NOINHERIT
+-- role, so the privilege does not apply until it does SET ROLE.
+--
+SET ROLE regress_stats_user3;
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.top_query,
+       ss.message, ss.comments, ss.pgsm_query_id <> 0 AS pgsm_query_id_bool,
+       ss.planid <> 0 AS planid_bool,
+       ss.top_queryid <> 0 AS top_queryid_bool,
+       ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows
+    FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
+    ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
+         rolname         | queryid_bool |          query           |        top_query         |         message          |         comments         | pgsm_query_id_bool | planid_bool | top_queryid_bool | client_ip_bool | calls | rows 
+-------------------------+--------------+--------------------------+--------------------------+--------------------------+--------------------------+--------------------+-------------+------------------+----------------+-------+------
+ regress_stats_superuser |              | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    1
+ regress_stats_superuser |              | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    1
+ regress_stats_superuser |              | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    1
+ regress_stats_superuser |              | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    1
+ regress_stats_superuser |              | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    9
+ regress_stats_user1     |              | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    0
+ regress_stats_user1     |              | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    1
+ regress_stats_user1     |              | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    1
+ regress_stats_user1     |              | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    1
+ regress_stats_user1     |              | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |    8
+ regress_stats_user2     |              | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> | <insufficient privilege> |                    |             |                  | f              |     1 |   10
+(11 rows)
+
+SET ROLE pg_read_all_stats;
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.top_query,
+       ss.message, ss.comments, ss.pgsm_query_id <> 0 AS pgsm_query_id_bool,
+       ss.planid <> 0 AS planid_bool,
+       ss.top_queryid <> 0 AS top_queryid_bool,
+       ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows
+    FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
+    ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
+         rolname         | queryid_bool |                                     query                                     |                   top_query                   |     message      |   comments    | pgsm_query_id_bool | planid_bool | top_queryid_bool | client_ip_bool | calls | rows 
+-------------------------+--------------+-------------------------------------------------------------------------------+-----------------------------------------------+------------------+---------------+--------------------+-------------+------------------+----------------+-------+------
+ regress_stats_superuser | t            | (SELECT $1 + $2)                                                              | SELECT regress_stats_nested(1);               |                  |               | t                  | t           | t                | t              |     1 |    1
+ regress_stats_superuser | t            | SELECT $1 AS "ONE"                                                            |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_superuser | t            | SELECT pg_stat_monitor_reset() IS NOT NULL AS t                               |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_superuser | t            | SELECT r.rolname, ss.queryid <> $1 AS queryid_bool, ss.query, ss.top_query,  +|                                               |                  |               | t                  | t           |                  | t              |     1 |    9
+                         |              |        ss.message, ss.comments, ss.pgsm_query_id <> $2 AS pgsm_query_id_bool,+|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.planid <> $3 AS planid_bool,                                       +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.top_queryid <> $4 AS top_queryid_bool,                             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows         +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows               |                                               |                  |               |                    |             |                  |                |       | 
+ regress_stats_superuser | t            | SELECT regress_stats_nested($1)                                               |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_user1     | t            | (SELECT $1 + 1)                                                               | SELECT regress_stats_nested(2) /* comment */; |                  |               | t                  | t           | t                | t              |     1 |    1
+ regress_stats_user1     | t            | SELECT $1+$2 AS "TWO"                                                         |                                               |                  |               | t                  | t           |                  | t              |     1 |    1
+ regress_stats_user1     | t            | SELECT 1 / 0;                                                                 |                                               | division by zero |               | t                  |             |                  | t              |     1 |    0
+ regress_stats_user1     | t            | SELECT r.rolname, ss.queryid <> $1 AS queryid_bool, ss.query, ss.top_query,  +|                                               |                  |               | t                  | t           |                  | t              |     1 |    8
+                         |              |        ss.message, ss.comments, ss.pgsm_query_id <> $2 AS pgsm_query_id_bool,+|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.planid <> $3 AS planid_bool,                                       +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.top_queryid <> $4 AS top_queryid_bool,                             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows         +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows               |                                               |                  |               |                    |             |                  |                |       | 
+ regress_stats_user1     | t            | SELECT regress_stats_nested($1) /* comment */                                 |                                               |                  | /* comment */ | t                  | t           |                  | t              |     1 |    1
+ regress_stats_user2     | t            | SELECT r.rolname, ss.queryid <> $1 AS queryid_bool, ss.query, ss.top_query,  +|                                               |                  |               | t                  | t           |                  | t              |     1 |   10
+                         |              |        ss.message, ss.comments, ss.pgsm_query_id <> $2 AS pgsm_query_id_bool,+|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.planid <> $3 AS planid_bool,                                       +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.top_queryid <> $4 AS top_queryid_bool,                             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows         +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows               |                                               |                  |               |                    |             |                  |                |       | 
+ regress_stats_user3     | t            | SELECT r.rolname, ss.queryid <> $1 AS queryid_bool, ss.query, ss.top_query,  +|                                               |                  |               | t                  | t           |                  | t              |     1 |   11
+                         |              |        ss.message, ss.comments, ss.pgsm_query_id <> $2 AS pgsm_query_id_bool,+|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.planid <> $3 AS planid_bool,                                       +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.top_queryid <> $4 AS top_queryid_bool,                             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |        ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows         +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid             +|                                               |                  |               |                    |             |                  |                |       | 
+                         |              |     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows               |                                               |                  |               |                    |             |                  |                |       | 
+(12 rows)
 
 --
 -- cleanup
 --
 RESET ROLE;
+DROP FUNCTION regress_stats_nested(int);
 DROP ROLE regress_stats_superuser;
 DROP ROLE regress_stats_user1;
 REVOKE pg_read_all_stats FROM regress_stats_user2;
 DROP ROLE regress_stats_user2;
+REVOKE pg_read_all_stats FROM regress_stats_user3;
+DROP ROLE regress_stats_user3;
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
  t 
 ---

--- a/regression/sql/privileges.sql
+++ b/regression/sql/privileges.sql
@@ -7,18 +7,46 @@
 CREATE EXTENSION pg_stat_monitor;
 SET pg_stat_monitor.pgsm_track_utility = off;
 SET pg_stat_monitor.pgsm_normalized_query = on;
+SET pg_stat_monitor.pgsm_track = 'all';
+SET pg_stat_monitor.pgsm_extract_comments = on;
+SET pg_stat_monitor.pgsm_enable_query_plan = on;
+
+CREATE FUNCTION regress_stats_nested(int) RETURNS int AS
+$$
+BEGIN
+    RETURN (SELECT $1 + 1);
+END
+$$ LANGUAGE plpgsql;
 
 CREATE ROLE regress_stats_superuser SUPERUSER;
 CREATE ROLE regress_stats_user1;
 CREATE ROLE regress_stats_user2;
+CREATE ROLE regress_stats_user3 NOINHERIT;
 GRANT pg_read_all_stats TO regress_stats_user2;
+GRANT pg_read_all_stats TO regress_stats_user3;
 
 SET ROLE regress_stats_superuser;
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 SELECT 1 AS "ONE";
+SELECT regress_stats_nested(1);
 
 SET ROLE regress_stats_user1;
 SELECT 1+1 AS "TWO";
+SELECT regress_stats_nested(2) /* comment */;
+SELECT 1 / 0;
+
+--
+-- regress_stats_user1 has no privileges to read the query text of queries
+-- executed by others but can see statistics like calls and rows.
+--
+
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.top_query,
+       ss.message, ss.comments, ss.pgsm_query_id <> 0 AS pgsm_query_id_bool,
+       ss.planid <> 0 AS planid_bool,
+       ss.top_queryid <> 0 AS top_queryid_bool,
+       ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows
+    FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
+    ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
 
 --
 -- A superuser can read all columns of queries executed by others,
@@ -26,17 +54,11 @@ SELECT 1+1 AS "TWO";
 --
 
 SET ROLE regress_stats_superuser;
-SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.calls, ss.rows
-    FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
-    ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
-
---
--- regress_stats_user1 has no privileges to read the query text of queries
--- executed by others but can see statistics like calls and rows.
---
-
-SET ROLE regress_stats_user1;
-SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.calls, ss.rows
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.top_query,
+       ss.message, ss.comments, ss.pgsm_query_id <> 0 AS pgsm_query_id_bool,
+       ss.planid <> 0 AS planid_bool,
+       ss.top_queryid <> 0 AS top_queryid_bool,
+       ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows
     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
 
@@ -46,7 +68,34 @@ SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.calls, ss.rows
 --
 
 SET ROLE regress_stats_user2;
-SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.calls, ss.rows
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.top_query,
+       ss.message, ss.comments, ss.pgsm_query_id <> 0 AS pgsm_query_id_bool,
+       ss.planid <> 0 AS planid_bool,
+       ss.top_queryid <> 0 AS top_queryid_bool,
+       ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows
+    FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
+    ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
+
+--
+-- regress_stats_user3 is a member of pg_read_all_stats, but it is a NOINHERIT
+-- role, so the privilege does not apply until it does SET ROLE.
+--
+
+SET ROLE regress_stats_user3;
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.top_query,
+       ss.message, ss.comments, ss.pgsm_query_id <> 0 AS pgsm_query_id_bool,
+       ss.planid <> 0 AS planid_bool,
+       ss.top_queryid <> 0 AS top_queryid_bool,
+       ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows
+    FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
+    ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
+
+SET ROLE pg_read_all_stats;
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.top_query,
+       ss.message, ss.comments, ss.pgsm_query_id <> 0 AS pgsm_query_id_bool,
+       ss.planid <> 0 AS planid_bool,
+       ss.top_queryid <> 0 AS top_queryid_bool,
+       ss.client_ip IS NOT NULL AS client_ip_bool, ss.calls, ss.rows
     FROM pg_stat_monitor ss JOIN pg_roles r ON ss.userid = r.oid
     ORDER BY r.rolname, ss.query COLLATE "C", ss.calls, ss.rows;
 
@@ -55,9 +104,12 @@ SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.query, ss.calls, ss.rows
 --
 
 RESET ROLE;
+DROP FUNCTION regress_stats_nested(int);
 DROP ROLE regress_stats_superuser;
 DROP ROLE regress_stats_user1;
 REVOKE pg_read_all_stats FROM regress_stats_user2;
 DROP ROLE regress_stats_user2;
+REVOKE pg_read_all_stats FROM regress_stats_user3;
+DROP ROLE regress_stats_user3;
 SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
 DROP EXTENSION pg_stat_monitor;

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -2060,7 +2060,7 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 						 bool showtext)
 {
 	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
-	bool		may_read_all_stats;
+	bool		is_allowed_role;
 	TupleDesc	tupdesc;
 	Tuplestorestate *tupstore;
 	MemoryContext per_query_ctx;
@@ -2072,7 +2072,7 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 	pgsmSharedState *pgsm;
 	int			expected_columns;
 
-	may_read_all_stats = is_member_of_role(GetUserId(), ROLE_PG_READ_ALL_STATS);
+	is_allowed_role = has_privs_of_role(GetUserId(), ROLE_PG_READ_ALL_STATS);
 
 	switch (api_version)
 	{
@@ -2169,6 +2169,7 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 		char	   *query_text;
 		char	   *parent_query_text = NULL;
 		bool		toplevel = entry->key.toplevel;
+		bool		visible = is_allowed_role || userid == GetUserId();
 
 		/* Load the query text from dsa area */
 		if (DsaPointerIsValid(entry->query))
@@ -2226,62 +2227,69 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 		/* datname at column number 4 */
 		values[i++] = CStringGetTextDatum(entry->datname);
 
-		/*
-		 * ip address at column number 5, Superusers or members of
-		 * pg_read_all_stats members are allowed
-		 */
-		if (may_read_all_stats || userid == GetUserId())
+		/* ip address at column number 5 */
+		if (visible)
 			values[i++] = UInt32GetDatum(ip);
 		else
 			nulls[i++] = true;
 
 		/* queryid at column number 6 */
-		values[i++] = Int64GetDatum(queryid);
+		if (visible)
+			values[i++] = Int64GetDatum(queryid);
+		else
+			nulls[i++] = true;
 
 		/* planid at column number 7 */
-		if (planid)
+		if (visible && planid)
 			values[i++] = Int64GetDatum(planid);
 		else
 			nulls[i++] = true;
 
-		if (may_read_all_stats || userid == GetUserId())
+		if (!showtext)
 		{
-			if (showtext)
-			{
-				/* query at column number 8 */
-				values[i++] = CStringGetTextDatum(query_text);
-				/* plan at column number 9 */
-				if (planid && tmp.planinfo.plan_text[0])
-					values[i++] = CStringGetTextDatum(tmp.planinfo.plan_text);
-				else
-					nulls[i++] = true;
-			}
+			/* query and plan at column number 8 and 9, text not requested */
+			nulls[i++] = true;
+			nulls[i++] = true;
+		}
+		else if (visible)
+		{
+			/* query at column number 8 */
+			values[i++] = CStringGetTextDatum(query_text);
+			/* plan at column number 9 */
+			if (planid && tmp.planinfo.plan_text[0])
+				values[i++] = CStringGetTextDatum(tmp.planinfo.plan_text);
 			else
-			{
-				/* query at column number 8 */
 				nulls[i++] = true;
-				/* plan at column number 9 */
-				nulls[i++] = true;
-			}
 		}
 		else
 		{
-			/* query text and plan at column number 8 and 9 */
+			/* query and plan at column number 8 and 9 */
 			values[i++] = CStringGetTextDatum("<insufficient privilege>");
 			values[i++] = CStringGetTextDatum("<insufficient privilege>");
 		}
 
 		/* pgsm_query_id at column number 10 */
-		if (pgsm_query_id)
+		if (visible && pgsm_query_id)
 			values[i++] = Int64GetDatum(pgsm_query_id);
 		else
 			nulls[i++] = true;
 
-		/* parentid at column number 11 */
-		if (tmpkey.parentid != INT64CONST(0))
+		/* parentid and top_query at column number 11 and 12 */
+		if (!visible)
+		{
+			nulls[i++] = true;
+			if (showtext)
+				values[i++] = CStringGetTextDatum("<insufficient privilege>");
+			else
+				nulls[i++] = true;
+		}
+		else if (tmpkey.parentid != INT64CONST(0))
 		{
 			values[i++] = Int64GetDatum(tmpkey.parentid);
-			values[i++] = CStringGetTextDatum(parent_query_text);
+			if (showtext)
+				values[i++] = CStringGetTextDatum(parent_query_text);
+			else
+				nulls[i++] = true;
 		}
 		else
 		{
@@ -2331,10 +2339,12 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 			values[i++] = CStringGetTextDatum(tmp.error.sqlcode);
 
 		/* message at column number 18 */
-		if (strlen(tmp.error.message) == 0)
-			nulls[i++] = true;
-		else
+		if (!visible)
+			values[i++] = CStringGetTextDatum("<insufficient privilege>");
+		else if (strlen(tmp.error.message) != 0)
 			values[i++] = CStringGetTextDatum(tmp.error.message);
+		else
+			nulls[i++] = true;
 
 		/* bucket_start_time at column number 19 */
 		values[i++] = TimestampTzGetDatum(pgsm->bucket_start_time[entry->key.bucket_id]);
@@ -2457,8 +2467,12 @@ pg_stat_monitor_internal(FunctionCallInfo fcinfo,
 			values[i++] = Int64GetDatumFast(tmp.walusage.wal_buffers_full);
 		}
 
-		/* application_name at column number 56 */
-		if (strlen(tmp.info.comments) > 0)
+		/* comments at column number 56 */
+		if (!showtext)
+			nulls[i++] = true;
+		else if (!visible)
+			values[i++] = CStringGetTextDatum("<insufficient privilege>");
+		else if (strlen(tmp.info.comments) != 0)
 			values[i++] = CStringGetTextDatum(tmp.info.comments);
 		else
 			nulls[i++] = true;


### PR DESCRIPTION
pg_stat_monitor exposes some data that can be considered as sensitive, so apply the same priveleges mechanism as for query text.

PG-2624



