### PR TITLE
PG-2735 Backport fix for buffer overflow in query normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@
 - Race condition where we could leak memory for the parent query
 - `plans` now counts only actual planner invocations instead of every execution: utility statements and executions that reuse a cached plan no longer bump the counter
 - Normalize the query text of utility statements ([PG-2623](https://perconadev.atlassian.net/browse/PG-2623))
-- Hide sensitive data for users who has no privileges ([PG-2624](https://perconadev.atlassian.net/browse/PG-2624)).
+- Hide sensitive data for users who has no privileges ([PG-2624](https://perconadev.atlassian.net/browse/PG-2624))
+- Fix buffer overflow in query normalization ([PG-2735](https://perconadev.atlassian.net/browse/PG-2735))
 
 ## [2.3.2] - 2026-03-02
 

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -2787,17 +2787,26 @@ static char *
 generate_normalized_query(const JumbleState *jstate, const char *query,
 						  int query_loc, int *query_len_p)
 {
-	char	   *norm_query;
+	StringInfoData norm_query;
 	int			query_len = *query_len_p;
-	int			norm_query_buflen,	/* Space allowed for norm_query */
-				len_to_wrt,		/* Length (in bytes) to write */
+	int			len_to_wrt,		/* Length (in bytes) to write */
 				quer_loc = 0,	/* Source query byte location */
-				n_quer_loc = 0, /* Normalized query byte location */
 				last_off = 0,	/* Offset from start for previous tok */
 				last_tok_len = 0;	/* Length (in bytes) of that tok */
-	LocationLen *locs;
 #if PG_VERSION_NUM >= 180000
 	int			num_constants_replaced = 0;
+#endif
+	LocationLen *locs = NULL;
+
+	/*
+	 * Our output buffer is an expansible StringInfo, but avoid enlarging it
+	 * in most cases by reserving extra space for each constant location.
+	 */
+	Assert(jstate->clocations_count > 0);
+#if PG_VERSION_NUM >= 180000
+	initStringInfoExt(&norm_query, query_len + jstate->clocations_count * 10);
+#else
+	initStringInfo(&norm_query);
 #endif
 
 	/*
@@ -2806,18 +2815,6 @@ generate_normalized_query(const JumbleState *jstate, const char *query,
 	 * in.
 	 */
 	locs = ComputeConstantLengths(jstate, query, query_loc);
-
-	/*
-	 * Allow for $n symbols to be longer than the constants they replace.
-	 * Constants must take at least one byte in text form, while a $n symbol
-	 * certainly isn't more than 11 bytes, even if n reaches INT_MAX.  We
-	 * could refine that limit based on the max value of n for the current
-	 * query, but it hardly seems worth any extra effort to do so.
-	 */
-	norm_query_buflen = query_len + jstate->clocations_count * 10;
-
-	/* Allocate result buffer */
-	norm_query = palloc(norm_query_buflen + 1);
 
 	for (int i = 0; i < jstate->clocations_count; i++)
 	{
@@ -2838,6 +2835,7 @@ generate_normalized_query(const JumbleState *jstate, const char *query,
 #endif
 
 		off = locs[i].location;
+
 		/* Adjust recorded location if we're dealing with partial string */
 		off -= query_loc;
 
@@ -2849,10 +2847,8 @@ generate_normalized_query(const JumbleState *jstate, const char *query,
 		/* Copy next chunk (what precedes the next constant) */
 		len_to_wrt = off - last_off;
 		len_to_wrt -= last_tok_len;
-
 		Assert(len_to_wrt >= 0);
-		memcpy(norm_query + n_quer_loc, query + quer_loc, len_to_wrt);
-		n_quer_loc += len_to_wrt;
+		appendBinaryStringInfo(&norm_query, query + quer_loc, len_to_wrt);
 
 #if PG_VERSION_NUM >= 180000
 
@@ -2861,14 +2857,14 @@ generate_normalized_query(const JumbleState *jstate, const char *query,
 		 * we have a squashable list, insert a placeholder comment starting
 		 * from the list's second value.
 		 */
-		n_quer_loc += sprintf(norm_query + n_quer_loc, "$%d%s",
-							  num_constants_replaced + 1 + jstate->highest_extern_param_id,
-							  locs[i].squashed ? " /*, ... */" : "");
+		appendStringInfo(&norm_query, "$%d%s",
+						 num_constants_replaced + 1 + jstate->highest_extern_param_id,
+						 locs[i].squashed ? " /*, ... */" : "");
 		num_constants_replaced++;
 #else
 		/* And insert a param symbol in place of the constant token */
-		n_quer_loc += sprintf(norm_query + n_quer_loc, "$%d",
-							  i + 1 + jstate->highest_extern_param_id);
+		appendStringInfo(&norm_query, "$%d",
+						 i + 1 + jstate->highest_extern_param_id);
 #endif
 
 		/* move forward */
@@ -2888,15 +2884,10 @@ generate_normalized_query(const JumbleState *jstate, const char *query,
 	len_to_wrt = query_len - quer_loc;
 
 	Assert(len_to_wrt >= 0);
-	memcpy(norm_query + n_quer_loc, query + quer_loc, len_to_wrt);
-	n_quer_loc += len_to_wrt;
+	appendBinaryStringInfo(&norm_query, query + quer_loc, len_to_wrt);
 
-	Assert(n_quer_loc <= norm_query_buflen);
-	norm_query[n_quer_loc] = '\0';
-
-	*query_len_p = n_quer_loc;
-
-	return norm_query;
+	*query_len_p = norm_query.len;
+	return norm_query.data;
 }
 
 #if PG_VERSION_NUM < 190000


### PR DESCRIPTION
PostgreSQL 18.6 included a fix for CVE-2026-14676 which also affected us due us copying code from pg_stat_statements. Only our code for 18 and 19 was affected but let's apply the fix for 18+ in a way which handles all versions so we can avoid ifdefs.

See https://git.postgresql.org/pg/commitdiff/1e2795ddeafc66cd78d2c90a69dd820488639c7c

PG-2735
