### PR TITLE
Ignore statements that have no query id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Race condition where we could leak memory for the parent query
 - `plans` now counts only actual planner invocations instead of every execution: utility statements and executions that reuse a cached plan no longer bump the counter
 - Normalize the query text of utility statements ([PG-2623](https://perconadev.atlassian.net/browse/PG-2623))
+- Ignore statements that have no query id
 
 ## [2.3.2] - 2026-03-02
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ REGRESS = basic \
 	version \
 	guc \
 	pgsm_query_id \
+	query_id \
 	functions \
 	counters \
 	relations \

--- a/regression/expected/level_tracking_4.out
+++ b/regression/expected/level_tracking_4.out
@@ -100,12 +100,11 @@ SELECT pg_stat_monitor_reset();
 CALL proc_with_utility_stmt();
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C", toplevel;
- toplevel | calls |              query              
-----------+-------+---------------------------------
+ toplevel | calls |             query              
+----------+-------+--------------------------------
  t        |     1 | CALL proc_with_utility_stmt()
  t        |     1 | SELECT pg_stat_monitor_reset()
- f        |     3 | SHOW pg_stat_monitor.pgsm_track
-(3 rows)
+(2 rows)
 
 -- top-level tracking.
 SET pg_stat_monitor.pgsm_track = 'top';

--- a/regression/expected/level_tracking_5.out
+++ b/regression/expected/level_tracking_5.out
@@ -100,12 +100,11 @@ SELECT pg_stat_monitor_reset();
 CALL proc_with_utility_stmt();
 SELECT toplevel, calls, query FROM pg_stat_monitor
   ORDER BY query COLLATE "C", toplevel;
- toplevel | calls |              query              
-----------+-------+---------------------------------
+ toplevel | calls |             query              
+----------+-------+--------------------------------
  t        |     1 | CALL proc_with_utility_stmt()
  t        |     1 | SELECT pg_stat_monitor_reset()
- f        |     3 | SHOW pg_stat_monitor.pgsm_track
-(3 rows)
+(2 rows)
 
 -- top-level tracking.
 SET pg_stat_monitor.pgsm_track = 'top';

--- a/regression/expected/query_id.out
+++ b/regression/expected/query_id.out
@@ -1,0 +1,79 @@
+CREATE EXTENSION pg_stat_monitor;
+SET pg_stat_monitor.pgsm_track_utility = on;
+SET pg_stat_monitor.pgsm_track_planning = on;
+SET pg_stat_monitor.pgsm_normalized_query = on;
+--
+-- Do not store queries without a query identifier
+--
+SET compute_query_id = off;
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT 1 AS no_query_id;
+ no_query_id 
+-------------
+           1
+(1 row)
+
+CREATE TABLE no_query_id_tab (x int);
+INSERT INTO no_query_id_tab VALUES (1);
+SELECT x FROM no_query_id_tab;
+ x 
+---
+ 1
+(1 row)
+
+PREPARE no_query_id_prep AS SELECT x FROM no_query_id_tab WHERE x = $1;
+EXECUTE no_query_id_prep(1);
+ x 
+---
+ 1
+(1 row)
+
+DEALLOCATE no_query_id_prep;
+DROP TABLE no_query_id_tab;
+DO $$
+BEGIN
+    PERFORM 1;
+END
+$$;
+-- Nothing of the above was recorded.
+SELECT count(*) FROM pg_stat_monitor;
+ count 
+-------
+     0
+(1 row)
+
+--
+-- Tracking resumes once query identifiers are computed again.
+--
+RESET compute_query_id;
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT 1 AS with_query_id;
+ with_query_id 
+---------------
+             1
+(1 row)
+
+SELECT calls, query FROM pg_stat_monitor
+    WHERE query LIKE '%with_query_id%' ORDER BY query COLLATE "C";
+ calls |           query            
+-------+----------------------------
+     1 | SELECT $1 AS with_query_id
+(1 row)
+
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+DROP EXTENSION pg_stat_monitor;

--- a/regression/sql/query_id.sql
+++ b/regression/sql/query_id.sql
@@ -1,0 +1,37 @@
+CREATE EXTENSION pg_stat_monitor;
+SET pg_stat_monitor.pgsm_track_utility = on;
+SET pg_stat_monitor.pgsm_track_planning = on;
+SET pg_stat_monitor.pgsm_normalized_query = on;
+
+--
+-- Do not store queries without a query identifier
+--
+SET compute_query_id = off;
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT 1 AS no_query_id;
+CREATE TABLE no_query_id_tab (x int);
+INSERT INTO no_query_id_tab VALUES (1);
+SELECT x FROM no_query_id_tab;
+PREPARE no_query_id_prep AS SELECT x FROM no_query_id_tab WHERE x = $1;
+EXECUTE no_query_id_prep(1);
+DEALLOCATE no_query_id_prep;
+DROP TABLE no_query_id_tab;
+DO $$
+BEGIN
+    PERFORM 1;
+END
+$$;
+-- Nothing of the above was recorded.
+SELECT count(*) FROM pg_stat_monitor;
+
+--
+-- Tracking resumes once query identifiers are computed again.
+--
+RESET compute_query_id;
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+SELECT 1 AS with_query_id;
+SELECT calls, query FROM pg_stat_monitor
+    WHERE query LIKE '%with_query_id%' ORDER BY query COLLATE "C";
+
+SELECT pg_stat_monitor_reset() IS NOT NULL AS t;
+DROP EXTENSION pg_stat_monitor;

--- a/src/pg_stat_monitor.c
+++ b/src/pg_stat_monitor.c
@@ -458,6 +458,13 @@ pgsm_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 		return;
 
 	/*
+	 * Nothing to do if compute_query_id isn't enabled and no other module
+	 * computed a query identifier.
+	 */
+	if (query->queryId == INT64CONST(0))
+		return;
+
+	/*
 	 * If it's EXECUTE, clear the queryId so that stats will accumulate for
 	 * the underlying PREPARE.  But don't do this if we're not tracking
 	 * utility statements, to avoid messing up another extension that might be
@@ -506,8 +513,6 @@ pgsm_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 	 */
 	if (query->utilityStmt && norm_query == NULL)
 		return;
-
-	Assert(query->queryId != INT64CONST(0));
 
 	/*
 	 * pgsm_query_id always groups by the normalized form when we have one.
@@ -1804,6 +1809,13 @@ pgsm_store(const pgsmQueryStats *stats)
 
 	/* Safety check... */
 	if (!IsSystemInitialized())
+		return;
+
+	/*
+	 * Nothing to do if compute_query_id isn't enabled and no other module
+	 * computed a query identifier.
+	 */
+	if (key.queryid == INT64CONST(0))
 		return;
 
 	pgsm = pgsm_get_ss();


### PR DESCRIPTION
Match pg_stat_statements behavior and ignore statements without query id. Otherwise all such statements stats will be merged into single entry as query id part of the hash key.


PG-0

### Description
<!--- Describe your changes in detail -->


### Links
<!--- Please provide links to any related PRs in this or other repositories --->

